### PR TITLE
Fix KOKKOS input file instructions

### DIFF
--- a/docs/src/engines/lammps.rst
+++ b/docs/src/engines/lammps.rst
@@ -381,7 +381,7 @@ and run the simulation with ``lmp -in input.in``.
 
 Here is the same input file, using the KOKKOS version of the ``pair_style``. You
 can save this file to ``input-kokkos.in``, and run it with ``lmp -in
-input-kokkos.in -sf kk -k on g 1``. See the `lammps-kokkos`_ documentation
+input-kokkos.in -suffix kk -k on g 1``. See the `lammps-kokkos`_ documentation
 for more information about kokkos options.
 
 .. _lammps-kokkos: https://docs.lammps.org/Speed_kokkos.html


### PR DESCRIPTION
`--suffix` doesn't work anymore. Not sure if it ever worked. LAMMPS mentions `-suffix` (which works), and `-sf` also works

<!-- What does this implement/fix? Explain your changes here. -->



# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation docs start -->
[📚 Download documentation for this pull-request](https://nightly.link/metatensor/metatomic/actions/artifacts/4688279850.zip)

<!-- download-section Documentation docs end -->