### PR TITLE
Allow variants to be used inside non-standard outputs

### DIFF
--- a/metatomic-torch/src/model.cpp
+++ b/metatomic-torch/src/model.cpp
@@ -165,6 +165,7 @@ void ModelCapabilitiesHolder::set_outputs(torch::Dict<std::string, ModelOutput> 
                     "with non-empty base and variant."
                 );
             }
+
             auto base = name.substr(0, slash);
             auto double_colon = base.rfind("::");
             if (double_colon != std::string::npos) {

--- a/metatomic-torch/tests/models.cpp
+++ b/metatomic-torch/tests/models.cpp
@@ -337,6 +337,7 @@ TEST_CASE("Models metadata") {
             Contains("Variant names must be of the form")
         );
         outputs_non_standard.clear();
+
         // "not-a-standard/"
         outputs_non_standard.insert("not-a-standard/", output_non_standard);
         CHECK_THROWS_WITH(


### PR DESCRIPTION
Variant names for last_layer_features fail as, the base is read incorrectly. 
This fixes by swapping the checks and avoiding the check for outputs with prefix mtt::aux::. 

This is a quick fix and should perhaps be extended, depending on preferred nomenclature of variant output features. 

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation docs start -->
[📚 Download documentation for this pull-request](https://nightly.link/metatensor/metatomic/actions/artifacts/4288271370.zip)

<!-- download-section Documentation docs end -->