### PR TITLE
Remove the version pin on numpy, it is no longer required

### DIFF
--- a/.github/workflows/torch-tests.yml
+++ b/.github/workflows/torch-tests.yml
@@ -20,7 +20,6 @@ jobs:
           - os: ubuntu-24.04
             python-version: "3.10"
             torch-version: "2.3"
-            numpy-version-pin: "<2.0"
           - os: ubuntu-24.04
             python-version: "3.10"
             torch-version: "2.11"
@@ -73,7 +72,6 @@ jobs:
         env:
           PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
           METATOMIC_TESTS_TORCH_VERSION: ${{ matrix.torch-version }}
-          METATOMIC_TESTS_NUMPY_VERSION_PIN:  ${{ matrix.numpy-version-pin }}
 
       - name: combine Python coverage files
         shell: bash

--- a/tox.ini
+++ b/tox.ini
@@ -125,7 +125,7 @@ deps =
     {[testenv]metatensor_deps}
 
     torch=={env:METATOMIC_TESTS_TORCH_VERSION:2.11}.*
-    numpy {env:METATOMIC_TESTS_NUMPY_VERSION_PIN}
+    numpy
 
     vesin
     vesin-torch
@@ -153,7 +153,7 @@ deps =
     {[testenv]metatensor_deps}
 
     torch=={env:METATOMIC_TESTS_TORCH_VERSION:2.11}.*
-    numpy {env:METATOMIC_TESTS_NUMPY_VERSION_PIN}
+    numpy
 
     vesin
     ase
@@ -177,7 +177,7 @@ deps =
     {[testenv]metatensor_deps}
 
     torch=={env:METATOMIC_TESTS_TORCH_VERSION:2.11}.*
-    numpy {env:METATOMIC_TESTS_NUMPY_VERSION_PIN}
+    numpy
 
     ase
     vesin
@@ -213,7 +213,7 @@ deps =
     {[testenv]metatensor_deps}
 
     torch=={env:METATOMIC_TESTS_TORCH_VERSION:2.11}.*
-    numpy {env:METATOMIC_TESTS_NUMPY_VERSION_PIN}
+    numpy
 
     vesin
     ase


### PR DESCRIPTION
Torch 2.3.1 should support numpy 2.0

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~
