### PR TITLE
Update variants

### DIFF
--- a/metatomic-torch/CHANGELOG.md
+++ b/metatomic-torch/CHANGELOG.md
@@ -25,6 +25,9 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 
 - `ModelOutput` now has a `description` field, to carry more information
   about a given output.
+- the `pick_output` function that can be used by simulation engines to pick the
+  correct output based on what's available inside a model and which variant (if
+  any) the user requested.
 
 ## [Version 0.1.5](https://github.com/metatensor/metatomic/releases/tag/metatomic-torch-v0.1.5) - 2025-10-06
 

--- a/metatomic-torch/include/metatomic/torch/misc.hpp
+++ b/metatomic-torch/include/metatomic/torch/misc.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include <torch/torch.h>
 
+#include "metatomic/torch/model.hpp"
 #include "metatomic/torch/system.hpp"
 
 #include <torch/types.h>
@@ -24,6 +25,14 @@ METATOMIC_TORCH_EXPORT std::string version();
 METATOMIC_TORCH_EXPORT std::string pick_device(
 	std::vector<std::string> model_devices,
 	torch::optional<std::string> desired_device = torch::nullopt
+);
+
+/// Pick the output for the given `requested_output` from the availabilities of the
+/// model's `outputs`, according to the optional `desired_variant`.
+METATOMIC_TORCH_EXPORT std::string pick_output(
+	std::string requested_output,
+	torch::Dict<std::string, ModelOutput> outputs,
+	torch::optional<std::string> desired_variant = torch::nullopt
 );
 
 // ===== File-based =====
@@ -46,7 +55,7 @@ inline System        load_system_buffer(const torch::Tensor& data) {
       throw std::runtime_error("System pickle: expected 1D torch.uint8 buffer");
   }
   const uint8_t* ptr = t.data_ptr<uint8_t>();
-  const size_t n = static_cast<size_t>(t.numel());
+  const auto n = static_cast<size_t>(t.numel());
   return load_system_buffer(ptr, n);
 }
 

--- a/metatomic-torch/include/metatomic/torch/model.hpp
+++ b/metatomic-torch/include/metatomic/torch/model.hpp
@@ -39,19 +39,19 @@ bool valid_quantity(const std::string& quantity);
 void validate_unit(const std::string& quantity, const std::string& unit);
 
 
-/// Metadata of one of the quantity a model can compute
+/// Information about one of the quantity a model can compute
 class METATOMIC_TORCH_EXPORT ModelOutputHolder: public torch::CustomClassHolder {
 public:
     ModelOutputHolder() = default;
 
     /// Initialize `ModelOutput` with the given data
     ModelOutputHolder(
-        std::string description_,
         std::string quantity,
         std::string unit,
         bool per_atom_,
-        std::vector<std::string> explicit_gradients_
-    ):  
+        std::vector<std::string> explicit_gradients_,
+        std::string description_
+    ):
         description(std::move(description_)),
         per_atom(per_atom_),
         explicit_gradients(std::move(explicit_gradients_))

--- a/metatomic-torch/src/register.cpp
+++ b/metatomic-torch/src/register.cpp
@@ -126,16 +126,16 @@ TORCH_LIBRARY(metatomic, m) {
             torch::init<
                 std::string,
                 std::string,
-                std::string,
                 bool,
-                std::vector<std::string>
+                std::vector<std::string>,
+                std::string
             >(),
             DOCSTRING, {
-                torch::arg("description") = "",
                 torch::arg("quantity") = "",
                 torch::arg("unit") = "",
                 torch::arg("per_atom") = false,
-                torch::arg("explicit_gradients") = std::vector<std::string>()
+                torch::arg("explicit_gradients") = std::vector<std::string>(),
+                torch::arg("description") = "",
             }
         )
         .def_readwrite("description", &ModelOutputHolder::description)
@@ -220,6 +220,7 @@ TORCH_LIBRARY(metatomic, m) {
     // standalone functions
     m.def("version() -> str", version);
     m.def("pick_device(str[] model_devices, str? requested_device = None) -> str", pick_device);
+    m.def("pick_output(str requested_output, Dict(str, __torch__.torch.classes.metatomic.ModelOutput) outputs, str? desired_variant = None) -> str", pick_output);
 
     m.def("read_model_metadata(str path) -> __torch__.torch.classes.metatomic.ModelMetadata", read_model_metadata);
     m.def("unit_conversion_factor(str quantity, str from_unit, str to_unit) -> float", unit_conversion_factor);

--- a/python/metatomic_torch/metatomic/torch/__init__.py
+++ b/python/metatomic_torch/metatomic/torch/__init__.py
@@ -17,6 +17,7 @@ if os.environ.get("METATOMIC_IMPORT_FOR_SPHINX", "0") != "0":
         check_atomistic_model,
         load_model_extensions,
         pick_device,
+        pick_output,
         read_model_metadata,
         register_autograd_neighbors,
         unit_conversion_factor,
@@ -40,6 +41,7 @@ else:
     register_autograd_neighbors = torch.ops.metatomic.register_autograd_neighbors
     unit_conversion_factor = torch.ops.metatomic.unit_conversion_factor
     pick_device = torch.ops.metatomic.pick_device
+    pick_output = torch.ops.metatomic.pick_output
 
 from .model import (  # noqa: F401
     AtomisticModel,

--- a/python/metatomic_torch/metatomic/torch/ase_calculator.py
+++ b/python/metatomic_torch/metatomic/torch/ase_calculator.py
@@ -19,6 +19,7 @@ from . import (
     System,
     load_atomistic_model,
     pick_device,
+    pick_output,
     register_autograd_neighbors,
 )
 
@@ -166,50 +167,59 @@ class MetatomicCalculator(ase.calculators.calculator.Calculator):
                 f"found unexpected dtype in model capabilities: {capabilities.dtype}"
             )
 
-        self._energy_key = "energy"
-        self._energy_uq_key = "energy_uncertainty"
-        self._nc_forces_key = "non_conservative_forces"
-        self._nc_stress_key = "non_conservative_stress"
+        # resolve the output keys to use based on the requested variants
+        variants = variants or {}
+        default_variant = variants.get("energy")
 
-        if variants:
-            if "energy" in variants:
-                self._energy_key += f"/{variants['energy']}"
-                self._energy_uq_key += f"/{variants['energy']}"
-                self._nc_forces_key += f"/{variants['energy']}"
-                self._nc_stress_key += f"/{variants['energy']}"
+        resolved_variants = {
+            key: variants.get(key, default_variant)
+            for key in [
+                "energy",
+                "energy_uncertainty",
+                "non_conservative_forces",
+                "non_conservative_stress",
+            ]
+        }
 
-            if "energy_uncertainty" in variants:
-                if variants["energy_uncertainty"] is None:
-                    self._energy_uq_key = "energy_uncertainty"
-                else:
-                    self._energy_uq_key += f"/{variants['energy_uncertainty']}"
+        outputs = capabilities.outputs
+        self._energy_key = pick_output("energy", outputs, resolved_variants["energy"])
 
-            if non_conservative:
-                if (
-                    "non_conservative_stress" in variants
-                    and "non_conservative_forces" in variants
-                    and (
-                        (variants["non_conservative_stress"] is None)
-                        != (variants["non_conservative_forces"] is None)
-                    )
-                ):
-                    raise ValueError(
-                        "if both 'non_conservative_stress' and "
-                        "'non_conservative_forces' are present in `variants`, they "
-                        "must either be both `None` or both not `None`."
-                    )
+        has_energy_uq = any("energy_uncertainty" in key for key in outputs.keys())
+        if has_energy_uq and uncertainty_threshold is not None:
+            self._energy_uq_key = pick_output(
+                "energy_uncertainty", outputs, resolved_variants["energy_uncertainty"]
+            )
+        else:
+            self._energy_uq_key = "energy_uncertainty"
 
-                if "non_conservative_forces" in variants:
-                    if variants["non_conservative_forces"] is None:
-                        self._nc_forces_key = "non_conservative_forces"
-                    else:
-                        self._nc_forces_key += f"/{variants['non_conservative_forces']}"
+        if non_conservative:
+            if (
+                "non_conservative_stress" in variants
+                and "non_conservative_forces" in variants
+                and (
+                    (variants["non_conservative_stress"] is None)
+                    != (variants["non_conservative_forces"] is None)
+                )
+            ):
+                raise ValueError(
+                    "if both 'non_conservative_stress' and "
+                    "'non_conservative_forces' are present in `variants`, they "
+                    "must either be both `None` or both not `None`."
+                )
 
-                if "non_conservative_stress" in variants:
-                    if variants["non_conservative_stress"] is None:
-                        self._nc_stress_key = "non_conservative_stress"
-                    else:
-                        self._nc_stress_key += f"/{variants['non_conservative_stress']}"
+            self._nc_forces_key = pick_output(
+                "non_conservative_forces",
+                outputs,
+                resolved_variants["non_conservative_forces"],
+            )
+            self._nc_stress_key = pick_output(
+                "non_conservative_stress",
+                outputs,
+                resolved_variants["non_conservative_stress"],
+            )
+        else:
+            self._nc_forces_key = "non_conservative_forces"
+            self._nc_stress_key = "non_conservative_stress"
 
         if additional_outputs is None:
             self._additional_output_requests = {}

--- a/python/metatomic_torch/metatomic/torch/documentation.py
+++ b/python/metatomic_torch/metatomic/torch/documentation.py
@@ -247,24 +247,17 @@ class NeighborListOptions:
 
 
 class ModelOutput:
-    """Description of one of the quantity a model can compute."""
+    """Information about one of the quantity a model can compute."""
 
     def __init__(
         self,
-        description: str = "",
         quantity: str = "",
         unit: str = "",
         per_atom: bool = False,
         explicit_gradients: List[str] = [],  # noqa B006
+        description: str = "",
     ):
         pass
-    
-    @property
-    def description(self) -> str:
-        """
-        A description of this output. Especially recommended for non-standard outputs
-        and variants of the one unit.
-        """
 
     @property
     def quantity(self) -> str:
@@ -293,6 +286,13 @@ class ModelOutput:
     Which gradients should be computed eagerly and stored inside the output
     :py:class:`TensorMap`.
     """
+
+    @property
+    def description(self) -> str:
+        """
+        A description of this output. Especially recommended for non-standard outputs
+        and variants of the one unit.
+        """
 
 
 class ModelCapabilities:
@@ -543,4 +543,19 @@ def pick_device(model_devices: List[str], desired_device: Optional[str]) -> str:
     :param model_devices: list of devices supported by a model in order of preference
     :param desired_device: user-provided desired device. If ``None`` or not available,
         the first available device from ``model_devices`` will be picked.
+    """
+
+
+def pick_output(
+    requested_output: str,
+    outputs: Dict[str, ModelOutput],
+    desired_variant: Optional[str] = None,
+) -> str:
+    """
+    Pick the output for the given ``requested_output`` from the availabilities of the
+    model's ``outputs``, according to the optional ``desired_variant``.
+
+    :param requested_output: name of the output to pick a variant for
+    :param outputs: all available outputs from the model
+    :param desired_variant: if provided, try to pick this specific variant
     """

--- a/python/metatomic_torch/tests/ase_calculator.py
+++ b/python/metatomic_torch/tests/ase_calculator.py
@@ -579,18 +579,23 @@ def test_additional_outputs(atoms):
     )
     model = AtomisticModel(MultipleOutputModel().eval(), ModelMetadata(), capabilities)
 
-    atoms.calc = MetatomicCalculator(model, check_consistency=True)
+    atoms.calc = MetatomicCalculator(
+        model,
+        check_consistency=True,
+        uncertainty_threshold=None,
+    )
 
     assert atoms.get_potential_energy() == 0.0
     assert atoms.calc.additional_outputs == {}
 
     atoms.calc = MetatomicCalculator(
         model,
-        check_consistency=True,
         additional_outputs={
             "test::test": ModelOutput(per_atom=False),
             "another::one": ModelOutput(per_atom=False),
         },
+        check_consistency=True,
+        uncertainty_threshold=None,
     )
     assert atoms.get_potential_energy() == 0.0
 


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

This PR adds a couple of updates to the variants:

- Allow no default unit present: i.e. now allowed are outputs like `"energy/A"`, `"energy/B"` without `"energy"` being present.
- Add a backwards compatible `description` attribute to `ModelOutputs`.
- Added `pick_variant` function that will pick a variant based on a `name` (like `"energy"`), a `ModelCapabilities` object and an optional `desired_variant`. The function will try to pick the user choice and if not given either pick the non-variant or error giving the provided variances. I am not happy with the parameter naming and order. We can discuss it

# TODO

 - [x] Update CXX tests
 - [x] Use `pick_variant` in ase calculator
 - [x] Update Python tests
 - [x] Update docs for variants

# Reviewer checklist

 - [x] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation docs start -->
[📚 Download documentation for this pull-request](https://nightly.link/metatensor/metatomic/actions/artifacts/4405842971.zip)

<!-- download-section Documentation docs end -->