### PR TITLE
Allow giving an already torch-scripted model to AtomisticModel

### DIFF
--- a/python/metatomic_torch/metatomic/torch/model.py
+++ b/python/metatomic_torch/metatomic/torch/model.py
@@ -596,51 +596,127 @@ def _get_requested_neighbor_lists(
 
 
 def _check_annotation(module: torch.nn.Module):
+    if isinstance(module, torch.jit.RecursiveScriptModule):
+        _check_annotation_torchscript(module)
+    else:
+        _check_annotation_python(module)
+
+
+EXPECTED_ARGUMENTS = [
+    "systems",
+    "outputs",
+    "selected_atoms",
+    "return",
+]
+
+EXPECTED_SIGNATURE = (
+    "`forward(self, "
+    "systems: List[System], "
+    "outputs: Dict[str, ModelOutput], "
+    "selected_atoms: Optional[Labels]"
+    ") -> Dict[str, TensorMap]`"
+)
+
+
+def _format_annotation(_type) -> str:
+    if hasattr(_type, "annotation_str"):
+        return _type.annotation_str
+    elif isinstance(_type, type):
+        return _type.__name__
+    else:
+        return str(_type)
+
+
+def _check_annotation_torchscript(module: torch.jit.RecursiveScriptModule):
+    args = module.forward.schema.arguments
+
+    # ignore `self` in arguments, and `return` in EXECTED_ARGUMENTS
+    if [str(arg.name) for arg in args[1:]] != EXPECTED_ARGUMENTS[:-1]:
+        actual_signature = (
+            "forward(self, "
+            + ", ".join(
+                f"{arg.name}: {_format_annotation(arg.type)}" for arg in args[1:]
+            )
+            + ") -> "
+            + _format_annotation(module.forward.schema.returns[0].type)
+        )
+        raise TypeError(
+            "`module.forward()` takes unexpected arguments, "
+            f"expected signature is {EXPECTED_SIGNATURE}, got `{actual_signature}`"
+        )
+
+    if str(args[1].type) != "List[__torch__.torch.classes.metatomic.System]":
+        raise TypeError(
+            "`systems` argument must be a list of metatomic `System`, "
+            f"not `{_format_annotation(args[1].type)}`"
+        )
+
+    if str(args[2].type) != "Dict[str, __torch__.torch.classes.metatomic.ModelOutput]":
+        raise TypeError(
+            "`outputs` argument must be `Dict[str, ModelOutput]`, "
+            f"not `{_format_annotation(args[2].type)}`"
+        )
+
+    if str(args[3].type) != "Optional[__torch__.torch.classes.metatensor.Labels]":
+        raise TypeError(
+            "`selected_atoms` argument must be `Optional[Labels]`, "
+            f"not `{_format_annotation(args[3].type)}`"
+        )
+
+    returns = module.forward.schema.returns
+    if (
+        len(returns) != 1
+        or str(returns[0].type)
+        != "Dict[str, __torch__.torch.classes.metatensor.TensorMap]"
+    ):
+        raise TypeError(
+            "`forward()` must return a `Dict[str, TensorMap]`, "
+            f"not `{', '.join(_format_annotation(r.type) for r in returns)}`"
+        )
+
+
+def _check_annotation_python(module: torch.nn.Module):
     # check annotations on forward
     annotations = module.forward.__annotations__
-    expected_arguments = [
-        "systems",
-        "outputs",
-        "selected_atoms",
-        "return",
-    ]
 
-    expected_signature = (
-        "`forward(self, "
-        "systems: List[System], "
-        "outputs: Dict[str, ModelOutput], "
-        "selected_atoms: Optional[Labels]"
-        ") -> Dict[str, TensorMap]`"
-    )
-
-    if list(annotations.keys()) != expected_arguments:
+    if list(annotations.keys()) != EXPECTED_ARGUMENTS:
+        actual_signature = (
+            "forward(self, "
+            + ", ".join(
+                f"{n}: {_format_annotation(t)}"
+                for (n, t) in annotations.items()
+                if n != "return"
+            )
+            + ") -> "
+            + _format_annotation(annotations.get("return", "None"))
+        )
         raise TypeError(
-            "`module.forward()` takes unexpected arguments, expected signature is "
-            + expected_signature
+            "`module.forward()` takes unexpected arguments, "
+            f"expected signature is {EXPECTED_SIGNATURE}, got `{actual_signature}`"
         )
 
     if annotations["systems"] != List[System]:
         raise TypeError(
             "`systems` argument must be a list of metatomic `System`, "
-            f"not {annotations['systems']}"
+            f"not `{_format_annotation(annotations['systems'])}`"
         )
 
     if annotations["outputs"] != Dict[str, ModelOutput]:
         raise TypeError(
             "`outputs` argument must be `Dict[str, ModelOutput]`, "
-            f"not {annotations['outputs']}"
+            f"not `{_format_annotation(annotations['outputs'])}`"
         )
 
     if annotations["selected_atoms"] != Optional[Labels]:
         raise TypeError(
             "`selected_atoms` argument must be `Optional[Labels]`, "
-            f"not {annotations['selected_atoms']}"
+            f"not `{_format_annotation(annotations['selected_atoms'])}`"
         )
 
     if annotations["return"] != Dict[str, TensorMap]:
         raise TypeError(
             "`forward()` must return a `Dict[str, TensorMap]`, "
-            f"not {annotations['return']}"
+            f"not `{_format_annotation(annotations['return'])}`"
         )
 
 

--- a/python/metatomic_torch/tests/model.py
+++ b/python/metatomic_torch/tests/model.py
@@ -1,4 +1,5 @@
 import os
+import re
 import zipfile
 from typing import Dict, List, Optional
 
@@ -403,6 +404,94 @@ def test_bad_capabilities():
         ModelCapabilities(outputs={"not-a-standard::": ModelOutput()})
 
 
+def test_annotation_check():
+    class BadModel(torch.nn.Module):
+        def forward(self, x: int) -> int:
+            return x
+
+    message = (
+        "`module.forward()` takes unexpected arguments, expected signature is "
+        "`forward(self, systems: List[System], outputs: Dict[str, ModelOutput], "
+        "selected_atoms: Optional[Labels]) -> Dict[str, TensorMap]`, got "
+        "`forward(self, x: int) -> int`"
+    )
+    model = BadModel().eval()
+    with pytest.raises(TypeError, match=re.escape(message)):
+        _ = AtomisticModel(model, ModelMetadata(), ModelCapabilities())
+
+    model = torch.jit.script(model)
+    with pytest.raises(TypeError, match=re.escape(message)):
+        _ = AtomisticModel(model, ModelMetadata(), ModelCapabilities())
+
+    # ================================================================================ #
+    class BadModel(torch.nn.Module):
+        def forward(self, systems: int, outputs: int, selected_atoms: int) -> int:
+            return 0
+
+    message = "`systems` argument must be a list of metatomic `System`, not `int`"
+    model = BadModel().eval()
+    with pytest.raises(TypeError, match=re.escape(message)):
+        _ = AtomisticModel(model, ModelMetadata(), ModelCapabilities())
+
+    model = torch.jit.script(model)
+    with pytest.raises(TypeError, match=re.escape(message)):
+        _ = AtomisticModel(model, ModelMetadata(), ModelCapabilities())
+
+    # ================================================================================ #
+    class BadModel(torch.nn.Module):
+        def forward(
+            self, systems: List[System], outputs: int, selected_atoms: int
+        ) -> int:
+            return 0
+
+    message = "`outputs` argument must be `Dict[str, ModelOutput]`, not `int`"
+    model = BadModel().eval()
+    with pytest.raises(TypeError, match=re.escape(message)):
+        _ = AtomisticModel(model, ModelMetadata(), ModelCapabilities())
+
+    model = torch.jit.script(model)
+    with pytest.raises(TypeError, match=re.escape(message)):
+        _ = AtomisticModel(model, ModelMetadata(), ModelCapabilities())
+
+    # ================================================================================ #
+    class BadModel(torch.nn.Module):
+        def forward(
+            self,
+            systems: List[System],
+            outputs: Dict[str, ModelOutput],
+            selected_atoms: int,
+        ) -> int:
+            return 0
+
+    message = "`selected_atoms` argument must be `Optional[Labels]`, not `int`"
+    model = BadModel().eval()
+    with pytest.raises(TypeError, match=re.escape(message)):
+        _ = AtomisticModel(model, ModelMetadata(), ModelCapabilities())
+
+    model = torch.jit.script(model)
+    with pytest.raises(TypeError, match=re.escape(message)):
+        _ = AtomisticModel(model, ModelMetadata(), ModelCapabilities())
+
+    # ================================================================================ #
+    class BadModel(torch.nn.Module):
+        def forward(
+            self,
+            systems: List[System],
+            outputs: Dict[str, ModelOutput],
+            selected_atoms: Optional[Labels],
+        ) -> int:
+            return 0
+
+    message = "`forward()` must return a `Dict[str, TensorMap]`, not `int`"
+    model = BadModel().eval()
+    with pytest.raises(TypeError, match=re.escape(message)):
+        _ = AtomisticModel(model, ModelMetadata(), ModelCapabilities())
+
+    model = torch.jit.script(model)
+    with pytest.raises(TypeError, match=re.escape(message)):
+        _ = AtomisticModel(model, ModelMetadata(), ModelCapabilities())
+
+
 def test_access_module(tmpdir):
     model = FullModel()
     model.train(False)
@@ -480,10 +569,22 @@ def test_read_metadata(tmpdir):
 
 
 @pytest.mark.parametrize("n_systems", [0, 1, 8])
-def test_predictions(model, tmp_path, system, n_systems):
+@pytest.mark.parametrize("torch_scripted_model", [True, False])
+def test_predictions(model, tmp_path, system, n_systems, torch_scripted_model):
     os.chdir(tmp_path)
     model.save("export.pt")
     model_loaded = load_atomistic_model("export.pt")
+
+    # check re-wrapping and re-saving an already scripted model
+    if torch_scripted_model:
+        assert isinstance(model_loaded.module, torch.jit.RecursiveScriptModule)
+        wrapper = AtomisticModel(
+            model_loaded.module,
+            model_loaded.metadata(),
+            model_loaded.capabilities(),
+        )
+        wrapper.save("export_scripted.pt")
+        model_loaded = load_atomistic_model("export_scripted.pt")
 
     requested_neighbor_lists = model_loaded.requested_neighbor_lists()
     for requested_neighbor_list in requested_neighbor_lists:
@@ -580,8 +681,7 @@ def test_inconsistent_dtype(system):
 
 
 def test_not_requested_output(system):
-    model = CustomOutputModel(["energy"])
-    model.eval()
+    model = torch.jit.script(CustomOutputModel(["energy"]).eval())
 
     outputs = {
         "energy/scaled": ModelOutput(


### PR DESCRIPTION
Some models (MACE in particular) can not be scripted with the default `torch.jit.script` but require more handling. This allows users to handle TorchScript compilation themself, and then giving the pre-compiled model to AtomisticModel.

@pfebrer, can you try this works for you?

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
