### PR TITLE
Deprecate ModelOutput.quantity

### DIFF
--- a/metatomic-torch/CHANGELOG.md
+++ b/metatomic-torch/CHANGELOG.md
@@ -31,6 +31,8 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 
 - 3-argument `unit_conversion_factor(quantity, from_unit, to_unit)` is
   deprecated; the `quantity` parameter is ignored
+- `ModelOutput.quantity` field is deprecated, since it is no longer required for
+  unit conversion.
 - `metatomic.torch.ase_calculator` has been split into a separate
   `metatomic-ase` package. The code is temporarily re-exported from the old
   path, but all users are encouraged to update to explicitly requiring

--- a/metatomic-torch/CHANGELOG.md
+++ b/metatomic-torch/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to metatomic-torch are documented here, following the [keep
 a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- Possible sections for each package:
+<!-- Possible sections:
 ### Added
 
 ### Fixed
@@ -23,12 +23,14 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
   `(eV*u)^(1/2)`, etc.) with automatic dimensional validation
 - 2-argument `unit_conversion_factor(from_unit, to_unit)` that parses
   arbitrary unit expressions and checks dimensional compatibility
+- Added `unit_dimension_for_quantity()` to get the physical dimension (i.e.
+  `energy`, `length`, …) corresponding to a standard quantity (output/input) in
+  metatomic.
 
 ### Changed
 
 - 3-argument `unit_conversion_factor(quantity, from_unit, to_unit)` is
   deprecated; the `quantity` parameter is ignored
-
 - `metatomic.torch.ase_calculator` has been split into a separate
   `metatomic-ase` package. The code is temporarily re-exported from the old
   path, but all users are encouraged to update to explicitly requiring

--- a/metatomic-torch/include/metatomic/torch/misc.hpp
+++ b/metatomic-torch/include/metatomic/torch/misc.hpp
@@ -68,19 +68,6 @@ inline System        load_system_buffer(const torch::Tensor& data) {
   return load_system_buffer(ptr, n);
 }
 
-namespace details {
-
-/// Validate that the given `name` is valid for a model output/input
-///
-/// The function returns a tuple with:
-/// - a boolean indicating whether this is a known output/input
-/// - the name of the base output/input (empty if custom)
-/// - the name of the variant (empty if none)
-std::tuple<bool, std::string, std::string> validate_name_and_check_variant(
-    const std::string& name
-);
-}
-
 }
 
 #endif

--- a/metatomic-torch/include/metatomic/torch/model.hpp
+++ b/metatomic-torch/include/metatomic/torch/model.hpp
@@ -84,13 +84,17 @@ public:
     /// description of this output, defaults to empty string of not set by the user
     std::string description;
 
-    /// quantity of the output (e.g. energy, dipole, …).  If this is an empty
+    /// quantity of the output (e.g. energy, dipole, ...).  If this is an empty
     /// string, no unit conversion will be performed.
+    /// @deprecated This field is no longer required for unit conversion.
+    ///             The unit parser determines dimensions from the expression itself.
+    [[deprecated("quantity is no longer required for unit conversion, use unit directly")]]
     const std::string& quantity() const {
         return quantity_;
     }
 
     /// set the quantity of the output
+    [[deprecated("quantity is no longer required for unit conversion, use unit directly")]]
     void set_quantity(std::string quantity);
 
     /// unit of the output. If this is an empty string, no unit conversion will
@@ -249,6 +253,10 @@ public:
     void set_length_unit(std::string unit);
 
     /// requested outputs for this run and corresponding settings
+
+    // FIXME: it would be nice to also check that the units are properly set
+    // here, but since this is a field and not a `set_outputs` function it will
+    // be hard to do, so we will wait until the next set of breaking changes.
     torch::Dict<std::string, ModelOutput> outputs;
 
     /// Only run the calculation for a selected subset of atoms. If this is set

--- a/metatomic-torch/include/metatomic/torch/outputs.hpp
+++ b/metatomic-torch/include/metatomic/torch/outputs.hpp
@@ -26,6 +26,38 @@ void METATOMIC_TORCH_EXPORT check_outputs(
     std::string model_dtype
 );
 
+/// Get the expected unit dimension of the given quantity used as model input or
+/// output.
+///
+/// This will return one of the following strings:
+/// - an empty string for non-standard outputs
+/// - "none" for outputs that should be dimensionless (features, …).
+/// - "length" for length-like quantities (positions, …);
+/// - "momentum" for momentum-like quantities (momenta, …);
+/// - "velocity" for velocity-like quantities (velocities, …);
+/// - "mass" for mass-like quantities (masses, …);
+/// - "energy" for energy-like quantities (energy, energy_ensemble, energy_uncertainty, …);
+/// - "force" for force-like quantities (non_conservative_forces, …);
+/// - "pressure" for pressure-like quantities (non_conservative_stress, …);
+/// - "charge" for charge-like quantities (charges, …);
+/// - "heat_flux" for heat flux-like quantities (heat_flux, …);
+METATOMIC_TORCH_EXPORT std::string unit_dimension_for_quantity(const std::string& output_name);
+
+namespace details {
+    /// Validate that the given `name` is valid for a model output/input
+    ///
+    /// The function returns a tuple with:
+    /// - a boolean indicating whether this is a known output/input
+    /// - the name of the base output/input (empty if custom)
+    /// - the name of the variant (empty if none)
+    ///
+    /// This is intentionally not exported with `METATOMIC_TORCH_EXPORT`, and is
+    /// only intended for internal use.
+    std::tuple<bool, std::string, std::string> validate_name_and_check_variant(
+        const std::string& name
+    );
+}
+
 }
 
 #endif

--- a/metatomic-torch/include/metatomic/torch/units.hpp
+++ b/metatomic-torch/include/metatomic/torch/units.hpp
@@ -7,23 +7,25 @@
 
 namespace metatomic_torch {
 
-/// Check that a given physical quantity is valid and known. This is
-/// intentionally not exported with `METATOMIC_TORCH_EXPORT`, and is only
-/// intended for internal use.
-///
-/// Known quantities are: "length", "energy", "force", "pressure", "momentum",
-/// "mass", "velocity", and "charge".
-bool valid_quantity(const std::string& quantity);
+namespace details {
+    /// Check that a given physical dimension is valid and known.
+    ///
+    /// This is intentionally not exported with `METATOMIC_TORCH_EXPORT`, and is
+    /// only intended for internal use.
+    bool valid_dimension(const std::string& dimension);
 
-/// Check that a given unit is valid and known for some physical quantity. This
-/// is intentionally not exported with `METATOMIC_TORCH_EXPORT`, and is only
-/// intended for internal use.
-///
-/// This function parses the unit expression and verifies that its physical
-/// dimensions match the expected dimensions for the given quantity. For example,
-/// `validate_unit("energy", "eV")` succeeds, but `validate_unit("energy", "eV/A")`
-/// throws an error because eV/A has dimensions of force, not energy.
-void validate_unit(const std::string& quantity, const std::string& unit);
+    /// Check that a given unit is valid and known for some physical dimension.
+    ///
+    /// This is intentionally not exported with `METATOMIC_TORCH_EXPORT`, and is
+    /// only intended for internal use.
+    ///
+    /// This function parses the unit expression and verifies that its physical
+    /// dimensions match the expected dimensions for the given quantity. For
+    /// example, `validate_unit("energy", "eV")` succeeds, but
+    /// `validate_unit("energy", "eV/A")` throws an error because eV/A has
+    /// dimensions of force, not energy.
+    void validate_unit(const std::string& dimension, const std::string& unit);
+}
 
 /// Get the multiplicative conversion factor to use to convert from
 /// `from_unit` to `to_unit`. Both units are parsed as expressions (e.g.

--- a/metatomic-torch/src/misc.cpp
+++ b/metatomic-torch/src/misc.cpp
@@ -7,7 +7,6 @@
 #include <algorithm>
 #include <stdexcept>
 #include <string>
-#include <tuple>
 #include <vector>
 #include <cstring>
 
@@ -411,105 +410,6 @@ System load_system(const std::string& path) {
 System load_system_buffer(const uint8_t* data, size_t size) {
     ZipReader zr(data, size);
     return read_system_from_zip(zr);
-}
-
-
-/// Known inputs and outputs
-inline std::unordered_set<std::string> KNOWN_INPUTS_OUTPUTS = {
-    "energy",
-    "energy_ensemble",
-    "energy_uncertainty",
-    "features",
-    "non_conservative_forces",
-    "non_conservative_stress",
-    "positions",
-    "momenta",
-    "velocities",
-    "masses",
-    "charges",
-    "spin_multiplicity",
-    "heat_flux",
-};
-
-std::tuple<bool, std::string, std::string> details::validate_name_and_check_variant(
-    const std::string& name
-) {
-    if (KNOWN_INPUTS_OUTPUTS.find(name) != KNOWN_INPUTS_OUTPUTS.end()) {
-        // known output, nothing to do
-        return {true, name, ""};
-    }
-
-    auto double_colon = name.rfind("::");
-    if (double_colon != std::string::npos) {
-        if (double_colon == 0 || double_colon == (name.length() - 2)) {
-            C10_THROW_ERROR(ValueError,
-                "Invalid name for model output: '" + name + "'. "
-                "Non-standard names should look like '<domain>::<output>' "
-                "with non-empty domain and output."
-            );
-        }
-
-        auto custom_name = name.substr(0, double_colon);
-        auto output_name = name.substr(double_colon + 2);
-
-        auto slash = custom_name.find('/');
-        if (slash != std::string::npos) {
-            // "domain/variant::custom" is not allowed
-            C10_THROW_ERROR(ValueError,
-                "Invalid name for model output: '" + name + "'. "
-                "Non-standard name with variant should look like "
-                "'<domain>::<output>/<variant>'"
-            );
-        }
-
-        slash = output_name.find('/');
-        if (slash != std::string::npos) {
-            if (slash == 0 || slash == (name.length() - 1)) {
-            C10_THROW_ERROR(ValueError,
-                    "Invalid name for model output: '" + name + "'. "
-                    "Non-standard name with variant should look like "
-                    "'<domain>::<output>/<variant>' with non-empty domain, "
-                    "output and variant."
-                );
-            }
-        }
-
-        // this is a custom output, nothing more to check
-        return {false, "", ""};
-    }
-
-    auto slash = name.find('/');
-    if (slash != std::string::npos) {
-        if (slash == 0 || slash == (name.length() - 1)) {
-            C10_THROW_ERROR(ValueError,
-                "Invalid name for model output: '" + name + "'. "
-                "Variant names should look like '<output>/<variant>' "
-                "with non-empty output and variant."
-            );
-        }
-
-        auto base = name.substr(0, slash);
-        auto double_colon = base.rfind("::");
-        if (double_colon != std::string::npos) {
-            // we don't do anything for custom outputs
-            return {false, "", ""};
-        }
-
-        if (KNOWN_INPUTS_OUTPUTS.find(base) == KNOWN_INPUTS_OUTPUTS.end()) {
-            C10_THROW_ERROR(ValueError,
-                "Invalid name for model output with variant: '" + name + "'. "
-                "'" + base + "' is not a known output."
-            );
-        }
-
-        return {true, base, name};
-    }
-
-    C10_THROW_ERROR(ValueError,
-        "Invalid name for model output: '" + name + "' is not a known output. "
-        "Variant names should be of the form '<output>/<variant>'. "
-        "Non-standard names should have the form '<domain>::<output>'."
-    );
 }
 
 } // namespace metatomic_torch

--- a/metatomic-torch/src/model.cpp
+++ b/metatomic-torch/src/model.cpp
@@ -12,6 +12,7 @@
 
 #include "metatomic/torch/model.hpp"
 #include "metatomic/torch/misc.hpp"
+#include "metatomic/torch/outputs.hpp"
 #include "metatomic/torch/units.hpp"
 
 #include "./internal/shared_libraries.hpp"
@@ -140,15 +141,15 @@ ModelOutputHolder::ModelOutputHolder(
 #endif
 
 void ModelOutputHolder::set_quantity(std::string quantity) {
-    if (valid_quantity(quantity)) {
-        validate_unit(quantity, unit_);
+    if (details::valid_dimension(quantity)) {
+        details::validate_unit(quantity, unit_);
     }
 
     this->quantity_ = std::move(quantity);
 }
 
 void ModelOutputHolder::set_unit(std::string unit) {
-    validate_unit(quantity_, unit);
+    details::validate_unit(quantity_, unit);
     this->unit_ = std::move(unit);
 }
 
@@ -319,7 +320,6 @@ bool ModelOutputHolder::get_per_atom_no_deprecation() const {
 
 
 void ModelCapabilitiesHolder::set_outputs(torch::Dict<std::string, ModelOutput> outputs) {
-
     std::unordered_map<std::string, std::vector<std::string>> variants;
     for (const auto& it: outputs) {
         auto [is_standard, base, variant] = details::validate_name_and_check_variant(it.key());
@@ -332,11 +332,11 @@ void ModelCapabilitiesHolder::set_outputs(torch::Dict<std::string, ModelOutput> 
         };
     }
 
-    // check descriptions for each variant group
-    for (const auto& kv : variants) {
+    for (const auto& kv: variants) {
         const auto& base = kv.first;
         const auto& all_names = kv.second;
 
+        // check descriptions for each variant group
         if (all_names.size() > 1) {
             for (const auto& name : all_names) {
                 if (outputs.at(name)->description.empty()) {
@@ -349,13 +349,38 @@ void ModelCapabilitiesHolder::set_outputs(torch::Dict<std::string, ModelOutput> 
                 }
             }
         }
+
+        for (const auto& name : all_names) {
+            auto output = outputs.at(name);
+            auto unit = output->unit();
+            auto dimension = unit_dimension_for_quantity(base);
+
+            if (dimension.empty()) {
+                // quantity with unknown dimension, just check if the unit is valid
+                details::validate_unit("", unit);
+            } else {
+                if (dimension != "none" && unit.empty()) {
+                    TORCH_WARN(
+                        "output '", name, "' has an empty unit. ",
+                        "Consider adding a unit to ensure correct unit conversion."
+                    );
+                } else if (dimension == "none" && !unit.empty()) {
+                    TORCH_WARN(
+                        "output '", name, "' is dimensionless but has a "
+                        "non-empty unit '", unit, "'."
+                    );
+                } else {
+                    details::validate_unit(dimension, unit);
+                }
+            }
+        }
     }
 
     outputs_ = outputs;
 }
 
 void ModelCapabilitiesHolder::set_length_unit(std::string unit) {
-    validate_unit("length", unit);
+    details::validate_unit("length", unit);
     this->length_unit_ = std::move(unit);
 }
 
@@ -494,7 +519,7 @@ static void check_selected_atoms(const torch::optional<metatensor_torch::Labels>
 }
 
 void ModelEvaluationOptionsHolder::set_length_unit(std::string unit) {
-    validate_unit("length", unit);
+    details::validate_unit("length", unit);
     this->length_unit_ = std::move(unit);
 }
 

--- a/metatomic-torch/src/model.cpp
+++ b/metatomic-torch/src/model.cpp
@@ -141,6 +141,12 @@ ModelOutputHolder::ModelOutputHolder(
 #endif
 
 void ModelOutputHolder::set_quantity(std::string quantity) {
+    if (!quantity.empty()) {
+        TORCH_WARN_DEPRECATION(
+            "ModelOutput.quantity is deprecated and will be removed in a future version"
+        );
+    }
+
     if (details::valid_dimension(quantity)) {
         details::validate_unit(quantity, unit_);
     }
@@ -149,7 +155,9 @@ void ModelOutputHolder::set_quantity(std::string quantity) {
 }
 
 void ModelOutputHolder::set_unit(std::string unit) {
-    details::validate_unit(quantity_, unit);
+    // just check that we can parse the unit
+    details::validate_unit("", unit);
+
     this->unit_ = std::move(unit);
 }
 
@@ -157,7 +165,6 @@ static nlohmann::json model_output_to_json(const ModelOutputHolder& self) {
     nlohmann::json result;
 
     result["class"] = "ModelOutput";
-    result["quantity"] = self.quantity();
     result["unit"] = self.unit();
     result["sample_kind"] = self.sample_kind();
     result["explicit_gradients"] = self.explicit_gradients;
@@ -185,13 +192,6 @@ ModelOutput ModelOutputHolder::from_json(std::string_view json) {
     }
 
     auto result = torch::make_intrusive<ModelOutputHolder>();
-
-    if (data.contains("quantity")) {
-        if (!data["quantity"].is_string()) {
-            throw std::runtime_error("'quantity' in JSON for ModelOutput must be a string");
-        }
-        result->set_quantity(data["quantity"]);
-    }
 
     if (data.contains("unit")) {
         if (!data["unit"].is_string()) {

--- a/metatomic-torch/src/outputs.cpp
+++ b/metatomic-torch/src/outputs.cpp
@@ -784,3 +784,114 @@ void metatomic_torch::check_outputs(
         }
     }
 }
+
+
+/// Known inputs and outputs, mapped to the corresponding unit dimension
+inline std::unordered_map<std::string, std::string> KNOWN_INPUTS_OUTPUTS = {
+    {"energy", "energy"},
+    {"energy_ensemble", "energy"},
+    {"energy_uncertainty", "energy"},
+    {"features", "none"},
+    {"non_conservative_forces", "force"},
+    {"non_conservative_stress", "pressure"},
+    {"positions", "length"},
+    {"momenta", "momentum"},
+    {"velocities", "velocity"},
+    {"masses", "mass"},
+    {"charges", "charge"},
+    {"spin_multiplicity", "none"},
+    {"heat_flux", "heat_flux"},
+};
+
+
+std::tuple<bool, std::string, std::string> metatomic_torch::details::validate_name_and_check_variant(
+    const std::string& name
+) {
+    if (KNOWN_INPUTS_OUTPUTS.find(name) != KNOWN_INPUTS_OUTPUTS.end()) {
+        // known output, nothing to do
+        return {true, name, ""};
+    }
+
+    auto double_colon = name.rfind("::");
+    if (double_colon != std::string::npos) {
+        if (double_colon == 0 || double_colon == (name.length() - 2)) {
+            C10_THROW_ERROR(ValueError,
+                "Invalid name for model output: '" + name + "'. "
+                "Non-standard names should look like '<domain>::<output>' "
+                "with non-empty domain and output."
+            );
+        }
+
+        auto custom_name = name.substr(0, double_colon);
+        auto output_name = name.substr(double_colon + 2);
+
+        auto slash = custom_name.find('/');
+        if (slash != std::string::npos) {
+            // "domain/variant::custom" is not allowed
+            C10_THROW_ERROR(ValueError,
+                "Invalid name for model output: '" + name + "'. "
+                "Non-standard name with variant should look like "
+                "'<domain>::<output>/<variant>'"
+            );
+        }
+
+        slash = output_name.find('/');
+        if (slash != std::string::npos) {
+            if (slash == 0 || slash == (name.length() - 1)) {
+            C10_THROW_ERROR(ValueError,
+                    "Invalid name for model output: '" + name + "'. "
+                    "Non-standard name with variant should look like "
+                    "'<domain>::<output>/<variant>' with non-empty domain, "
+                    "output and variant."
+                );
+            }
+        }
+
+        // this is a custom output, nothing more to check
+        return {false, "", ""};
+    }
+
+    auto slash = name.find('/');
+    if (slash != std::string::npos) {
+        if (slash == 0 || slash == (name.length() - 1)) {
+            C10_THROW_ERROR(ValueError,
+                "Invalid name for model output: '" + name + "'. "
+                "Variant names should look like '<output>/<variant>' "
+                "with non-empty output and variant."
+            );
+        }
+
+        auto base = name.substr(0, slash);
+        auto double_colon = base.rfind("::");
+        if (double_colon != std::string::npos) {
+            // we don't do anything for custom outputs
+            return {false, "", ""};
+        }
+
+        if (KNOWN_INPUTS_OUTPUTS.find(base) == KNOWN_INPUTS_OUTPUTS.end()) {
+            C10_THROW_ERROR(ValueError,
+                "Invalid name for model output with variant: '" + name + "'. "
+                "'" + base + "' is not a known output."
+            );
+        }
+
+        return {true, base, name};
+    }
+
+    C10_THROW_ERROR(ValueError,
+        "Invalid name for model output: '" + name + "' is not a known output. "
+        "Variant names should be of the form '<output>/<variant>'. "
+        "Non-standard names should have the form '<domain>::<output>'."
+    );
+}
+
+
+std::string metatomic_torch::unit_dimension_for_quantity(const std::string& name) {
+    auto [is_known, base_name, _] = details::validate_name_and_check_variant(name);
+
+    if (!is_known) {
+        return "";
+    }
+
+    return KNOWN_INPUTS_OUTPUTS.at(base_name);
+}

--- a/metatomic-torch/src/register.cpp
+++ b/metatomic-torch/src/register.cpp
@@ -222,6 +222,11 @@ TORCH_LIBRARY(metatomic, m) {
         );
 
 
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
     m.class_<ModelOutputHolder>("ModelOutput")
         .def(
             torch::init<
@@ -259,6 +264,9 @@ TORCH_LIBRARY(metatomic, m) {
             }
         );
 
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
     m.class_<ModelCapabilitiesHolder>("ModelCapabilities")
         .def(

--- a/metatomic-torch/src/register.cpp
+++ b/metatomic-torch/src/register.cpp
@@ -348,6 +348,8 @@ TORCH_LIBRARY(metatomic, m) {
         unit_conversion_factor_backward_compatible
     );
 
+    m.def("unit_dimension_for_quantity(str name) -> str", unit_dimension_for_quantity);
+
     // manually construct the schema for "check_atomistic_model(str path) -> ()",
     // so we can set AliasAnalysisKind to CONSERVATIVE. In turn, this make it so
     // the TorchScript compiler knows this function has side-effects, and does

--- a/metatomic-torch/src/system.cpp
+++ b/metatomic-torch/src/system.cpp
@@ -10,8 +10,7 @@
 #include <metatensor/torch.hpp>
 
 #include "metatomic/torch/system.hpp"
-#include "metatomic/torch/misc.hpp"
-#include "metatomic/torch/model.hpp"
+#include "metatomic/torch/outputs.hpp"
 #include "metatomic/torch/units.hpp"
 
 #include "./internal/utils.hpp"
@@ -48,7 +47,7 @@ void NeighborListOptionsHolder::add_requestor(std::string requestor) {
 }
 
 void NeighborListOptionsHolder::set_length_unit(std::string length_unit) {
-    validate_unit("length", length_unit);
+    details::validate_unit("length", length_unit);
     this->length_unit_ = std::move(length_unit);
 }
 

--- a/metatomic-torch/src/units.cpp
+++ b/metatomic-torch/src/units.cpp
@@ -582,23 +582,18 @@ static UnitValue parse_unit_expression(const std::string& unit) {
     return ast->eval();
 }
 
-// ---- Quantity dimension map (for validate_unit) ----
 
-
-static const auto QUANTITY_DIMS = std::unordered_map<std::string, Dimension>{
+static const auto DIMENSION_MAP = std::unordered_map<std::string, Dimension>{
     {"length",    DIM_LENGTH},
     {"energy",    DIM_ENERGY},
-    {"force",     {{1, -2, 1, 0, 0}}},   // energy/length
-    {"pressure",  {{-1, -2, 1, 0, 0}}},  // energy/length^3
-    {"momentum",  {{1, -1, 1, 0, 0}}},   // mass*length/time
+    {"force",     {{1, -2, 1, 0, 0}}},      // energy/length
+    {"pressure",  {{-1, -2, 1, 0, 0}}},     // energy/length^3
+    {"momentum",  {{1, -1, 1, 0, 0}}},      // mass*length/time
     {"mass",      DIM_MASS},
-    {"velocity",  {{1, -1, 0, 0, 0}}},   // length/time
+    {"velocity",  {{1, -1, 0, 0, 0}}},      // length/time
     {"charge",    DIM_CHARGE},
-    {"heat_flux", {{3, -3, 1, 0, 0}}}, // energy*velocity
+    {"heat_flux", {{3, -3, 1, 0, 0}}},      // energy*velocity
 };
-
-
-// ---- Public API ----
 
 /// 2-argument unit_conversion_factor: parse both expressions, check dimensions
 /// match, and return from_factor / to_factor.
@@ -627,23 +622,23 @@ double metatomic_torch::unit_conversion_factor(
     return from.factor / to.factor;
 }
 
-bool metatomic_torch::valid_quantity(const std::string& quantity) {
-    if (quantity.empty()) {
+bool metatomic_torch::details::valid_dimension(const std::string& dimension) {
+    if (dimension.empty()) {
         return false;
     }
 
-    if (QUANTITY_DIMS.find(quantity) == QUANTITY_DIMS.end()) {
-        auto valid_quantities = std::vector<std::string>();
-        for (const auto& it: QUANTITY_DIMS) {
-            valid_quantities.emplace_back(it.first);
+    if (DIMENSION_MAP.find(dimension) == DIMENSION_MAP.end()) {
+        auto valid_dimensions = std::vector<std::string>();
+        for (const auto& it: DIMENSION_MAP) {
+            valid_dimensions.emplace_back(it.first);
         }
-        std::sort(valid_quantities.begin(), valid_quantities.end());
+        std::sort(valid_dimensions.begin(), valid_dimensions.end());
 
         static std::unordered_set<std::string> ALREADY_WARNED = {};
-        if (ALREADY_WARNED.insert(quantity).second) {
+        if (ALREADY_WARNED.insert(dimension).second) {
             TORCH_WARN(
-                "unknown quantity '", quantity, "', only [",
-                torch::str(valid_quantities), "] are supported"
+                "unknown dimension '", dimension, "', only [",
+                torch::str(valid_dimensions), "] are supported"
             );
         }
         return false;
@@ -653,22 +648,22 @@ bool metatomic_torch::valid_quantity(const std::string& quantity) {
 }
 
 
-void metatomic_torch::validate_unit(const std::string& quantity, const std::string& unit) {
-    if (quantity.empty() || unit.empty()) {
+void metatomic_torch::details::validate_unit(const std::string& dimension, const std::string& unit) {
+    if (dimension.empty() || unit.empty()) {
         return;
     }
 
     // Always try to parse the expression (catches syntax errors)
     auto parsed = parse_unit_expression(unit);
 
-    // If the quantity is known, verify dimensions match
-    auto it = QUANTITY_DIMS.find(quantity);
-    if (it != QUANTITY_DIMS.end()) {
+    // If the dimension is known, verify dimensions match
+    auto it = DIMENSION_MAP.find(dimension);
+    if (it != DIMENSION_MAP.end()) {
         if (parsed.dim != it->second) {
             C10_THROW_ERROR(ValueError,
-                "unit '" + unit + "' has dimension " + parsed.dim.to_string()
-                + " which is incompatible with quantity '" + quantity
-                + "' (expected " + it->second.to_string() + ")"
+                "unit '" + unit + "' has dimension " + parsed.dim.to_string() +
+                " which is incompatible with '" + dimension + "' (" +
+                it->second.to_string() + ")"
             );
         }
     }

--- a/metatomic-torch/src/units.cpp
+++ b/metatomic-torch/src/units.cpp
@@ -597,9 +597,6 @@ static const auto DIMENSION_MAP = std::unordered_map<std::string, Dimension>{
 
 /// 2-argument unit_conversion_factor: parse both expressions, check dimensions
 /// match, and return from_factor / to_factor.
-///
-/// Note: Empty strings return 1.0 for backwards compatibility with the 3-arg API
-/// where quantity="" was sometimes used to skip unit conversion.
 double metatomic_torch::unit_conversion_factor(
     const std::string& from_unit,
     const std::string& to_unit
@@ -649,7 +646,7 @@ bool metatomic_torch::details::valid_dimension(const std::string& dimension) {
 
 
 void metatomic_torch::details::validate_unit(const std::string& dimension, const std::string& unit) {
-    if (dimension.empty() || unit.empty()) {
+    if (unit.empty()) {
         return;
     }
 

--- a/metatomic-torch/tests/misc.cpp
+++ b/metatomic-torch/tests/misc.cpp
@@ -80,14 +80,11 @@ TEST_CASE("Pick device errors") {
 TEST_CASE("Pick variant") {
     auto output_base = torch::make_intrusive<metatomic_torch::ModelOutputHolder>();
     output_base->description = "my awesome energy";
-    output_base->set_quantity("energy");
 
     auto variantA = torch::make_intrusive<metatomic_torch::ModelOutputHolder>();
-    variantA->set_quantity("energy");
     variantA->description = "Variant A of the output";
 
     auto variantfoo = torch::make_intrusive<metatomic_torch::ModelOutputHolder>();
-    variantfoo->set_quantity("energy");
     variantfoo->description = "Variant foo of the output";
 
     auto outputs = torch::Dict<std::string, metatomic_torch::ModelOutput>();

--- a/metatomic-torch/tests/models.cpp
+++ b/metatomic-torch/tests/models.cpp
@@ -110,7 +110,7 @@ TEST_CASE("Models metadata") {
             virtual ~WarningHandler() override = default;
             void process(const torch::Warning& warning) override {
                 auto expected = std::string(
-                    "unknown quantity 'unknown', only [charge energy force heat_flux "
+                    "unknown dimension 'unknown', only [charge energy force heat_flux "
                     "length mass momentum pressure velocity] are supported"
                 );
                 CHECK(warning.msg() == expected);
@@ -303,6 +303,7 @@ TEST_CASE("Models metadata") {
         auto capabilities_variants = torch::make_intrusive<ModelCapabilitiesHolder>();
         auto output_variant = torch::make_intrusive<ModelOutputHolder>();
         output_variant->set_sample_kind("atom");
+        output_variant->set_unit("kJ/mol");
         output_variant->description = "variant output";
 
         auto outputs_variant = torch::Dict<std::string, ModelOutput>();
@@ -392,6 +393,7 @@ TEST_CASE("Models metadata") {
         outputs_non_standard.clear();
 
         // test for intended naming
+        output_non_standard->set_unit("Ry");
         outputs_non_standard.insert("energy", output_non_standard);
         outputs_non_standard.insert("custom::custom-output/variant", output_non_standard);
         CHECK_NOTHROW(capabilities_non_standard->set_outputs(outputs_non_standard));
@@ -412,8 +414,11 @@ TEST_CASE("Models metadata") {
         struct WarningHandler: public torch::WarningHandler {
             virtual ~WarningHandler() override = default;
             void process(const torch::Warning& warning) override {
-                CHECK(warning.msg() == "'energy' defines 3 output variants and 'energy/foo' has an empty description. "
-                "Consider adding meaningful descriptions helping users to distinguish between them.");
+                auto expected = std::string(
+                    "'energy' defines 3 output variants and 'energy/foo' has an empty description. "
+                    "Consider adding meaningful descriptions helping users to distinguish between them."
+                );
+                CHECK(warning.msg() == expected);
             }
         };
 
@@ -422,6 +427,7 @@ TEST_CASE("Models metadata") {
         torch::WarningUtils::set_warning_handler(&check_expected_warning);
 
         auto output_variant_no_desc = torch::make_intrusive<ModelOutputHolder>();
+        output_variant_no_desc->set_unit("eV");
         outputs_variant.insert("energy/foo", output_variant_no_desc);
         capabilities_variants->set_outputs(outputs_variant);
 

--- a/metatomic-torch/tests/models.cpp
+++ b/metatomic-torch/tests/models.cpp
@@ -63,7 +63,6 @@ TEST_CASE("Models metadata") {
         // save to JSON
         auto output = torch::make_intrusive<ModelOutputHolder>();
         output->description = "my awesome energy";
-        output->set_quantity("energy");
         output->set_unit("kJ / mol");
         output->set_sample_kind("system");
         output->explicit_gradients = {"baz", "not.this-one_"};
@@ -75,7 +74,6 @@ TEST_CASE("Models metadata") {
         "baz",
         "not.this-one_"
     ],
-    "quantity": "energy",
     "sample_kind": "system",
     "unit": "kJ / mol"
 })";
@@ -84,11 +82,9 @@ TEST_CASE("Models metadata") {
         // load from JSON
         std::string json = R"({
     "class": "ModelOutput",
-    "quantity": "length",
     "explicit_gradients": []
 })";
         output = ModelOutputHolder::from_json(json);
-        CHECK(output->quantity() == "length");
         CHECK(output->unit().empty());
         CHECK(output->sample_kind() == "system");
         CHECK(output->explicit_gradients.empty());
@@ -102,28 +98,9 @@ TEST_CASE("Models metadata") {
             StartsWith("'class' in JSON for ModelOutput must be 'ModelOutput'")
         );
 
-        CHECK_THROWS_WITH(output->set_unit("unknown"),
-            StartsWith("unknown unit 'unknown'")
+        CHECK_THROWS_WITH(output->set_unit("foobar"),
+            StartsWith("unknown unit 'foobar'")
         );
-
-        struct WarningHandler: public torch::WarningHandler {
-            virtual ~WarningHandler() override = default;
-            void process(const torch::Warning& warning) override {
-                auto expected = std::string(
-                    "unknown dimension 'unknown', only [charge energy force heat_flux "
-                    "length mass momentum pressure velocity] are supported"
-                );
-                CHECK(warning.msg() == expected);
-            }
-        };
-
-        auto* old_handler = torch::WarningUtils::get_warning_handler();
-        auto check_expected_warning = WarningHandler();
-        torch::WarningUtils::set_warning_handler(&check_expected_warning);
-
-        output->set_quantity("unknown"),
-
-        torch::WarningUtils::set_warning_handler(old_handler);
     }
 
     SECTION("ModelEvaluationOptions") {
@@ -135,7 +112,6 @@ TEST_CASE("Models metadata") {
 
         auto output = torch::make_intrusive<ModelOutputHolder>();
         output->set_sample_kind("atom");
-        output->set_quantity("energy");
         output->set_unit("eV");
         options->outputs.insert("output_2", output);
 
@@ -147,7 +123,6 @@ TEST_CASE("Models metadata") {
             "class": "ModelOutput",
             "description": "",
             "explicit_gradients": [],
-            "quantity": "",
             "sample_kind": "system",
             "unit": ""
         },
@@ -155,7 +130,6 @@ TEST_CASE("Models metadata") {
             "class": "ModelOutput",
             "description": "",
             "explicit_gradients": [],
-            "quantity": "energy",
             "sample_kind": "atom",
             "unit": "eV"
         }
@@ -190,7 +164,6 @@ TEST_CASE("Models metadata") {
         CHECK(*options->get_selected_atoms().value() == *expected_selection);
 
         output = options->outputs.at("foo");
-        CHECK(output->quantity().empty());
         CHECK(output->unit().empty());
         CHECK(output->sample_kind() == "system");
         CHECK(output->explicit_gradients == std::vector<std::string>{"test"});
@@ -220,7 +193,6 @@ TEST_CASE("Models metadata") {
 
         auto output = torch::make_intrusive<ModelOutputHolder>();
         output->set_sample_kind("atom");
-        output->set_quantity("length");
         output->explicit_gradients.emplace_back("µ-λ");
 
         auto outputs = torch::Dict<std::string, ModelOutput>();
@@ -244,7 +216,6 @@ TEST_CASE("Models metadata") {
             "explicit_gradients": [
                 "\u00b5-\u03bb"
             ],
-            "quantity": "length",
             "sample_kind": "atom",
             "unit": ""
         }
@@ -281,7 +252,6 @@ TEST_CASE("Models metadata") {
         CHECK(capabilities->atomic_types == std::vector<int64_t>{1, -2});
 
         output = capabilities->outputs().at("tests::foo");
-        CHECK(output->quantity().empty());
         CHECK(output->unit().empty());
         // check that we can load JSON with `per_atom` and without `sample_kind`
         CHECK(output->sample_kind() == "atom");
@@ -533,4 +503,45 @@ Please cite the following references when using this model:
 
         CHECK(metadata->print() == expected);
     }
+}
+
+
+TEST_CASE("quantity and unit correspondence checks") {
+
+    auto force_output = torch::make_intrusive<metatomic_torch::ModelOutputHolder>();
+    force_output->set_unit("eV/A");
+
+    auto energy_output = torch::make_intrusive<metatomic_torch::ModelOutputHolder>();
+    energy_output->set_unit("eV");
+
+    auto capabilities = torch::make_intrusive<ModelCapabilitiesHolder>();
+    auto outputs = torch::Dict<std::string, ModelOutput>();
+
+    // energy quantity with a force unit
+    outputs.clear();
+    outputs.insert("energy", force_output);
+    CHECK_THROWS_WITH(
+        capabilities->set_outputs(outputs),
+        Contains(
+            "unit 'eV/A' has dimension L T^-2 M which is incompatible "
+            "with 'energy' (L^2 T^-2 M)"
+        )
+    );
+
+    // force quantity with an energy unit
+    outputs.clear();
+    outputs.insert("non_conservative_forces", energy_output);
+    CHECK_THROWS_WITH(
+        capabilities->set_outputs(outputs),
+        Contains(
+            "unit 'eV' has dimension L^2 T^-2 M which is incompatible "
+            "with 'force' (L T^-2 M)"
+        )
+    );
+
+    // this should work
+    outputs.clear();
+    outputs.insert("non_conservative_forces", force_output);
+    outputs.insert("energy", energy_output);
+    CHECK_NOTHROW(capabilities->set_outputs(outputs));
 }

--- a/metatomic-torch/tests/units.cpp
+++ b/metatomic-torch/tests/units.cpp
@@ -288,7 +288,7 @@ TEST_CASE("ModelOutput rejects mismatched quantity and unit") {
         ),
         Contains(
             "unit 'eV/A' has dimension L T^-2 M which is incompatible "
-            "with quantity 'energy' (expected L^2 T^-2 M)"
+            "with 'energy' (L^2 T^-2 M)"
         )
     );
 
@@ -299,7 +299,7 @@ TEST_CASE("ModelOutput rejects mismatched quantity and unit") {
         ),
         Contains(
             "unit 'eV' has dimension L^2 T^-2 M which is incompatible "
-            "with quantity 'force' (expected L T^-2 M)"
+            "with 'force' (L T^-2 M)"
         )
     );
 
@@ -310,7 +310,7 @@ TEST_CASE("ModelOutput rejects mismatched quantity and unit") {
         ),
         Contains(
             "unit 'eV/A^3' has dimension L^-1 T^-2 M which is incompatible with "
-            "quantity 'length' (expected L)"
+            "'length' (L)"
         )
     );
 }

--- a/metatomic-torch/tests/units.cpp
+++ b/metatomic-torch/tests/units.cpp
@@ -279,66 +279,6 @@ TEST_CASE("Micro sign (U+00B5) handling") {
     CHECK_APPROX_ULP(c3, c4);
 }
 
-
-TEST_CASE("ModelOutput rejects mismatched quantity and unit") {
-    // energy quantity with a force unit
-    CHECK_THROWS_WITH(
-        torch::make_intrusive<metatomic_torch::ModelOutputHolder>(
-            "energy", "eV/A", "system", std::vector<std::string>{}, ""
-        ),
-        Contains(
-            "unit 'eV/A' has dimension L T^-2 M which is incompatible "
-            "with 'energy' (L^2 T^-2 M)"
-        )
-    );
-
-    // force quantity with an energy unit
-    CHECK_THROWS_WITH(
-        torch::make_intrusive<metatomic_torch::ModelOutputHolder>(
-            "force", "eV", "system", std::vector<std::string>{}, ""
-        ),
-        Contains(
-            "unit 'eV' has dimension L^2 T^-2 M which is incompatible "
-            "with 'force' (L T^-2 M)"
-        )
-    );
-
-    // length quantity with a pressure unit
-    CHECK_THROWS_WITH(
-        torch::make_intrusive<metatomic_torch::ModelOutputHolder>(
-            "length", "eV/A^3", "system", std::vector<std::string>{}, ""
-        ),
-        Contains(
-            "unit 'eV/A^3' has dimension L^-1 T^-2 M which is incompatible with "
-            "'length' (L)"
-        )
-    );
-}
-
-
-TEST_CASE("ModelOutput accepts matching quantity and unit") {
-    // These should not throw
-    torch::make_intrusive<metatomic_torch::ModelOutputHolder>(
-        "energy", "eV", "system", std::vector<std::string>{}, ""
-    );
-    torch::make_intrusive<metatomic_torch::ModelOutputHolder>(
-        "force", "eV/A", "system", std::vector<std::string>{}, ""
-    );
-    torch::make_intrusive<metatomic_torch::ModelOutputHolder>(
-        "pressure", "eV/A^3", "system", std::vector<std::string>{}, ""
-    );
-    torch::make_intrusive<metatomic_torch::ModelOutputHolder>(
-        "length", "Angstrom", "system", std::vector<std::string>{}, ""
-    );
-    torch::make_intrusive<metatomic_torch::ModelOutputHolder>(
-        "momentum", "u*A/fs", "system", std::vector<std::string>{}, ""
-    );
-    torch::make_intrusive<metatomic_torch::ModelOutputHolder>(
-        "velocity", "A/fs", "system", std::vector<std::string>{}, ""
-    );
-}
-
-
 // Call the deprecated 3-arg overload without triggering -Wdeprecated-declarations
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push

--- a/python/examples/1-export-atomistic-model.py
+++ b/python/examples/1-export-atomistic-model.py
@@ -176,14 +176,13 @@ metadata = ModelMetadata(
 #
 # A big part of exporting a model is the definition of the model capabilities, i.e. what
 # are the things that this model can do? First we'll need to define which outputs our
-# model can handle: there is only one, called ``"energy"``, which corresponds to the
-# physical quantity of energies (``quantity="energy"``). This energy is returned in
+# model can handle: there is only one, called ``"energy"`. This energy is returned in
 # electronvolt (``units="eV"``); and with the code above it can not be computed
 # per-atom, only for the full structure (``sample_kind="system"``).
 
 
 outputs = {
-    "energy": ModelOutput(quantity="energy", unit="eV", sample_kind="system"),
+    "energy": ModelOutput(unit="eV", sample_kind="system"),
 }
 
 # %%

--- a/python/examples/2-running-ase-md.py
+++ b/python/examples/2-running-ase-md.py
@@ -184,9 +184,7 @@ model = HarmonicModel(
 )
 
 capabilities = ModelCapabilities(
-    outputs={
-        "energy": ModelOutput(quantity="energy", unit="eV", sample_kind="system"),
-    },
+    outputs={"energy": ModelOutput(unit="eV", sample_kind="system")},
     atomic_types=[6],
     interaction_range=0.0,
     length_unit="Angstrom",

--- a/python/examples/3-atomistic-model-with-nl.py
+++ b/python/examples/3-atomistic-model-with-nl.py
@@ -390,9 +390,7 @@ model = LennardJonesModel(
 )
 
 capabilities = ModelCapabilities(
-    outputs={
-        "energy": ModelOutput(quantity="energy", unit="kJ/mol", sample_kind="system"),
-    },
+    outputs={"energy": ModelOutput(unit="kJ/mol", sample_kind="system")},
     atomic_types=[18],
     interaction_range=5.0,
     length_unit="Angstrom",

--- a/python/examples/4-profiling.py
+++ b/python/examples/4-profiling.py
@@ -113,7 +113,7 @@ model = HarmonicModel(
 
 capabilities = ModelCapabilities(
     outputs={
-        "energy": ModelOutput(quantity="energy", unit="eV", sample_kind="system"),
+        "energy": ModelOutput(unit="eV", sample_kind="system"),
     },
     atomic_types=[6],
     interaction_range=0.0,

--- a/python/examples/5-torchsim-getting-started.py
+++ b/python/examples/5-torchsim-getting-started.py
@@ -84,7 +84,7 @@ capabilities = mta.ModelCapabilities(
     length_unit="Angstrom",
     atomic_types=[14],  # Silicon
     interaction_range=0.0,
-    outputs={"energy": mta.ModelOutput(quantity="energy", unit="eV")},
+    outputs={"energy": mta.ModelOutput(unit="eV")},
     supported_devices=["cpu"],
     dtype="float64",
 )

--- a/python/examples/6-torchsim-batched.py
+++ b/python/examples/6-torchsim-batched.py
@@ -65,7 +65,7 @@ capabilities = mta.ModelCapabilities(
     length_unit="Angstrom",
     atomic_types=[13, 29],  # Al, Cu
     interaction_range=0.0,
-    outputs={"energy": mta.ModelOutput(quantity="energy", unit="eV")},
+    outputs={"energy": mta.ModelOutput(unit="eV")},
     supported_devices=["cpu"],
     dtype="float64",
 )

--- a/python/metatomic_ase/src/metatomic_ase/_calculator.py
+++ b/python/metatomic_ase/src/metatomic_ase/_calculator.py
@@ -495,7 +495,6 @@ class MetatomicCalculator(ase.calculators.calculator.Calculator):
             outputs.update(self._additional_output_requests)
             if calculate_energy and self._calculate_uncertainty:
                 outputs[self._energy_uq_key] = ModelOutput(
-                    quantity="energy",
                     unit="eV",
                     sample_kind="atom",
                     explicit_gradients=[],
@@ -843,7 +842,6 @@ class MetatomicCalculator(ase.calculators.calculator.Calculator):
         # Only add energy output if the model supports it
         if self._energy_key is not None:
             output = ModelOutput(
-                quantity="energy",
                 unit="ev",
                 explicit_gradients=[],
             )
@@ -856,14 +854,12 @@ class MetatomicCalculator(ase.calculators.calculator.Calculator):
             metatensor_outputs[self._energy_key] = output
         if calculate_forces and self.parameters["non_conservative"]:
             metatensor_outputs[self._nc_forces_key] = ModelOutput(
-                quantity="force",
                 unit="eV/Angstrom",
                 sample_kind="atom",
             )
 
         if calculate_stress and self.parameters["non_conservative"]:
             metatensor_outputs[self._nc_stress_key] = ModelOutput(
-                quantity="pressure",
                 unit="eV/Angstrom^3",
                 sample_kind="system",
             )

--- a/python/metatomic_ase/tests/calculator.py
+++ b/python/metatomic_ase/tests/calculator.py
@@ -795,12 +795,10 @@ class AdditionalInputModel(torch.nn.Module):
 
 def test_additional_input(atoms):
     inputs = {
-        "masses": ModelOutput(quantity="mass", unit="u", sample_kind="atom"),
-        "velocities": ModelOutput(quantity="velocity", unit="A/fs", sample_kind="atom"),
-        "charges": ModelOutput(quantity="charge", unit="e", sample_kind="atom"),
-        "ase::initial_charges": ModelOutput(
-            quantity="charge", unit="e", sample_kind="atom"
-        ),
+        "masses": ModelOutput(unit="u", sample_kind="atom"),
+        "velocities": ModelOutput(unit="A/fs", sample_kind="atom"),
+        "charges": ModelOutput(unit="e", sample_kind="atom"),
+        "ase::initial_charges": ModelOutput(unit="e", sample_kind="atom"),
     }
     outputs = {("extra::" + n): inputs[n] for n in inputs}
     capabilities = ModelCapabilities(
@@ -823,7 +821,8 @@ def test_additional_input(atoms):
         assert head == "extra"
         assert name in inputs
 
-        assert tensor.get_info("quantity") == inputs[name].quantity
+        # quantity info is no longer set (deprecated); just check unit is set
+        assert tensor.get_info("unit") == inputs[name].unit
         values = tensor[0].values.numpy()
 
         expected = ARRAY_QUANTITIES[name]["getter"](atoms).reshape(values.shape)

--- a/python/metatomic_ase/tests/calculator.py
+++ b/python/metatomic_ase/tests/calculator.py
@@ -551,7 +551,7 @@ class MultipleOutputModel(torch.nn.Module):
 def test_additional_outputs(atoms):
     capabilities = ModelCapabilities(
         outputs={
-            "energy": ModelOutput(sample_kind="system"),
+            "energy": ModelOutput(sample_kind="system", unit="eV"),
             "test::test": ModelOutput(sample_kind="system"),
             "another::one": ModelOutput(sample_kind="system"),
         },

--- a/python/metatomic_ase/tests/heat_flux.py
+++ b/python/metatomic_ase/tests/heat_flux.py
@@ -49,7 +49,6 @@ def test_wrap(model, atoms):
         device="cpu",
         additional_outputs={
             "heat_flux": ModelOutput(
-                quantity="heat_flux",
                 unit="eV*A/fs",
                 explicit_gradients=[],
                 sample_kind="system",

--- a/python/metatomic_ase/tests/symmetrized.py
+++ b/python/metatomic_ase/tests/symmetrized.py
@@ -296,9 +296,11 @@ def mock_calculator(
         ModelMetadata("mock_aniso", "Mock anisotropic model for testing"),
         ModelCapabilities(
             {
-                "energy": ModelOutput(sample_kind="system"),
-                "non_conservative_forces": ModelOutput(sample_kind="atom"),
-                "non_conservative_stress": ModelOutput(sample_kind="system"),
+                "energy": ModelOutput(sample_kind="system", unit="eV"),
+                "non_conservative_forces": ModelOutput(sample_kind="atom", unit="eV/A"),
+                "non_conservative_stress": ModelOutput(
+                    sample_kind="system", unit="eV/A^3"
+                ),
             },
             list(range(1, 102)),
             100,

--- a/python/metatomic_torch/metatomic/torch/__init__.py
+++ b/python/metatomic_torch/metatomic/torch/__init__.py
@@ -22,6 +22,7 @@ if os.environ.get("METATOMIC_IMPORT_FOR_SPHINX", "0") != "0" or TYPE_CHECKING:
         read_model_metadata,
         register_autograd_neighbors,
         unit_conversion_factor,
+        unit_dimension_for_quantity,
     )
 
     _check_outputs = None
@@ -44,8 +45,8 @@ else:
 
     register_autograd_neighbors = torch.ops.metatomic.register_autograd_neighbors
 
-    # TorchScript-compatible unit conversion factor
     unit_conversion_factor = torch.ops.metatomic.unit_conversion_factor
+    unit_dimension_for_quantity = torch.ops.metatomic.unit_dimension_for_quantity
 
     pick_device = torch.ops.metatomic.pick_device
     pick_output = torch.ops.metatomic.pick_output

--- a/python/metatomic_torch/metatomic/torch/documentation.py
+++ b/python/metatomic_torch/metatomic/torch/documentation.py
@@ -633,6 +633,31 @@ def unit_conversion_factor(from_unit: str, to_unit: str) -> float:
     raise THIS_CODE_SHOULD_NOT_RUN
 
 
+def unit_dimension_for_quantity(name: str) -> str:
+    """
+    Get the physical dimension of the standard quantity (input or outptu) with the given
+    ``name``.
+
+    This function will return one of the following strings:
+
+    - an empty string for non-standard outputs
+    - "none" for outputs that should be dimensionless (features, …).
+    - "length" for length-like quantities (positions, …);
+    - "momentum" for momentum-like quantities (momenta, …);
+    - "velocity" for velocity-like quantities (velocities, …);
+    - "mass" for mass-like quantities (masses, …);
+    - "energy" for energy-like quantities (energy, energy_ensemble, …);
+    - "force" for force-like quantities (non_conservative_forces, …);
+    - "pressure" for pressure-like quantities (non_conservative_stress, …);
+    - "charge" for charge-like quantities (charges, …);
+    - "heat_flux" for heat flux-like quantities (heat_flux, …);
+
+    :param name: name of the output/input
+    :return: physical dimension of the output
+    """
+    raise THIS_CODE_SHOULD_NOT_RUN
+
+
 def pick_device(model_devices: List[str], desired_device: Optional[str]) -> str:
     """
     Select the best device according to the list of ``model_devices`` from a model, the

--- a/python/metatomic_torch/metatomic/torch/documentation.py
+++ b/python/metatomic_torch/metatomic/torch/documentation.py
@@ -295,6 +295,11 @@ class ModelOutput:
         Quantity of the output (e.g. energy, dipole, …).  If this is an empty string, no
         unit conversion will be performed.
 
+        .. deprecated::
+            The ``quantity`` field is deprecated and will be removed.
+            Unit conversion determines dimensions from the unit expression.
+            Set ``quantity`` to an empty string to suppress deprecation warnings.
+
         The list of possible quantities is available :ref:`here
         <known-base-units>`.
         """

--- a/python/metatomic_torch/metatomic/torch/heat_flux.py
+++ b/python/metatomic_torch/metatomic/torch/heat_flux.py
@@ -229,12 +229,10 @@ class HeatFlux(torch.nn.Module):
         self._requested_neighbor_lists = model.requested_neighbor_lists()
         self._requested_inputs = {
             "masses": ModelOutput(
-                quantity="mass",
                 unit="u",
                 sample_kind="atom",
             ),
             "velocities": ModelOutput(
-                quantity="velocity",
                 unit="A/fs",
                 sample_kind="atom",
             ),
@@ -372,7 +370,6 @@ class HeatFlux(torch.nn.Module):
                 heat_flux_unit = energy_unit + "*" + velocity_unit
 
                 heat_flux_outputs["heat_flux" + variant] = ModelOutput(
-                    quantity="heat_flux",
                     unit=heat_flux_unit,
                     explicit_gradients=[],
                     sample_kind="system",

--- a/python/metatomic_torch/metatomic/torch/model.py
+++ b/python/metatomic_torch/metatomic/torch/model.py
@@ -575,21 +575,8 @@ class AtomisticModel(torch.nn.Module):
         if self._capabilities.length_unit == "":
             warnings.warn(
                 "No length unit was provided for the model.",
-                stacklevel=1,
+                stacklevel=2,
             )
-
-        for name, output in self._capabilities.outputs.items():
-            # TODO: coordinate a list of standard outputs needing
-            # unit checks, should also be consistent with `outputs.py`
-            if name in ["energy", "energy_ensemble", "energy_uncertainty"]:
-                if output.unit == "":
-                    warnings.warn(
-                        f"No units were provided for output {name}.",
-                        stacklevel=1,
-                    )
-
-        # TODO: can we freeze these?
-        # module = torch.jit.freeze(module)
 
         # Metadata about where and when the model was exported
         export_metadata = {

--- a/python/metatomic_torch/metatomic/torch/model.py
+++ b/python/metatomic_torch/metatomic/torch/model.py
@@ -265,7 +265,6 @@ class AtomisticModel(torch.nn.Module):
     >>> capabilities = ModelCapabilities(
     ...     outputs={
     ...         "energy": ModelOutput(
-    ...             quantity="energy",
     ...             unit="eV",
     ...             sample_kind="system",
     ...             explicit_gradients=[],
@@ -507,15 +506,8 @@ class AtomisticModel(torch.nn.Module):
             for name, output in outputs.items():
                 declared = self._capabilities.outputs[name]
                 requested = options.outputs.get(name, ModelOutput())
-                if declared.quantity == "" or requested.quantity == "":
+                if declared.unit == "" or requested.unit == "":
                     continue
-
-                if declared.quantity != requested.quantity:
-                    raise ValueError(
-                        f"model produces values as '{declared.quantity}' for the "
-                        f"'{name}' output, but the engine requested "
-                        f"'{requested.quantity}'"
-                    )
 
                 conversion = unit_conversion_factor(
                     declared.unit,
@@ -999,7 +991,9 @@ def _convert_systems_units(
                 tensor = system.get_data(name)
                 unit = tensor.get_info("unit")
 
-                if requested.quantity != "" and unit is not None:
+                # Convert units if both the tensor and requested output have units.
+                # The quantity field is deprecated; unit conversion is dimension-aware.
+                if unit is not None and requested.unit != "":
                     conversion = unit_conversion_factor(
                         unit,
                         requested.unit,
@@ -1037,7 +1031,6 @@ def _convert_systems_units(
                     blocks=new_blocks,
                 )
                 new_tensor.set_info("unit", requested.unit)
-                new_tensor.set_info("quantity", requested.quantity)
                 new_system.add_data(name, new_tensor)
 
         new_systems.append(new_system)

--- a/python/metatomic_torch/tests/examples.py
+++ b/python/metatomic_torch/tests/examples.py
@@ -47,7 +47,7 @@ def test_export_atomistic_model(tmp_path):
     )
 
     outputs = {
-        "energy": ModelOutput(quantity="energy", unit="eV", sample_kind="system"),
+        "energy": ModelOutput(unit="eV", sample_kind="system"),
     }
 
     # run bare model

--- a/python/metatomic_torch/tests/heat_flux.py
+++ b/python/metatomic_torch/tests/heat_flux.py
@@ -105,8 +105,7 @@ def system(request):
         keys=Labels(["_"], torch.tensor([[0]])),
         blocks=[velocities_block],
     )
-    masses_tensor.set_info("quantity", "mass")
-    velocities_tensor.set_info("quantity", "velocity")
+
     masses_tensor.set_info("unit", "u")
     velocities_tensor.set_info("unit", "(eV/u)^(1/2)")
     system.add_data("masses", masses_tensor)
@@ -137,9 +136,7 @@ def test_heat_flux(model, script, system, variant, expected):
     evaluation_options = ModelEvaluationOptions(
         length_unit="Angstrom",
         outputs={
-            "heat_flux" + variant: ModelOutput(
-                quantity="heat_flux", unit="eV*A/fs", sample_kind="system"
-            )
+            "heat_flux" + variant: ModelOutput(unit="eV*A/fs", sample_kind="system")
         },
     )
 
@@ -161,12 +158,8 @@ def test_multiple_outputs(model, system):
     evaluation_options = ModelEvaluationOptions(
         length_unit="Angstrom",
         outputs={
-            "heat_flux": ModelOutput(
-                quantity="heat_flux", unit="eV*A/fs", sample_kind="system"
-            ),
-            "heat_flux/doubled": ModelOutput(
-                quantity="heat_flux", unit="eV*A/fs", sample_kind="system"
-            ),
+            "heat_flux": ModelOutput(unit="eV*A/fs", sample_kind="system"),
+            "heat_flux/doubled": ModelOutput(unit="eV*A/fs", sample_kind="system"),
         },
     )
 
@@ -189,11 +182,7 @@ def test_input_energy_in_kcal_per_mol(model_in_kcal_per_mol, system):
     heat_flux_model = HeatFlux.wrap(model_in_kcal_per_mol)
     evaluation_options = ModelEvaluationOptions(
         length_unit="Angstrom",
-        outputs={
-            "heat_flux": ModelOutput(
-                quantity="heat_flux", unit="eV*A/fs", sample_kind="system"
-            )
-        },
+        outputs={"heat_flux": ModelOutput(unit="eV*A/fs", sample_kind="system")},
     )
     results = heat_flux_model([system], evaluation_options, check_consistency=True)
 
@@ -208,11 +197,7 @@ def test_output_unit_conversion(model, system):
     heat_flux_model = HeatFlux.wrap(model)
     evaluation_options = ModelEvaluationOptions(
         length_unit="Angstrom",
-        outputs={
-            "heat_flux": ModelOutput(
-                quantity="heat_flux", unit="kcal/mol*A/ps", sample_kind="system"
-            )
-        },
+        outputs={"heat_flux": ModelOutput(unit="kcal/mol*A/ps", sample_kind="system")},
     )
 
     results = heat_flux_model([system], evaluation_options, check_consistency=True)

--- a/python/metatomic_torch/tests/model.py
+++ b/python/metatomic_torch/tests/model.py
@@ -87,12 +87,7 @@ def model():
         atomic_types=[1, 2, 3],
         interaction_range=4.3,
         outputs={
-            "tests::dummy::long_name": ModelOutput(
-                quantity="",
-                unit="",
-                sample_kind="system",
-                explicit_gradients=[],
-            ),
+            "tests::dummy::long_name": ModelOutput(sample_kind="system"),
         },
         supported_devices=["cpu"],
         dtype="float64",
@@ -546,11 +541,7 @@ def test_predictions(model, tmp_path, system, n_systems, torch_scripted_model):
         )
     systems = [system] * n_systems
 
-    outputs = {
-        "tests::dummy::long_name": ModelOutput(
-            quantity="", unit="", sample_kind="system"
-        )
-    }
+    outputs = {"tests::dummy::long_name": ModelOutput(sample_kind="system")}
     evaluation_options = ModelEvaluationOptions(length_unit="angstrom", outputs=outputs)
 
     result = model_loaded(systems, evaluation_options, check_consistency=True)
@@ -563,13 +554,7 @@ def test_consistent_requested_outputs(system):
     model = CustomOutputModel([])
     model.eval()
 
-    outputs = {
-        "energy": ModelOutput(
-            quantity="",
-            unit="eV",
-            sample_kind="system",
-        ),
-    }
+    outputs = {"energy": ModelOutput(unit="eV", sample_kind="system")}
 
     capabilities = ModelCapabilities(
         length_unit="angstrom",
@@ -592,13 +577,7 @@ def test_inconsistent_dtype(system):
     model = CustomOutputModel(["energy"])
     model.eval()
 
-    outputs = {
-        "energy": ModelOutput(
-            quantity="",
-            unit="eV",
-            sample_kind="system",
-        ),
-    }
+    outputs = {"energy": ModelOutput(unit="eV", sample_kind="system")}
 
     capabilities = ModelCapabilities(
         length_unit="angstrom",
@@ -670,7 +649,6 @@ def test_not_requested_output(system):
 def test_systems_unit_conversion(system):
     requested_inputs = {
         "masses": ModelOutput(
-            quantity="mass",
             unit="kg",
             sample_kind="atom",
         ),

--- a/python/metatomic_torch/tests/model.py
+++ b/python/metatomic_torch/tests/model.py
@@ -112,31 +112,6 @@ def system():
     )
 
 
-@pytest.fixture
-def model_energy_nounit():
-    model_energy_nounit = MinimalModel()
-    model_energy_nounit.train(False)
-
-    capabilities = ModelCapabilities(
-        length_unit="angstrom",
-        atomic_types=[1, 2, 3],
-        interaction_range=4.3,
-        outputs={
-            "energy": ModelOutput(
-                quantity="",
-                unit="",
-                sample_kind="system",
-                explicit_gradients=[],
-            ),
-        },
-        supported_devices=["cpu"],
-        dtype="float64",
-    )
-
-    metadata = ModelMetadata()
-    return AtomisticModel(model_energy_nounit, metadata, capabilities)
-
-
 def test_save(model, tmp_path):
     os.chdir(tmp_path)
     model.save("export.pt")
@@ -192,12 +167,6 @@ def test_save_warning_length_unit(model):
     match = r"No length unit was provided for the model."
     with pytest.warns(UserWarning, match=match):
         model.save("export.pt")
-
-
-def test_save_warning_quantity(model_energy_nounit):
-    match = r"No units were provided for output energy."
-    with pytest.warns(UserWarning, match=match):
-        model_energy_nounit.save("export.pt")
 
 
 def test_export(model, tmp_path):
@@ -597,7 +566,7 @@ def test_consistent_requested_outputs(system):
     outputs = {
         "energy": ModelOutput(
             quantity="",
-            unit="",
+            unit="eV",
             sample_kind="system",
         ),
     }
@@ -626,7 +595,7 @@ def test_inconsistent_dtype(system):
     outputs = {
         "energy": ModelOutput(
             quantity="",
-            unit="",
+            unit="eV",
             sample_kind="system",
         ),
     }
@@ -656,10 +625,12 @@ def test_not_requested_output(system):
 
     outputs = {
         "energy/scaled": ModelOutput(
+            unit="eV",
             sample_kind="system",
             description="scaled energy",
         ),
         "energy": ModelOutput(
+            unit="eV",
             sample_kind="system",
             description="energy without scaling",
         ),

--- a/python/metatomic_torch/tests/outputs.py
+++ b/python/metatomic_torch/tests/outputs.py
@@ -445,14 +445,10 @@ class CombinedModel(torch.nn.Module):
 
 def test_inputs_different_units():
     model_a = AdditionalInputModel(
-        {
-            "masses": ModelOutput(quantity="mass", unit="u", sample_kind="atom"),
-        }
+        {"masses": ModelOutput(unit="u", sample_kind="atom")}
     )
     model_b = AdditionalInputModel(
-        {
-            "masses": ModelOutput(quantity="mass", unit="kg", sample_kind="atom"),
-        }
+        {"masses": ModelOutput(unit="kg", sample_kind="atom")}
     )
 
     outputs = {

--- a/python/metatomic_torch/tests/outputs.py
+++ b/python/metatomic_torch/tests/outputs.py
@@ -106,19 +106,15 @@ def system():
     )
 
 
-@pytest.fixture
-def get_capabilities() -> callable:
-    def _create_capabilities(output_name: str) -> ModelCapabilities:
-        return ModelCapabilities(
-            length_unit="angstrom",
-            atomic_types=[1, 2, 3],
-            interaction_range=4.3,
-            outputs={output_name: ModelOutput(sample_kind="system")},
-            supported_devices=["cpu"],
-            dtype="float64",
-        )
-
-    return _create_capabilities
+def get_capabilities(output_name: str, unit: str):
+    return ModelCapabilities(
+        length_unit="angstrom",
+        atomic_types=[1, 2, 3],
+        interaction_range=4.3,
+        outputs={output_name: ModelOutput(sample_kind="system", unit=unit)},
+        supported_devices=["cpu"],
+        dtype="float64",
+    )
 
 
 class BaseAtomisticModel(torch.nn.Module):
@@ -253,9 +249,9 @@ class PositionsMomentaModel(torch.nn.Module):
         }
 
 
-def test_energy_ensemble_model(system, get_capabilities):
+def test_energy_ensemble_model(system):
     model = EnergyEnsembleModel()
-    capabilities = get_capabilities("energy_ensemble")
+    capabilities = get_capabilities("energy_ensemble", unit="eV")
     atomistic = AtomisticModel(model.eval(), ModelMetadata(), capabilities)
 
     options = ModelEvaluationOptions(
@@ -273,9 +269,9 @@ def test_energy_ensemble_model(system, get_capabilities):
     assert ensemble.block().properties.names == ["energy"]
 
 
-def test_energy_uncertainty_model(system, get_capabilities):
+def test_energy_uncertainty_model(system):
     model = EnergyUncertaintyModel()
-    capabilities = get_capabilities("energy_uncertainty")
+    capabilities = get_capabilities("energy_uncertainty", unit="eV")
     atomistic = AtomisticModel(model.eval(), ModelMetadata(), capabilities)
 
     options = ModelEvaluationOptions(
@@ -292,9 +288,9 @@ def test_energy_uncertainty_model(system, get_capabilities):
     assert uncertainty.block().properties.names == ["energy"]
 
 
-def test_features_model(system, get_capabilities):
+def test_features_model(system):
     model = FeaturesModel()
-    capabilities = get_capabilities("features")
+    capabilities = get_capabilities("features", unit="")
     atomistic = AtomisticModel(model.eval(), ModelMetadata(), capabilities)
 
     options = ModelEvaluationOptions(
@@ -316,8 +312,8 @@ def test_features_model(system, get_capabilities):
 def test_positions_momenta_model(system):
     model = PositionsMomentaModel()
     outputs = {
-        "positions": ModelOutput(sample_kind="atom"),
-        "momenta": ModelOutput(sample_kind="atom"),
+        "positions": ModelOutput(sample_kind="atom", unit="A"),
+        "momenta": ModelOutput(sample_kind="atom", unit="u*A/fs"),
     }
     capabilities = ModelCapabilities(
         length_unit="angstrom",

--- a/python/metatomic_torch/tests/units.py
+++ b/python/metatomic_torch/tests/units.py
@@ -1,5 +1,4 @@
 import math
-import re
 
 import ase.units
 import pytest
@@ -12,15 +11,9 @@ from metatomic.torch import (
 )
 
 
-# 3-arg C++ op (deprecated, but still registered for backward compat)
-_unit_conversion_factor_3arg = torch.ops.metatomic.unit_conversion_factor
-
-
 def test_conversion_length_3arg(capfd):
     length_angstrom = 1.0
-    length_nm = (
-        _unit_conversion_factor_3arg("length", "angstrom", "nm") * length_angstrom
-    )
+    length_nm = unit_conversion_factor("length", "angstrom", "nm") * length_angstrom
     assert length_nm == pytest.approx(0.1)
 
     captured = capfd.readouterr()
@@ -35,7 +28,7 @@ def test_conversion_length_3arg(capfd):
 
 def test_conversion_energy_3arg():
     energy_ev = 1.0
-    energy_mev = _unit_conversion_factor_3arg("energy", "ev", "mev") * energy_ev
+    energy_mev = unit_conversion_factor("energy", "ev", "mev") * energy_ev
     assert energy_mev == pytest.approx(1000.0)
 
 
@@ -184,41 +177,42 @@ def test_overflow_division():
 
 def test_valid_units():
     # just checking that all of these are valid
-    ModelOutput(quantity="length", unit="A")
-    ModelOutput(quantity="length", unit="Angstrom")
-    ModelOutput(quantity="length", unit="Bohr")
-    ModelOutput(quantity="length", unit="meter")
-    ModelOutput(quantity="length", unit=" centimeter")
-    ModelOutput(quantity="length", unit="cm")
-    ModelOutput(quantity="length", unit="millimeter")
-    ModelOutput(quantity="length", unit="mm")
-    ModelOutput(quantity="length", unit=" micrometer")
-    ModelOutput(quantity="length", unit="um")
-    ModelOutput(quantity="length", unit="µm")
-    ModelOutput(quantity="length", unit="nanometer")
-    ModelOutput(quantity="length", unit="nm ")
+    # quantity parameter is deprecated, only testing unit parsing
+    ModelOutput(unit="A")
+    ModelOutput(unit="Angstrom")
+    ModelOutput(unit="Bohr")
+    ModelOutput(unit="meter")
+    ModelOutput(unit=" centimeter")
+    ModelOutput(unit="cm")
+    ModelOutput(unit="millimeter")
+    ModelOutput(unit="mm")
+    ModelOutput(unit=" micrometer")
+    ModelOutput(unit="um")
+    ModelOutput(unit="µm")
+    ModelOutput(unit="nanometer")
+    ModelOutput(unit="nm ")
 
-    ModelOutput(quantity="energy", unit="eV")
-    ModelOutput(quantity="energy", unit="meV")
-    ModelOutput(quantity="energy", unit="Hartree")
-    ModelOutput(quantity="energy", unit="kcal /  mol ")
-    ModelOutput(quantity="energy", unit="kJ/mol")
-    ModelOutput(quantity="energy", unit="Joule")
-    ModelOutput(quantity="energy", unit="J")
-    ModelOutput(quantity="energy", unit="Rydberg")
-    ModelOutput(quantity="energy", unit="Ry")
+    ModelOutput(unit="eV")
+    ModelOutput(unit="meV")
+    ModelOutput(unit="Hartree")
+    ModelOutput(unit="kcal /  mol ")
+    ModelOutput(unit="kJ/mol")
+    ModelOutput(unit="Joule")
+    ModelOutput(unit="J")
+    ModelOutput(unit="Rydberg")
+    ModelOutput(unit="Ry")
 
-    ModelOutput(quantity="force", unit="eV/Angstrom")
-    ModelOutput(quantity="force", unit="eV/A")
+    ModelOutput(unit="eV/Angstrom")
+    ModelOutput(unit="eV/A")
 
-    ModelOutput(quantity="pressure", unit="eV/Angstrom^3")
-    ModelOutput(quantity="pressure", unit="eV/A^3")
+    ModelOutput(unit="eV/Angstrom^3")
+    ModelOutput(unit="eV/A^3")
 
-    ModelOutput(quantity="momentum", unit="u * A/ fs")
-    ModelOutput(quantity="momentum", unit=" (eV*u )^(1/ 2 )")
+    ModelOutput(unit="u * A/ fs")
+    ModelOutput(unit=" (eV*u )^(1/ 2 )")
 
-    ModelOutput(quantity="velocity", unit="A/fs")
-    ModelOutput(quantity="velocity", unit="A/s")
+    ModelOutput(unit="A/fs")
+    ModelOutput(unit="A/s")
 
 
 def test_fractional_power_accumulated_error():
@@ -273,79 +267,45 @@ def test_micro_sign_microsecond():
     )
 
 
-def test_quantity_unit_mismatch():
-    # energy quantity with force unit
-    message = (
-        "unit 'eV/A' has dimension L T^-2 M which is incompatible with "
-        "'energy' (L^2 T^-2 M)"
-    )
-    with pytest.raises(ValueError, match=re.escape(message)):
-        ModelOutput(quantity="energy", unit="eV/A")
-
-    # force quantity with energy unit
-
-    message = (
-        "unit 'eV' has dimension L^2 T^-2 M which is incompatible with "
-        "'force' (L T^-2 M)"
-    )
-    with pytest.raises(ValueError, match=re.escape(message)):
-        ModelOutput(quantity="force", unit="eV")
-
-    # length quantity with pressure unit
-    message = (
-        "unit 'eV/A^3' has dimension L^-1 T^-2 M which is incompatible with "
-        "'length' (L)"
-    )
-    with pytest.raises(ValueError, match=re.escape(message)):
-        ModelOutput(quantity="length", unit="eV/A^3")
-
-
 def test_3arg_deprecation_warning():
     # The 3-arg C++ op emits a torch warning (not a Python DeprecationWarning)
     # on first call. We just verify the call succeeds and returns the right value.
-    result = _unit_conversion_factor_3arg("energy", "eV", "meV")
+    result = unit_conversion_factor("energy", "eV", "meV")
     assert result == pytest.approx(1000.0)
 
 
 def test_3arg_kwargs_backward_compat():
     # Verify that the old kwargs-based calling convention still works
-    result = _unit_conversion_factor_3arg(
-        quantity="energy", from_unit="eV", to_unit="meV"
-    )
+    result = unit_conversion_factor(quantity="energy", from_unit="eV", to_unit="meV")
     assert result == pytest.approx(1000.0)
 
 
 def test_3arg_all_calling_conventions():
     """Test all supported calling conventions for the deprecated 3-arg form."""
     # 3 positional arguments
-    assert _unit_conversion_factor_3arg("energy", "eV", "meV") == pytest.approx(1000.0)
-    assert _unit_conversion_factor_3arg("length", "angstrom", "nm") == pytest.approx(
-        0.1
-    )
+    assert unit_conversion_factor("energy", "eV", "meV") == 1000.0
+    assert unit_conversion_factor("length", "angstrom", "nm") == 1e-10 / 1e-9
 
     # 2 positional + to_unit keyword
-    assert _unit_conversion_factor_3arg("energy", "eV", to_unit="meV") == pytest.approx(
-        1000.0
-    )
-    assert _unit_conversion_factor_3arg(
-        "length", "angstrom", to_unit="nm"
-    ) == pytest.approx(0.1)
+    assert unit_conversion_factor("energy", "eV", to_unit="meV") == 1000.0
+    assert unit_conversion_factor("length", "angstrom", to_unit="nm") == 1e-10 / 1e-9
 
     # 1 positional + from_unit + to_unit keywords
-    assert _unit_conversion_factor_3arg(
-        "energy", from_unit="eV", to_unit="meV"
-    ) == pytest.approx(1000.0)
-    assert _unit_conversion_factor_3arg(
-        "length", from_unit="angstrom", to_unit="nm"
-    ) == pytest.approx(0.1)
+    assert unit_conversion_factor("energy", from_unit="eV", to_unit="meV") == 1000.0
+    assert (
+        unit_conversion_factor("length", from_unit="angstrom", to_unit="nm")
+        == 1e-10 / 1e-9
+    )
 
     # All keywords
-    assert _unit_conversion_factor_3arg(
-        quantity="energy", from_unit="eV", to_unit="meV"
-    ) == pytest.approx(1000.0)
-    assert _unit_conversion_factor_3arg(
-        quantity="length", from_unit="angstrom", to_unit="nm"
-    ) == pytest.approx(0.1)
+    assert (
+        unit_conversion_factor(quantity="energy", from_unit="eV", to_unit="meV")
+        == 1000.0
+    )
+    assert (
+        unit_conversion_factor(quantity="length", from_unit="angstrom", to_unit="nm")
+        == 1e-10 / 1e-9
+    )
 
 
 def test_2arg_all_calling_conventions():
@@ -372,7 +332,7 @@ def test_3arg_error_cases():
     # 2 positional args without to_unit keyword is treated as 2-arg form
     # This will fail with "unknown unit" since "energy" is not a valid unit expression
     with pytest.raises((ValueError, RuntimeError), match="unknown unit"):
-        _unit_conversion_factor_3arg(
+        unit_conversion_factor(
             "energy", "eV"
         )  # treated as 2-arg: from="energy", to="eV"
 
@@ -380,16 +340,14 @@ def test_3arg_error_cases():
     with pytest.raises(
         RuntimeError, match="unit_conversion_factor requires 2 arguments"
     ):
-        _unit_conversion_factor_3arg(
-            "energy"
-        )  # treated as 2-arg: from="energy", to=None
+        unit_conversion_factor("energy")  # treated as 2-arg: from="energy", to=None
 
     # quantity keyword alone without from_unit/to_unit is treated as 2-arg form
     # _0=None, from_unit="energy", to_unit=None → fails 2-arg validation
     with pytest.raises(
         RuntimeError, match="unit_conversion_factor requires 2 arguments"
     ):
-        _unit_conversion_factor_3arg(quantity="energy")
+        unit_conversion_factor(quantity="energy")
 
 
 def test_2arg_error_cases():

--- a/python/metatomic_torch/tests/units.py
+++ b/python/metatomic_torch/tests/units.py
@@ -1,17 +1,19 @@
 import math
+import re
 
 import ase.units
 import pytest
 import torch
 
-from metatomic.torch import ModelOutput, unit_conversion_factor
+from metatomic.torch import (
+    ModelOutput,
+    unit_conversion_factor,
+    unit_dimension_for_quantity,
+)
 
 
 # 3-arg C++ op (deprecated, but still registered for backward compat)
 _unit_conversion_factor_3arg = torch.ops.metatomic.unit_conversion_factor
-
-
-# ---- Backward compat: 3-arg C++ op still works (with deprecation warning) ----
 
 
 def test_conversion_length_3arg(capfd):
@@ -37,9 +39,6 @@ def test_conversion_energy_3arg():
     assert energy_mev == pytest.approx(1000.0)
 
 
-# ---- 2-arg API ----
-
-
 def test_conversion_length():
     assert unit_conversion_factor("angstrom", "nm") == pytest.approx(0.1)
     assert unit_conversion_factor("angstrom", "Bohr") == pytest.approx(
@@ -53,9 +52,6 @@ def test_conversion_length():
 def test_conversion_energy():
     assert unit_conversion_factor("eV", "meV") == pytest.approx(1000.0)
     assert unit_conversion_factor("eV", "Hartree") == pytest.approx(0.0367493, rel=1e-3)
-
-
-# ---- 2-arg API with keyword arguments ----
 
 
 def test_conversion_length_kwargs():
@@ -79,9 +75,6 @@ def test_conversion_energy_kwargs():
     assert unit_conversion_factor(from_unit="eV", to_unit="Hartree") == pytest.approx(
         0.0367493, rel=1e-3
     )
-
-
-# ---- Mixed positional and keyword arguments ----
 
 
 def test_conversion_mixed_args():
@@ -118,9 +111,6 @@ def test_units_vs_ase():
     )
 
 
-# ---- Compound expressions ----
-
-
 def test_compound_expressions():
     # Force: eV/Angstrom -> Hartree/Bohr
     conv = unit_conversion_factor("eV/Angstrom", "Hartree/Bohr")
@@ -133,9 +123,6 @@ def test_compound_expressions():
     # Pressure identity
     conv = unit_conversion_factor("eV/Angstrom^3", "eV/A^3")
     assert conv == pytest.approx(1.0)
-
-
-# ---- Fractional powers ----
 
 
 def test_fractional_powers():
@@ -154,15 +141,9 @@ def test_fractional_powers():
     assert conv == pytest.approx(expected, rel=1e-3)
 
 
-# ---- Dimension mismatch ----
-
-
 def test_dimension_mismatch():
     with pytest.raises((ValueError, RuntimeError), match="dimension mismatch"):
         unit_conversion_factor("eV", "Angstrom")
-
-
-# ---- Unknown unit ----
 
 
 def test_unknown_unit():
@@ -170,16 +151,10 @@ def test_unknown_unit():
         unit_conversion_factor("foobar", "eV")
 
 
-# ---- Empty string ----
-
-
 def test_empty_string():
     assert unit_conversion_factor("", "eV") == 1.0
     assert unit_conversion_factor("eV", "") == 1.0
     assert unit_conversion_factor("", "") == 1.0
-
-
-# ---- Overflow/underflow handling ----
 
 
 def test_overflow_exponentiation():
@@ -205,9 +180,6 @@ def test_overflow_division():
     # u^(-25) / u^25 = u^(-50), which overflows (u has factor 1.66e-27)
     with pytest.raises((ValueError, RuntimeError), match="overflows"):
         unit_conversion_factor("u^(-25)", "u^25")
-
-
-# ---- Valid units (ModelOutput creation still works) ----
 
 
 def test_valid_units():
@@ -249,9 +221,6 @@ def test_valid_units():
     ModelOutput(quantity="velocity", unit="A/s")
 
 
-# ---- Accumulated floating-point error with fractional powers ----
-
-
 def test_fractional_power_accumulated_error():
     # Test that (eV*u)^(1/3) then ^3 equals eV*u within tolerance
     # This verifies the 1e-10 dimension comparison tolerance handles
@@ -268,18 +237,12 @@ def test_fractional_power_accumulated_error():
     assert conv3 == pytest.approx(1.0, rel=1e-6)
 
 
-# ---- Time units ----
-
-
 def test_time_units():
     assert unit_conversion_factor("s", "fs") == pytest.approx(1e15)
     assert unit_conversion_factor("second", "ps") == pytest.approx(1e12)
     assert unit_conversion_factor("ns", "fs") == pytest.approx(1e6)
     assert unit_conversion_factor("us", "ns") == pytest.approx(1e3)
     assert unit_conversion_factor("ms", "us") == pytest.approx(1e3)
-
-
-# ---- Mass and charge units ----
 
 
 def test_mass_units():
@@ -303,9 +266,6 @@ def test_derived_constants():
     assert conv == pytest.approx(1.054571817e-34, rel=1e-6)
 
 
-# ---- Micro sign for microsecond ----
-
-
 def test_micro_sign_microsecond():
     # µs -> ns (microsecond via micro sign)
     assert unit_conversion_factor("µs", "ns") == pytest.approx(
@@ -313,24 +273,31 @@ def test_micro_sign_microsecond():
     )
 
 
-# ---- Quantity-unit mismatch ----
-
-
 def test_quantity_unit_mismatch():
     # energy quantity with force unit
-    with pytest.raises((ValueError, RuntimeError), match="incompatible with quantity"):
+    message = (
+        "unit 'eV/A' has dimension L T^-2 M which is incompatible with "
+        "'energy' (L^2 T^-2 M)"
+    )
+    with pytest.raises(ValueError, match=re.escape(message)):
         ModelOutput(quantity="energy", unit="eV/A")
 
     # force quantity with energy unit
-    with pytest.raises((ValueError, RuntimeError), match="incompatible with quantity"):
+
+    message = (
+        "unit 'eV' has dimension L^2 T^-2 M which is incompatible with "
+        "'force' (L T^-2 M)"
+    )
+    with pytest.raises(ValueError, match=re.escape(message)):
         ModelOutput(quantity="force", unit="eV")
 
     # length quantity with pressure unit
-    with pytest.raises((ValueError, RuntimeError), match="incompatible with quantity"):
+    message = (
+        "unit 'eV/A^3' has dimension L^-1 T^-2 M which is incompatible with "
+        "'length' (L)"
+    )
+    with pytest.raises(ValueError, match=re.escape(message)):
         ModelOutput(quantity="length", unit="eV/A^3")
-
-
-# ---- Deprecation warning for 3-arg C++ op ----
 
 
 def test_3arg_deprecation_warning():
@@ -448,9 +415,6 @@ def test_2arg_error_cases():
         unit_conversion_factor(from_unit="eV")  # missing to_unit
 
 
-# ---- TorchScript compatibility ----
-
-
 def test_torchscript_unit_conversion():
     """unit_conversion_factor must be callable from TorchScript."""
 
@@ -462,74 +426,12 @@ def test_torchscript_unit_conversion():
     assert convert("angstrom", "nm") == pytest.approx(0.1)
 
 
-# ---- Multithreading tests ----
+def test_unit_dimension_for_quantity():
+    assert unit_dimension_for_quantity("energy") == "energy"
+    assert unit_dimension_for_quantity("energy_uncertainty") == "energy"
+    assert unit_dimension_for_quantity("energy_ensemble") == "energy"
+    assert unit_dimension_for_quantity("energy/variant") == "energy"
 
-
-def test_thread_local_cache():
-    """Test that thread-local cache works correctly across multiple threads."""
-    import threading
-
-    num_threads = 10
-    iterations_per_thread = 100
-    results = [None] * (num_threads * iterations_per_thread)
-
-    def worker(thread_id):
-        for i in range(iterations_per_thread):
-            factor = unit_conversion_factor("eV", "meV")
-            results[thread_id * iterations_per_thread + i] = factor
-
-    threads = []
-    for t in range(num_threads):
-        thread = threading.Thread(target=worker, args=(t,))
-        threads.append(thread)
-        thread.start()
-
-    for thread in threads:
-        thread.join()
-
-    # All results should be consistent (1000.0 for eV -> meV)
-    for result in results:
-        assert result == pytest.approx(1000.0, rel=1e-10)
-
-
-def test_concurrent_different_conversions():
-    """Test that different threads can safely convert different units."""
-    import threading
-
-    num_threads = 5
-    results = [None] * num_threads
-
-    conversions = [
-        ("eV", "meV"),  # energy
-        ("angstrom", "bohr"),  # length
-        ("fs", "ps"),  # time
-        ("u", "kg"),  # mass
-        ("eV/A", "Hartree/Bohr"),  # force
-    ]
-
-    expected = [
-        1000.0,  # eV -> meV
-        1.8897259886,  # angstrom -> bohr
-        0.001,  # fs -> ps
-        1.66053906660e-27,  # u -> kg
-        0.0194469,  # eV/A -> Hartree/Bohr
-    ]
-
-    def worker(thread_id):
-        for _ in range(50):
-            results[thread_id] = unit_conversion_factor(
-                conversions[thread_id][0], conversions[thread_id][1]
-            )
-
-    threads = []
-    for t in range(num_threads):
-        thread = threading.Thread(target=worker, args=(t,))
-        threads.append(thread)
-        thread.start()
-
-    for thread in threads:
-        thread.join()
-
-    # Check each thread got the correct result
-    for t in range(num_threads):
-        assert results[t] == pytest.approx(expected[t], rel=1e-4)
+    assert unit_dimension_for_quantity("heat_flux") == "heat_flux"
+    assert unit_dimension_for_quantity("features") == "none"
+    assert unit_dimension_for_quantity("unknown::output") == ""

--- a/python/metatomic_torchsim/metatomic_torchsim/_model.py
+++ b/python/metatomic_torchsim/metatomic_torchsim/_model.py
@@ -260,22 +260,20 @@ class MetatomicModel(ModelInterface):
 
         # Precompute the outputs dict (immutable after __init__)
         run_outputs: Dict[str, ModelOutput] = {
-            self._energy_key: ModelOutput(
-                quantity="energy", unit="eV", sample_kind="system"
-            ),
+            self._energy_key: ModelOutput(unit="eV", sample_kind="system")
         }
         if self._calculate_uncertainty:
             run_outputs[self._energy_uq_key] = ModelOutput(
-                quantity="energy", unit="eV", sample_kind="atom"
+                unit="eV", sample_kind="atom"
             )
         if self._non_conservative:
             if self._compute_forces:
                 run_outputs[self._nc_forces_key] = ModelOutput(
-                    quantity="force", unit="eV/Angstrom", sample_kind="atom"
+                    unit="eV/Angstrom", sample_kind="atom"
                 )
             if self._compute_stress:
                 run_outputs[self._nc_stress_key] = ModelOutput(
-                    quantity="pressure", unit="eV/Angstrom^3", sample_kind="system"
+                    unit="eV/Angstrom^3", sample_kind="system"
                 )
         run_outputs.update(self._additional_output_requests)
 

--- a/python/metatomic_torchsim/tests/torchsim.py
+++ b/python/metatomic_torchsim/tests/torchsim.py
@@ -410,9 +410,7 @@ def test_additional_outputs_empty(lj_model, ni_atoms):
 def test_additional_outputs_requested(lj_model, ni_atoms):
     """Extra model outputs are stored in additional_outputs."""
     extra = {
-        "energy_ensemble": ModelOutput(
-            quantity="energy", unit="eV", sample_kind="atom"
-        ),
+        "energy_ensemble": ModelOutput(unit="eV", sample_kind="atom"),
     }
     model = MetatomicModel(
         model=lj_model,

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,9 @@ requires = tox >=4.39
 # `tox` in the command-line without anything else
 envlist =
     lint
-    torch-tests
     torch-tests-cxx
     torch-install-tests-cxx
+    torch-tests
     docs-tests
     ase-tests
     torchsim-tests
@@ -25,7 +25,7 @@ setenv =
 package = skip
 lint_folders = "{toxinidir}/python" "{toxinidir}/setup.py"
 build_single_wheel = --no-deps --no-build-isolation --check-build-dependencies
-install_lj_tests = pip install {[testenv]build_single_wheel} git+https://github.com/metatensor/lj-test@eea52c6
+install_lj_tests = pip install {[testenv]build_single_wheel} git+https://github.com/metatensor/lj-test@2f74cf8
 
 packaging_deps =
     setuptools >= 77


### PR DESCRIPTION

<!-- What does this implement/fix? Explain your changes here. -->

The quantity field is no longer required for unit conversion since the unit parser determines dimensions from the expression itself.

Changes:
- Add deprecated documentation to C++ header
- Add TORCH_WARN in C++ setter when quantity is non-empty
- Add DeprecationWarning in Python when quantity validation runs
- Update documentation with deprecation notice
- Add deprecation entries to CHANGELOG


# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [x] CHANGELOG updated with public API or any other important changes?
