### PR TITLE
Do not crash in AtomisticModel if the model returns too many outputs

### DIFF
--- a/python/metatomic_torch/metatomic/torch/model.py
+++ b/python/metatomic_torch/metatomic/torch/model.py
@@ -473,7 +473,7 @@ class AtomisticModel(torch.nn.Module):
         with record_function("AtomisticModel::convert_units_output"):
             for name, output in outputs.items():
                 declared = self._capabilities.outputs[name]
-                requested = options.outputs[name]
+                requested = options.outputs.get(name, ModelOutput())
                 if declared.quantity == "" or requested.quantity == "":
                     continue
 

--- a/python/metatomic_torch/tests/model.py
+++ b/python/metatomic_torch/tests/model.py
@@ -710,6 +710,19 @@ def test_not_requested_output(system):
     atomistic = AtomisticModel(model, ModelMetadata(), capabilities)
     system = system.to(torch.float32)
 
+    # the model will be missing an output that was requested
     match = "the model did not produce the 'energy/scaled' output, which was requested"
     with pytest.raises(ValueError, match=match):
         atomistic([system], evaluation_options, check_consistency=True)
+
+    # make sure it does not crash with check_consistency=False
+    atomistic([system], evaluation_options, check_consistency=False)
+
+    # the model will create outputs that where not requested
+    evaluation_options = ModelEvaluationOptions(length_unit="angstrom", outputs={})
+    match = "the model produced an output named 'energy', which was not requested"
+    with pytest.raises(ValueError, match=match):
+        atomistic([system], evaluation_options, check_consistency=True)
+
+    # make sure it does not crash with check_consistency=False
+    atomistic([system], evaluation_options, check_consistency=False)


### PR DESCRIPTION
We would previously try to access `evaluation_options.outputs[name]` if the model created an output for `name` even if the output was not requested. 

This already shows a proper error with check_consistency=True.


# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~
