### PR TITLE
Also look for libgomp in the user site-package if enabled

### DIFF
--- a/python/metatomic_torch/metatomic/torch/_extensions.py
+++ b/python/metatomic_torch/metatomic/torch/_extensions.py
@@ -68,7 +68,11 @@ def _find_openmp_dep(search_dir):
     if sys.platform.startswith("linux"):
         libs_list = []
 
-        for prefix in site.getsitepackages():
+        site_packages = site.getsitepackages()
+        if site.ENABLE_USER_SITE:
+            site_packages.append(site.getusersitepackages())
+
+        for prefix in site_packages:
             libs_dir = os.path.join(prefix, search_dir)
             if os.path.exists(libs_dir):
                 libs_list = glob.glob(os.path.join(libs_dir, "libgomp-*.so*"))


### PR DESCRIPTION
We would otherwise miss it and then fail loading extensions that depend on libgomp.

This happens in https://github.com/plumed/plumed2/pull/1305

# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [ ] ~Documentation updated (for new features)?~
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~
