### PR TITLE
Use the new metatensor_torch::Module in load_atomistic_model

### DIFF
--- a/metatomic-torch/include/metatomic/torch/model.hpp
+++ b/metatomic-torch/include/metatomic/torch/model.hpp
@@ -316,7 +316,7 @@ METATOMIC_TORCH_EXPORT void load_model_extensions(
 /// This function calls `check_atomistic_model(path)` and
 /// `load_model_extensions(path, extension_directory)` before attempting to load
 /// the model.
-METATOMIC_TORCH_EXPORT torch::jit::Module load_atomistic_model(
+METATOMIC_TORCH_EXPORT metatensor_torch::Module load_atomistic_model(
     std::string path,
     c10::optional<std::string> extensions_directory = c10::nullopt
 );

--- a/metatomic-torch/src/model.cpp
+++ b/metatomic-torch/src/model.cpp
@@ -933,13 +933,13 @@ void metatomic_torch::check_atomistic_model(std::string path) {
     }
 }
 
-torch::jit::Module metatomic_torch::load_atomistic_model(
+metatensor_torch::Module metatomic_torch::load_atomistic_model(
     std::string path,
     c10::optional<std::string> extensions_directory
 ) {
     load_model_extensions(path, extensions_directory);
     check_atomistic_model(path);
-    return torch::jit::load(path);
+    return metatensor_torch::Module(torch::jit::load(path));
 }
 
 /******************************************************************************/


### PR DESCRIPTION
Follow up to #74, making sure we can use https://github.com/metatensor/metatensor/pull/921 inside atomistic models

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
