### PR TITLE
[MAINT] Better lazy loading

### DIFF
--- a/python/metatomic_torch/metatomic/torch/__init__.py
+++ b/python/metatomic_torch/metatomic/torch/__init__.py
@@ -59,7 +59,5 @@ def __getattr__(name):
     if name in ("ase_calculator", "MetatomicCalculator"):
         if name == "ase_calculator":
             return importlib.import_module(".ase_calculator", __name__)
-        else:  # name == "MetatomicCalculator"
-            return importlib.import_module(".ase_calculator", __name__).MetatomicCalculator
 
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/python/metatomic_torch/metatomic/torch/__init__.py
+++ b/python/metatomic_torch/metatomic/torch/__init__.py
@@ -3,9 +3,9 @@ import os
 
 import torch
 
+from . import utils  # noqa: F401
 from ._c_lib import _load_library
 from .version import __version__  # noqa: F401
-from . import utils
 
 
 if os.environ.get("METATOMIC_IMPORT_FOR_SPHINX", "0") != "0":

--- a/python/metatomic_torch/metatomic/torch/__init__.py
+++ b/python/metatomic_torch/metatomic/torch/__init__.py
@@ -8,6 +8,27 @@ from . import utils  # noqa: F401
 from ._c_lib import _load_library
 from .version import __version__  # noqa: F401
 
+_PUBLIC_API = [
+    "System",
+    "NeighborListOptions",
+    "ModelOutput",
+    "ModelEvaluationOptions",
+    "ModelCapabilities",
+    "ModelMetadata",
+    "read_model_metadata",
+    "load_model_extensions",
+    "check_atomistic_model",
+    "register_autograd_neighbors",
+    "unit_conversion_factor",
+    "load_system",
+    "save",
+    "AtomisticModel",
+    "ModelInterface",
+    "is_atomistic_model",
+    "load_atomistic_model",
+    "systems_to_torch",
+]
+
 
 if os.environ.get("METATOMIC_IMPORT_FOR_SPHINX", "0") != "0":
     from .documentation import (
@@ -69,7 +90,7 @@ _lazy_imports = {
 
 # The public API of this module includes the lazy-loaded names.
 # This is used by `help()` and introspecting tools.
-__all__ = list(_lazy_imports.keys())
+__all__ = _PUBLIC_API + list(_lazy_imports.keys())
 
 
 def __getattr__(name: str):

--- a/python/metatomic_torch/metatomic/torch/__init__.py
+++ b/python/metatomic_torch/metatomic/torch/__init__.py
@@ -57,15 +57,9 @@ def __getattr__(name):
     class upon first access.
     """
     if name in ("ase_calculator", "MetatomicCalculator"):
-        # Import the submodule once using importlib for a clean, relative import
-        module = importlib.import_module(".ase_calculator", __name__)
-
         if name == "ase_calculator":
-            globals()[name] = module
-            return module
+            return importlib.import_module(".ase_calculator", __name__)
         else:  # name == "MetatomicCalculator"
-            calculator_class = module.MetatomicCalculator
-            globals()[name] = calculator_class
-            return calculator_class
+            return importlib.import_module(".ase_calculator", __name__).MetatomicCalculator
 
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/python/metatomic_torch/tests/ase_calculator.py
+++ b/python/metatomic_torch/tests/ase_calculator.py
@@ -584,6 +584,7 @@ def with_isolated_imports(test_func):
     return wrapper
 
 
+
 @with_isolated_imports
 def test_lazy_loading_module():
     """Tests that the `ase_calculator` module is lazy-loaded correctly.
@@ -614,5 +615,4 @@ def test_lazy_loading_class():
     calculator_class = metatomic.torch.MetatomicCalculator
 
     assert module_name in sys.modules
-    assert "MetatomicCalculator" in metatomic.torch.__dict__
     assert metatomic.torch.MetatomicCalculator is calculator_class


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

Reworks the fix to #54 a bit by:
- Caching the module to prevent multiple imports
  - By vendoring a stripped version of [lazy-loader](https://github.com/scientific-python/lazy-loader/tree/main)
- Adding tests
- Demonstrating lazy re-exports of both `ase_calculator` and `MetatomicCalculator`.


~**Do not merge** until a consensus of which to export is reached (both, as shown in this PR is a bit redundant but.. also OK).~ Both is fine.

# Contributor (creator of pull-request) checklist

 - [X] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [X] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
