### PR TITLE
Allow output variants

### DIFF
--- a/docs/src/engines/ase.rst
+++ b/docs/src/engines/ase.rst
@@ -16,7 +16,9 @@ Supported model outputs
 
 .. py:currentmodule:: metatomic.torch.ase_calculator
 
-- the :ref:`energy <energy-output>` output is supported and fully integrated
+- the :ref:`energy <energy-output>`, non-conservative :ref:`forces
+  <non-conservative-forces-output>` and :ref:`stress <non-conservative-stress-output>`
+  including their :ref:`variants <output-variants>` are supported and fully integrated
   with ASE calculator interface (i.e. :py:meth:`ase.Atoms.get_potential_energy`,
   :py:meth:`ase.Atoms.get_forces`, …);
 - arbitrary outputs can be computed for any :py:class:`ase.Atoms` using

--- a/docs/src/engines/ipi.rst
+++ b/docs/src/engines/ipi.rst
@@ -15,9 +15,10 @@ i-PI
 Supported model outputs
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Only the :ref:`energy <energy-output>` output is supported, and used to run path
-integral simulations, incorporating quantum nuclear effects in the statistical
-sampling.
+The :ref:`energy <energy-output>`, non-conservative :ref:`forces
+<non-conservative-forces-output>` and :ref:`stress <non-conservative-stress-output>`
+outputs are supported, and can be used to run path integral simulations, incorporating
+integral simulations, incorporating quantum nuclear effects in the statistical sampling.
 
 How to install the code
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/src/engines/lammps.rst
+++ b/docs/src/engines/lammps.rst
@@ -15,10 +15,11 @@ LAMMPS
 Supported model outputs
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Only the :ref:`energy <energy-output>` output is supported in LAMMPS, as a
-custom ``pair_style``. This allows running molecular dynamics simulations with
-interatomic potentials in the metatomic format; distributing the simulation over
-multiple nodes and potentially multiple GPUs.
+The :ref:`energy <energy-output>`, non-conservative :ref:`forces
+<non-conservative-forces-output>` and :ref:`stress <non-conservative-stress-output>`
+outputs are supported in LAMMPS, as a custom ``pair_style``. This allows running
+molecular dynamics simulations with interatomic potentials in the metatomic format;
+distributing the simulation over multiple nodes and potentially multiple GPUs.
 
 How to install the code
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/src/outputs/energy.rst
+++ b/docs/src/outputs/energy.rst
@@ -3,8 +3,8 @@
 Energy
 ^^^^^^
 
-Energy is associated with the ``"energy"`` key in the model outputs, and must
-have the following metadata:
+Energy is associated with the ``"energy"`` or ``"energy/<variant>"`` key (see
+:ref:`output-variants`) in the model outputs, and must have the following metadata:
 
 .. list-table:: Metadata for energy output
   :widths: 2 3 7
@@ -157,10 +157,10 @@ The following gradients can be defined and requested with
 Energy ensemble
 ---------------
 
-An ensemble of energies is associated with the ``"energy_ensemble"`` key in the
-model outputs. Such ensembles are sometimes used to perform uncertainty
-quantification, using multiple prediction to estimate an error on the mean
-prediction.
+An ensemble of energies is associated with the ``"energy_ensemble"``  or
+``"energy_ensemble/<variant>"`` key (see :ref:`output-variants`) in the model outputs.
+Such ensembles are sometimes used to perform uncertainty quantification, using multiple
+prediction to estimate an error on the mean prediction.
 
 Energy ensembles must have the following metadata:
 

--- a/docs/src/outputs/features.rst
+++ b/docs/src/outputs/features.rst
@@ -14,8 +14,9 @@ by a neural-network or a similar machine learning construct.
 .. _SOAP power spectrum: https://doi.org/10.1103/PhysRevB.87.184115
 .. _Atom-centered symmetry functions: https://doi.org/10.1063/1.3553717
 
-In metatomic models, they are associated with the ``"features"`` key in the
-model outputs, and must adhere to the following metadata specification:
+In metatomic models, they are associated with the ``"features"`` or
+``"features/<variant>"`` key (see :ref:`output-variants`) key in the model
+outputs, and must adhere to the following metadata specification:
 
 .. list-table:: Metadata for features output
   :widths: 2 3 7

--- a/docs/src/outputs/index.rst
+++ b/docs/src/outputs/index.rst
@@ -21,6 +21,7 @@ section to these pages.
   features
   non_conservative
   positions-and-momenta
+  variants
 
 
 Physical quantities
@@ -93,6 +94,12 @@ quantities, i.e. quantities with a well-defined physical meaning.
 
       Atomic momenta predicted by the model, to be used in ML-driven simulations.
 
+Output variants
+^^^^^^^^^^^^^^^
+
+models can define output variants are used to provide for example different levels of
+theory for a given output based from the same model. For more information on output
+variants, please refer to :ref:`output-variants`.
 
 Machine learning outputs
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/src/outputs/index.rst
+++ b/docs/src/outputs/index.rst
@@ -18,10 +18,18 @@ section to these pages.
   :hidden:
 
   energy
-  features
   non_conservative
   positions-and-momenta
+  features
   variants
+
+Output variants
+^^^^^^^^^^^^^^^
+
+Models can define variants of any output, for example to provide the same output
+at different levels of theory in a single model. For more information on output
+variants, please refer to :ref:`the corresponding documentation
+<output-variants>`.
 
 
 Physical quantities
@@ -93,13 +101,6 @@ quantities, i.e. quantities with a well-defined physical meaning.
       .. image:: /../static/images/momenta-output.png
 
       Atomic momenta predicted by the model, to be used in ML-driven simulations.
-
-Output variants
-^^^^^^^^^^^^^^^
-
-models can define output variants are used to provide for example different levels of
-theory for a given output based from the same model. For more information on output
-variants, please refer to :ref:`output-variants`.
 
 Machine learning outputs
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/src/outputs/non_conservative.rst
+++ b/docs/src/outputs/non_conservative.rst
@@ -8,8 +8,9 @@ gradient of a potential energy function. These are generally faster to compute
 than forces derived from the potential energy by backpropagation. However, these
 predictions must be used with care, see https://arxiv.org/abs/2412.11569.
 
-In metatomic models, they are associated with the ``"non_conservative_forces"``
-key in the model outputs, and must adhere to the following metadata schema:
+In metatomic models, they are associated with the ``"non_conservative_forces"`` or
+``"non_conservative_forces/<variant>"`` key (see :ref:`output-variants`) in the model
+outputs, and must adhere to the following metadata schema:
 
 .. list-table:: Metadata for non-conservative forces
   :widths: 2 3 7
@@ -94,8 +95,9 @@ not calculated using derivatives of the potential energy. As with forces, they
 are typically faster to compute but need to be used with care, see
 https://arxiv.org/abs/2412.11569.
 
-In metatomic models, they are associated with the ``"non_conservative_stress"``
-key in the model outputs, and must adhere to the following metadata schema:
+In metatomic models, they are associated with the ``"non_conservative_stress"`` or
+``"non_conservative_stress/<variant>"`` key (see :ref:`output-variants`) in the model
+outputs, and must adhere to the following metadata schema:
 
 .. list-table:: Metadata for non-conservative stress output
   :widths: 2 3 7

--- a/docs/src/outputs/positions-and-momenta.rst
+++ b/docs/src/outputs/positions-and-momenta.rst
@@ -7,8 +7,9 @@ Positions are differences between atomic positions at two different times.
 They can be used to predict the next configuration in molecular dynamics
 (see, e.g., https://arxiv.org/pdf/2505.19350).
 
-In metatomic models, they are associated with the ``"positions"``
-key in the model outputs, and must adhere to the following metadata schema:
+In metatomic models, they are associated with the ``"positions"`` or
+``"positions/<variant>"`` key (see :ref:`output-variants`) key in the model
+outputs, and must adhere to the following metadata schema:
 
 .. list-table:: Metadata for positions
   :widths: 2 3 7
@@ -58,8 +59,9 @@ The momentum of a particle is a vector defined as its mass times its velocity.
 Predictions of momenta can be used, for example, to predict a future step in molecular
 dynamics (see, e.g., https://arxiv.org/pdf/2505.19350).
 
-In metatomic models, they are associated with the ``"momenta"``
-key in the model outputs, and must adhere to the following metadata schema:
+In metatomic models, they are associated with the ``"momenta"`` or
+``"momenta/<variant>"`` key (see :ref:`output-variants`) key in the model
+outputs, and must adhere to the following metadata schema:
 
 .. list-table:: Metadata for momenta
   :widths: 2 3 7

--- a/docs/src/outputs/variants.rst
+++ b/docs/src/outputs/variants.rst
@@ -1,0 +1,31 @@
+.. _output-variants:
+
+Output variants
+^^^^^^^^^^^^^^^
+
+Models can provide multiple *variants* of the same output, for example different
+exchange–correlation functionals for the energy. Variants allow you to select which
+"head" of the model to use in downstream engines and workflows.
+
+Variants are identified by appending ``"/<variant>"`` to the base output name. For
+example:
+
+- ``energy`` (default)
+- ``energy/pbe0``
+- ``energy/r2scan``
+
+If a model defines one or more variants, it **must also define the default base output**
+(e.g. ``energy``). Both the default and its variants follow the same :ref:`output
+metadata <atomistic-models-outputs>` rules.
+
+The following simulation engines currently support output variants:
+
+.. grid:: 1 3 3 3
+
+  .. grid-item-card::
+    :text-align: center
+    :padding: 1
+    :link: engine-ase
+    :link-type: ref
+
+    |ase-logo|

--- a/docs/src/outputs/variants.rst
+++ b/docs/src/outputs/variants.rst
@@ -3,22 +3,29 @@
 Output variants
 ^^^^^^^^^^^^^^^
 
-Models can provide multiple *variants* of the same output, for example different
-exchange–correlation functionals for the energy. Variants allow you to select which
-"head" of the model to use in downstream engines and workflows.
+Models can provide multiple **variants** of the same output, for example
+different exchange–correlation functionals for the energy. Users of a model can
+then select which variant of the output should be used in simulation engines and
+workflows. Variants are also sometimes referred to as **heads**, especially in
+the context of deep learning models.
 
-Variants are identified by appending ``"/<variant>"`` to the base output name. For
-example:
+Variants are identified by appending ``"/<variant>"`` to the base output name.
+For example:
 
 - ``energy`` (default)
+- ``energy/pbe``
 - ``energy/pbe0``
 - ``energy/r2scan``
 
-If a model defines one or more variants, it **must also define the default base output**
-(e.g. ``energy``). Both the default and its variants follow the same :ref:`output
-metadata <atomistic-models-outputs>` rules.
+.. important::
 
-The following simulation engines currently support output variants:
+  If a model defines one or more variants, it **must also define the default
+  base output** (e.g. ``energy``). Both the default and its variants follow the
+  same :ref:`output metadata <atomistic-models-outputs>` rules.
+
+-------------------------------------------------------------------------------
+
+The following simulation engines can use variants for all their supported outputs:
 
 .. grid:: 1 3 3 3
 

--- a/python/metatomic_torch/metatomic/torch/outputs.py
+++ b/python/metatomic_torch/metatomic/torch/outputs.py
@@ -43,21 +43,30 @@ def _check_outputs(
                 f"the model did not produce the '{name}' output, which was requested"
             )
 
-        if name in ["energy", "energy_ensemble", "energy_uncertainty"]:
-            _check_energy_like(name, value, systems, request, selected_atoms)
-        elif name == "features":
+        # get base output (strip variant if present)
+        base = name.split("/", 1)[0]
+
+        if base in ["energy", "energy_ensemble", "energy_uncertainty"]:
+            _check_energy_like(base, value, systems, request, selected_atoms)
+        elif base == "features":
             _check_features(value, systems, request, selected_atoms)
-        elif name == "non_conservative_forces":
+        elif base == "non_conservative_forces":
             _check_non_conservative_forces(value, systems, request, selected_atoms)
-        elif name == "non_conservative_stress":
+        elif base == "non_conservative_stress":
             _check_non_conservative_stress(value, systems, request)
-        elif name == "positions":
+        elif base == "positions":
             _check_positions(value, systems, request)
-        elif name == "momenta":
+        elif base == "momenta":
             _check_momenta(value, systems, request)
-        else:
+        elif "::" in name:
             # this is a non-standard output, there is nothing to check
-            continue
+            pass
+        else:
+            raise ValueError(
+                f"Invalid output name: '{name}'. Variants should be of the form "
+                "'<output>/<variant>'. Non-standard output names should have the form "
+                "'<domain>::<output>'."
+            )
 
 
 def _check_energy_like(

--- a/tox.ini
+++ b/tox.ini
@@ -154,7 +154,7 @@ deps =
 changedir = python/metatomic_torch
 commands =
     # use the reference LJ implementation for tests
-    pip install {[testenv]build_single_wheel} git+https://github.com/metatensor/lj-test@59e20a4
+    pip install {[testenv]build_single_wheel} git+https://github.com/metatensor/lj-test@37fb61a
 
     # Make torch.autograd.gradcheck works with pytest
     python {toxinidir}/scripts/pytest-dont-rewrite-torch.py


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

Fixes #69

It allows user to define variants with a slash syntax `<base>/<variant>` in the model outputs. If the user defines a variant, there has to be also a defined `<base>` output.

I added a selector `energy_variants` to the ASE calculator.

If we are happy with API I will update the tests and docs.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation docs start -->
[📚 Download documentation for this pull-request](https://nightly.link/metatensor/metatomic/actions/artifacts/4156256553.zip)

<!-- download-section Documentation docs end -->