### PR TITLE
Rename classes to remove Metatensor prefix

### DIFF
--- a/docs/src/engines/ase.rst
+++ b/docs/src/engines/ase.rst
@@ -20,16 +20,16 @@ Supported model outputs
   with ASE calculator interface (i.e. :py:meth:`ase.Atoms.get_potential_energy`,
   :py:meth:`ase.Atoms.get_forces`, …);
 - arbitrary outputs can be computed for any :py:class:`ase.Atoms` using
-  :py:meth:`MetatensorCalculator.run_model`;
+  :py:meth:`MetatomicCalculator.run_model`;
 
 How to install the code
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 The code is available in the ``metatomic-torch`` package, in the
-:py:class:`metatomic.torch.ase_calculator.MetatensorCalculator` class.
+:py:class:`metatomic.torch.ase_calculator.MetatomicCalculator` class.
 
 How to use the code
 ^^^^^^^^^^^^^^^^^^^
 
 See the :ref:`corresponding tutorial <atomistic-tutorial-md>`, and API
-documentation of the :py:class:`MetatensorCalculator` class.
+documentation of the :py:class:`MetatomicCalculator` class.

--- a/docs/src/outputs/features.rst
+++ b/docs/src/outputs/features.rst
@@ -71,7 +71,7 @@ The following simulation engines can use the ``"features"`` output:
     :link: engine-ase
     :link-type: ref
 
-    .. py:currentmodule:: metatomic.torch.ase_calculator.MetatensorCalculator
+    .. py:currentmodule:: metatomic.torch.ase_calculator.MetatomicCalculator
 
     |ase-logo|
 

--- a/docs/src/outputs/non_conservative.rst
+++ b/docs/src/outputs/non_conservative.rst
@@ -60,7 +60,7 @@ The following simulation engines can use the ``"non_conservative_forces"`` outpu
 
     |ase-logo|
 
-    (using the ``non_conservative`` flag or ``MetatensorCalculator.run_model()``)
+    (using the ``non_conservative`` flag or ``MetatomicCalculator.run_model()``)
 
 
 .. _non-conservative-stress-output:
@@ -119,4 +119,4 @@ The following simulation engines can use the ``"non_conservative_stress"`` outpu
 
     |ase-logo|
 
-    (using the ``non_conservative`` flag or ``MetatensorCalculator.run_model()``)
+    (using the ``non_conservative`` flag or ``MetatomicCalculator.run_model()``)

--- a/docs/src/overview.rst
+++ b/docs/src/overview.rst
@@ -129,7 +129,7 @@ for each property (i.e. energy, atomic charges, dipole, electronic density,
 chemical shielding, *etc.*)
 
 Once a model is defined and trained, it should be exported by constructing a
-:py:class:`MetatensorAtomisticModel`, and calling ``export`` on it. This class
+:py:class:`AtomisticModel`, and calling ``export`` on it. This class
 is a wrapper for the model that will handle unit conversions on input and
 outputs. It will also store metadata about the model (such as the authors, a
 list of references, …) and the model capabilities (what properties it can
@@ -230,7 +230,7 @@ below.
    .. tip::
 
         This can be done by calling
-        :py:func:`MetatensorAtomisticModel.capabilities`. This function is also
+        :py:func:`AtomisticModel.capabilities`. This function is also
         exported to TorchScript and can be called from C++ with
         :cpp:func:`torch::jit::Module::run_method`.
 
@@ -250,7 +250,7 @@ below.
    .. tip::
 
         This can be done by calling
-        :py:func:`MetatensorAtomisticModel.requested_neighbor_lists`. This
+        :py:func:`AtomisticModel.requested_neighbor_lists`. This
         function is also exported to TorchScript and can be called from C++ with
         :cpp:func:`torch::jit::Module::run_method`.
 

--- a/docs/src/torch/reference/ase.rst
+++ b/docs/src/torch/reference/ase.rst
@@ -4,16 +4,16 @@ Atomic Simulation Environment (ASE) integration
 .. py:currentmodule:: metatomic.torch
 
 The code in ``metatomic.torch.ase_calculator`` defines a class that
-allow using :py:class:`MetatensorAtomisticModel` which predict the energy of a
+allow using :py:class:`AtomisticModel` which predict the energy of a
 system as an ASE `calculator`_; enabling the use of machine learning interatomic
 potentials to drive simulations inside ASE.
 
 Additionally, it allow using arbitrary models with prediction targets which are
 not just the energy, through the
-:py:meth:`ase_calculator.MetatensorCalculator.run_model` function.
+:py:meth:`ase_calculator.MetatomicCalculator.run_model` function.
 
 .. _calculator: https://wiki.fysik.dtu.dk/ase/ase/calculators/calculators.html
 
-.. autoclass:: metatomic.torch.ase_calculator.MetatensorCalculator
+.. autoclass:: metatomic.torch.ase_calculator.MetatomicCalculator
     :show-inheritance:
     :members:

--- a/docs/src/torch/reference/models/export.rst
+++ b/docs/src/torch/reference/models/export.rst
@@ -4,7 +4,7 @@ Exporting models
 .. py:currentmodule:: metatomic.torch
 
 Exporting models to work with any metatomic-compatible simulation engine is
-done with the :py:class:`MetatensorAtomisticModel` class. This class takes in an
+done with the :py:class:`AtomisticModel` class. This class takes in an
 arbitrary :py:class:`torch.nn.Module`, with a forward functions that follows the
 :py:class:`ModelInterface`. In addition to the actual model, you also need to
 define some information about the model, using :py:class:`ModelMetadata` and
@@ -14,5 +14,5 @@ define some information about the model, using :py:class:`ModelMetadata` and
     :members:
     :show-inheritance:
 
-.. autoclass:: metatomic.torch.MetatensorAtomisticModel
+.. autoclass:: metatomic.torch.AtomisticModel
     :members:

--- a/docs/src/torch/reference/models/metadata.rst
+++ b/docs/src/torch/reference/models/metadata.rst
@@ -13,7 +13,7 @@ atomistic models.
   :py:class:`ModelOutput`;
 - :py:class:`ModelEvaluationOptions` is used by the simulation engine to request
   the model to do some things. This is handled by
-  :py:class:`MetatensorAtomisticModel`, and transformed into the arguments given
+  :py:class:`AtomisticModel`, and transformed into the arguments given
   to :py:meth:`ModelInterface.forward`.
 
 --------------------------------------------------------------------------------

--- a/metatomic-torch/include/metatomic/torch/system.hpp
+++ b/metatomic-torch/include/metatomic/torch/system.hpp
@@ -42,7 +42,7 @@ public:
 
     /// Set the length unit to a new value.
     ///
-    /// This is typically called by `MetatensorAtomisticModel`, and should not
+    /// This is typically called by `AtomisticModel`, and should not
     /// need to be set by users directly.
     void set_length_unit(std::string length_unit);
 

--- a/python/examples/1-export-atomistic-model.py
+++ b/python/examples/1-export-atomistic-model.py
@@ -29,7 +29,7 @@ import torch
 from metatensor.torch import Labels, TensorBlock, TensorMap
 
 from metatomic.torch import (
-    MetatensorAtomisticModel,
+    AtomisticModel,
     ModelCapabilities,
     ModelMetadata,
     ModelOutput,
@@ -156,7 +156,7 @@ model = SingleAtomEnergy(
 #
 # Once your model has been trained, we can export it to a model file, that can be used
 # to run simulations or make predictions on new systems. This is done with the
-# :py:class:`MetatensorAtomisticModel` class, which takes your model and make sure it
+# :py:class:`AtomisticModel` class, which takes your model and make sure it
 # follows the required interface.
 #
 # When exporting the model, we can define some metadata about this model, so when the
@@ -197,7 +197,7 @@ outputs = {
 #   decomposition, and running simulations on multiple nodes;
 # - the ``length_unit`` the model expects as input. This applies to the
 #   ``interaction_range``, any neighbors list cutoff, the atoms positions and the system
-#   cell. If this is set to a non empty string, :py:class:`MetatensorAtomisticModel`
+#   cell. If this is set to a non empty string, :py:class:`AtomisticModel`
 #   will handle the necessary unit conversions for you;
 # - the set of ``supported_devices`` on which the model can run. These should be ordered
 #   according to the model preference.
@@ -217,7 +217,7 @@ capabilities = ModelCapabilities(
 # With the model metadata and capabilities defined, we can now create a wrapper around
 # the model, and export it to a file:
 
-wrapper = MetatensorAtomisticModel(model.eval(), metadata, capabilities)
+wrapper = AtomisticModel(model.eval(), metadata, capabilities)
 wrapper.save("exported-model.pt")
 
 # the file was created in the current directory

--- a/python/examples/2-running-ase-md.py
+++ b/python/examples/2-running-ase-md.py
@@ -34,7 +34,7 @@ import torch
 from metatensor.torch import Labels, TensorBlock, TensorMap
 
 from metatomic.torch import (
-    MetatensorAtomisticModel,
+    AtomisticModel,
     ModelCapabilities,
     ModelMetadata,
     ModelOutput,
@@ -42,7 +42,7 @@ from metatomic.torch import (
 )
 
 # Integration with ASE calculator for metatomic models
-from metatomic.torch.ase_calculator import MetatensorCalculator
+from metatomic.torch.ase_calculator import MetatomicCalculator
 
 
 # %%
@@ -173,8 +173,8 @@ print("temperature =", atoms.get_temperature(), "K")
 #
 # The final step to run the simulation is to register our model as the energy calculator
 # for these ``atoms``. This is the job of
-# :py:class:`ase_calculator.MetatensorCalculator`, which takes either an instance of
-# :py:class:`MetatensorAtomisticModel` or the path to a pre-exported model, and allow to
+# :py:class:`ase_calculator.MetatomicCalculator`, which takes either an instance of
+# :py:class:`AtomisticModel` or the path to a pre-exported model, and allow to
 # use it to compute the energy, forces and stress acting on a system.
 
 # define & wrap the model, using the initial positions as equilibrium positions
@@ -196,10 +196,10 @@ capabilities = ModelCapabilities(
 
 # we don't want to bother with model metadata, so we define it as empty
 metadata = ModelMetadata()
-wrapper = MetatensorAtomisticModel(model.eval(), metadata, capabilities)
+wrapper = AtomisticModel(model.eval(), metadata, capabilities)
 
 # Use the wrapped model as the calculator for these atoms
-atoms.calc = MetatensorCalculator(wrapper)
+atoms.calc = MetatomicCalculator(wrapper)
 
 # %%
 #
@@ -266,13 +266,13 @@ fig.show()
 # Using a pre-exported model
 # --------------------------
 #
-# As already mentioned, :py:class:`ase_calculator.MetatensorCalculator` also work with a
+# As already mentioned, :py:class:`ase_calculator.MetatomicCalculator` also work with a
 # pre-exported model, meaning you can also run simulations without defining or
 # re-training a model:
 
 wrapper.save("exported-model.pt")
 
-atoms.calc = MetatensorCalculator("exported-model.pt")
+atoms.calc = MetatomicCalculator("exported-model.pt")
 
 print(atoms.get_potential_energy())
 integrator.run(10)

--- a/python/examples/3-atomistic-model-with-nl.py
+++ b/python/examples/3-atomistic-model-with-nl.py
@@ -52,14 +52,14 @@ import torch
 from metatensor.torch import Labels, TensorBlock, TensorMap
 
 from metatomic.torch import (
-    MetatensorAtomisticModel,
+    AtomisticModel,
     ModelCapabilities,
     ModelMetadata,
     ModelOutput,
     NeighborListOptions,
     System,
 )
-from metatomic.torch.ase_calculator import MetatensorCalculator
+from metatomic.torch.ase_calculator import MetatomicCalculator
 
 
 # %%
@@ -400,10 +400,10 @@ capabilities = ModelCapabilities(
     dtype="float32",
 )
 
-wrapper = MetatensorAtomisticModel(model.eval(), ModelMetadata(), capabilities)
+wrapper = AtomisticModel(model.eval(), ModelMetadata(), capabilities)
 
 # Use the wrapped model as the calculator for these atoms
-atoms.calc = MetatensorCalculator(wrapper)
+atoms.calc = MetatomicCalculator(wrapper)
 
 # %%
 #

--- a/python/examples/4-profiling.py
+++ b/python/examples/4-profiling.py
@@ -23,13 +23,13 @@ import torch
 from metatensor.torch import Labels, TensorBlock, TensorMap
 
 from metatomic.torch import (
-    MetatensorAtomisticModel,
+    AtomisticModel,
     ModelCapabilities,
     ModelMetadata,
     ModelOutput,
     System,
 )
-from metatomic.torch.ase_calculator import MetatensorCalculator
+from metatomic.torch.ase_calculator import MetatomicCalculator
 
 
 # %%
@@ -123,7 +123,7 @@ capabilities = ModelCapabilities(
 )
 
 metadata = ModelMetadata()
-wrapper = MetatensorAtomisticModel(model.eval(), metadata, capabilities)
+wrapper = AtomisticModel(model.eval(), metadata, capabilities)
 
 wrapper.export("exported-model.pt")
 
@@ -138,10 +138,10 @@ wrapper.export("exported-model.pt")
 # %%
 #
 # If you are trying to profile your own model, you can start here and create a
-# ``MetatensorCalculator`` with your own model.
+# ``MetatomicCalculator`` with your own model.
 
 
-atoms.calc = MetatensorCalculator("exported-model.pt")
+atoms.calc = MetatomicCalculator("exported-model.pt")
 
 # %%
 #
@@ -182,9 +182,9 @@ print(energy_profiler.key_averages().table(sort_by="self_cpu_time_total", row_li
 # Anything starting with ``aten::`` comes from operations on torch tensors, typically
 # with the same function name as the corresponding torch functions (e.g.
 # ``aten::arange`` is :py:func:`torch.arange`). We can also see some internal functions
-# from metatomic, with the name staring with ``MetatensorAtomisticModel::`` for
-# :py:class:`MetatensorAtomisticModel`; and ``ASECalculator::`` for
-# :py:class:`ase_calculator.MetatensorCalculator`.
+# from metatomic, with the name staring with ``AtomisticModel::`` for
+# :py:class:`AtomisticModel`; and ``ASECalculator::`` for
+# :py:class:`ase_calculator.MetatomicCalculator`.
 #
 # If you want to see more details on the internal steps taken by your model, you can add
 # :py:func:`torch.profiler.record_function`

--- a/python/metatomic_torch/metatomic/torch/__init__.py
+++ b/python/metatomic_torch/metatomic/torch/__init__.py
@@ -41,7 +41,7 @@ else:
 
 from .io import load_system, save  # noqa: F401
 from .model import (  # noqa: F401
-    MetatensorAtomisticModel,
+    AtomisticModel,
     ModelInterface,
     is_atomistic_model,
     load_atomistic_model,  # noqa: F401

--- a/python/metatomic_torch/metatomic/torch/ase_calculator.py
+++ b/python/metatomic_torch/metatomic/torch/ase_calculator.py
@@ -12,7 +12,7 @@ from metatensor.torch import Labels, TensorBlock, TensorMap
 from torch.profiler import record_function
 
 from . import (
-    MetatensorAtomisticModel,
+    AtomisticModel,
     ModelEvaluationOptions,
     ModelMetadata,
     ModelOutput,
@@ -43,13 +43,13 @@ STR_TO_DTYPE = {
 }
 
 
-class MetatensorCalculator(ase.calculators.calculator.Calculator):
+class MetatomicCalculator(ase.calculators.calculator.Calculator):
     """
-    The :py:class:`MetatensorCalculator` class implements ASE's
+    The :py:class:`MetatomicCalculator` class implements ASE's
     :py:class:`ase.calculators.calculator.Calculator` API using metatensor atomistic
     models to compute energy, forces and any other supported property.
 
-    This class can be initialized with any :py:class:`MetatensorAtomisticModel`, and
+    This class can be initialized with any :py:class:`AtomisticModel`, and
     used to run simulations using ASE's MD facilities.
 
     Neighbor lists are computed using the fast
@@ -70,7 +70,7 @@ class MetatensorCalculator(ase.calculators.calculator.Calculator):
 
     def __init__(
         self,
-        model: Union[FilePath, MetatensorAtomisticModel],
+        model: Union[FilePath, AtomisticModel],
         *,
         additional_outputs: Optional[Dict[str, ModelOutput]] = None,
         extensions_directory=None,
@@ -80,8 +80,8 @@ class MetatensorCalculator(ase.calculators.calculator.Calculator):
     ):
         """
         :param model: model to use for the calculation. This can be a file path, a
-            Python instance of :py:class:`MetatensorAtomisticModel`, or the output of
-            :py:func:`torch.jit.script` on :py:class:`MetatensorAtomisticModel`.
+            Python instance of :py:class:`AtomisticModel`, or the output of
+            :py:func:`torch.jit.script` on :py:class:`AtomisticModel`.
         :param additional_outputs: Dictionary of additional outputs to be computed by
             the model. These outputs will always be computed whenever the
             :py:meth:`calculate` function is called (e.g. by
@@ -119,12 +119,12 @@ class MetatensorCalculator(ase.calculators.calculator.Calculator):
             )
 
         elif isinstance(model, torch.jit.RecursiveScriptModule):
-            if model.original_name != "MetatensorAtomisticModel":
+            if model.original_name != "AtomisticModel":
                 raise InputError(
-                    "torch model must be 'MetatensorAtomisticModel', "
+                    "torch model must be 'AtomisticModel', "
                     f"got '{model.original_name}' instead"
                 )
-        elif isinstance(model, MetatensorAtomisticModel):
+        elif isinstance(model, AtomisticModel):
             # nothing to do
             pass
         else:
@@ -193,7 +193,7 @@ class MetatensorCalculator(ase.calculators.calculator.Calculator):
         if "model_path" not in self.parameters:
             raise RuntimeError(
                 "can not save metatensor model in ASE `todict`, please initialize "
-                "`MetatensorCalculator` with a path to a saved model file if you need "
+                "`MetatomicCalculator` with a path to a saved model file if you need "
                 "to use `todict`"
             )
 
@@ -201,7 +201,7 @@ class MetatensorCalculator(ase.calculators.calculator.Calculator):
 
     @classmethod
     def fromdict(cls, data):
-        return MetatensorCalculator(
+        return MetatomicCalculator(
             model=data["model_path"],
             check_consistency=data["check_consistency"],
             device=data["device"],
@@ -380,7 +380,7 @@ class MetatensorCalculator(ase.calculators.calculator.Calculator):
                 )
                 system.add_neighbor_list(options, neighbors)
 
-        # no `record_function` here, this will be handled by MetatensorAtomisticModel
+        # no `record_function` here, this will be handled by AtomisticModel
         outputs = self._model(
             [system],
             run_options,

--- a/python/metatomic_torch/metatomic/torch/documentation.py
+++ b/python/metatomic_torch/metatomic/torch/documentation.py
@@ -194,7 +194,7 @@ class NeighborListOptions:
         """
         The unit of length used for the cutoff.
 
-        This is typically set by :py:class:`MetatensorAtomisticModel` when collecting
+        This is typically set by :py:class:`AtomisticModel` when collecting
         all neighbors list requests.
 
         The list of possible units is available :ref:`here <known-quantities-units>`.
@@ -485,7 +485,7 @@ def load_model_extensions(path: str, extensions_directory: Optional[str] = None)
     :param path: path to the exported model file
     :param extensions_directory: path to a directory containing the extensions. This
         directory will typically be created by calling
-        :py:meth:`MetatensorAtomisticModel.export` with
+        :py:meth:`AtomisticModel.export` with
         ``collect_extensions=extensions_directory``.
     """
 

--- a/python/metatomic_torch/tests/model.py
+++ b/python/metatomic_torch/tests/model.py
@@ -8,7 +8,7 @@ from metatensor.torch import Labels, TensorBlock, TensorMap
 from packaging import version
 
 from metatomic.torch import (
-    MetatensorAtomisticModel,
+    AtomisticModel,
     ModelCapabilities,
     ModelEvaluationOptions,
     ModelMetadata,
@@ -75,7 +75,7 @@ def model():
     )
 
     metadata = ModelMetadata()
-    return MetatensorAtomisticModel(model, metadata, capabilities)
+    return AtomisticModel(model, metadata, capabilities)
 
 
 @pytest.fixture
@@ -100,7 +100,7 @@ def model_energy_nounit():
     )
 
     metadata = ModelMetadata()
-    return MetatensorAtomisticModel(model_energy_nounit, metadata, capabilities)
+    return AtomisticModel(model_energy_nounit, metadata, capabilities)
 
 
 def test_save(model, tmp_path):
@@ -133,7 +133,7 @@ def test_training_mode():
     capabilities = ModelCapabilities(supported_devices=["cpu"], dtype="float64")
 
     with pytest.raises(ValueError, match="module should not be in training mode"):
-        MetatensorAtomisticModel(model, ModelMetadata(), capabilities)
+        AtomisticModel(model, ModelMetadata(), capabilities)
 
 
 def test_save_warning_length_unit(model):
@@ -219,7 +219,7 @@ def test_requested_neighbor_lists(tmpdir):
         supported_devices=["cpu"],
         dtype="float64",
     )
-    atomistic = MetatensorAtomisticModel(model, ModelMetadata(), capabilities)
+    atomistic = AtomisticModel(model, ModelMetadata(), capabilities)
     requests = atomistic.requested_neighbor_lists()
 
     assert len(requests) == 2
@@ -281,7 +281,7 @@ def test_bad_capabilities():
         "but it is required to run simulations"
     )
     with pytest.raises(ValueError, match=message):
-        MetatensorAtomisticModel(model, ModelMetadata(), capabilities)
+        AtomisticModel(model, ModelMetadata(), capabilities)
 
     capabilities = ModelCapabilities(
         interaction_range=12,
@@ -292,7 +292,7 @@ def test_bad_capabilities():
         "but it is required to run simulations"
     )
     with pytest.raises(ValueError, match=message):
-        MetatensorAtomisticModel(model, ModelMetadata(), capabilities)
+        AtomisticModel(model, ModelMetadata(), capabilities)
 
     capabilities = ModelCapabilities(
         interaction_range=float("nan"),
@@ -303,7 +303,7 @@ def test_bad_capabilities():
         "`capabilities.interaction_range` should be a float between 0 and infinity"
     )
     with pytest.raises(ValueError, match=message):
-        MetatensorAtomisticModel(model, ModelMetadata(), capabilities)
+        AtomisticModel(model, ModelMetadata(), capabilities)
 
     capabilities = ModelCapabilities(
         interaction_range=12.0,
@@ -311,7 +311,7 @@ def test_bad_capabilities():
     )
     message = "`capabilities.dtype` was not set, but it is required to run simulations"
     with pytest.raises(ValueError, match=message):
-        MetatensorAtomisticModel(model, ModelMetadata(), capabilities)
+        AtomisticModel(model, ModelMetadata(), capabilities)
 
     message = (
         "Invalid name for model output: 'not-a-standard'. "
@@ -345,7 +345,7 @@ def test_access_module(tmpdir):
         supported_devices=["cpu"],
         dtype="float64",
     )
-    atomistic = MetatensorAtomisticModel(model, ModelMetadata(), capabilities)
+    atomistic = AtomisticModel(model, ModelMetadata(), capabilities)
 
     # Access wrapped module
     assert atomistic.module is model
@@ -372,7 +372,7 @@ def test_is_atomistic_model(tmpdir):
         supported_devices=["cpu"],
         dtype="float64",
     )
-    atomistic = MetatensorAtomisticModel(model, ModelMetadata(), capabilities)
+    atomistic = AtomisticModel(model, ModelMetadata(), capabilities)
     atomistic.save(tmpdir / "model.pt")
 
     scripted_atomistic = torch.jit.script(atomistic)
@@ -403,7 +403,7 @@ def test_read_metadata(tmpdir):
         authors=["Alice", "Bob"],
         references={"implementation": ["doi:1234", "arXiv:1234"]},
     )
-    atomistic = MetatensorAtomisticModel(model, metadata, capabilities)
+    atomistic = AtomisticModel(model, metadata, capabilities)
     atomistic.save(tmpdir / "model.pt")
 
     extracted_metadata = read_model_metadata(str(tmpdir / "model.pt"))

--- a/python/metatomic_torch/tests/outputs.py
+++ b/python/metatomic_torch/tests/outputs.py
@@ -5,7 +5,7 @@ import torch
 from metatensor.torch import Labels, TensorBlock, TensorMap
 
 from metatomic.torch import (
-    MetatensorAtomisticModel,
+    AtomisticModel,
     ModelCapabilities,
     ModelEvaluationOptions,
     ModelMetadata,
@@ -108,7 +108,7 @@ class FeaturesModel(BaseAtomisticModel):
 def test_energy_ensemble_model(system, get_capabilities):
     model = EnergyEnsembleModel()
     capabilities = get_capabilities("energy_ensemble")
-    atomistic = MetatensorAtomisticModel(model.eval(), ModelMetadata(), capabilities)
+    atomistic = AtomisticModel(model.eval(), ModelMetadata(), capabilities)
 
     options = ModelEvaluationOptions(
         outputs={"energy_ensemble": ModelOutput(per_atom=False)}
@@ -128,7 +128,7 @@ def test_energy_ensemble_model(system, get_capabilities):
 def test_energy_uncertainty_model(system, get_capabilities):
     model = EnergyUncertaintyModel()
     capabilities = get_capabilities("energy_uncertainty")
-    atomistic = MetatensorAtomisticModel(model.eval(), ModelMetadata(), capabilities)
+    atomistic = AtomisticModel(model.eval(), ModelMetadata(), capabilities)
 
     options = ModelEvaluationOptions(
         outputs={"energy_uncertainty": ModelOutput(per_atom=False)}
@@ -147,7 +147,7 @@ def test_energy_uncertainty_model(system, get_capabilities):
 def test_features_model(system, get_capabilities):
     model = FeaturesModel()
     capabilities = get_capabilities("features")
-    atomistic = MetatensorAtomisticModel(model.eval(), ModelMetadata(), capabilities)
+    atomistic = AtomisticModel(model.eval(), ModelMetadata(), capabilities)
 
     options = ModelEvaluationOptions(outputs={"features": ModelOutput(per_atom=False)})
 

--- a/tox.ini
+++ b/tox.ini
@@ -154,7 +154,7 @@ deps =
 changedir = python/metatomic_torch
 commands =
     # use the reference LJ implementation for tests
-    pip install {[testenv]build_single_wheel} git+https://github.com/metatensor/lj-test@bc8d4b7
+    pip install {[testenv]build_single_wheel} git+https://github.com/metatensor/lj-test@5ef9744
 
     # Make torch.autograd.gradcheck works with pytest
     python {toxinidir}/scripts/pytest-dont-rewrite-torch.py


### PR DESCRIPTION
This still works fine when re-exported from metatensor.torch.atomistic

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~
