### PR TITLE
Deprecate Python 3.9 and include 3.13

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
       - name: setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: install dependencies
         run: |

--- a/.github/workflows/torch-tests.yml
+++ b/.github/workflows/torch-tests.yml
@@ -18,20 +18,20 @@ jobs:
       matrix:
         include:
           - os: ubuntu-24.04
-            python-version: "3.9"
+            python-version: "3.10"
             torch-version: "2.1"
             numpy-version-pin: "<2.0"
           - os: ubuntu-24.04
-            python-version: "3.9"
+            python-version: "3.10"
             torch-version: "2.8"
           - os: ubuntu-24.04
-            python-version: "3.12"
+            python-version: "3.13"
             torch-version: "2.8"
           - os: macos-15
-            python-version: "3.12"
+            python-version: "3.13"
             torch-version: "2.8"
           - os: windows-2022
-            python-version: "3.12"
+            python-version: "3.13"
             torch-version: "2.8"
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Update the CI tests to reflect the supported Python version - bumping oldest to 3.10 and newest to 3.13