### PR TITLE
Skip constrained ase.atoms in forward

### DIFF
--- a/python/metatomic_ase/CHANGELOG.md
+++ b/python/metatomic_ase/CHANGELOG.md
@@ -16,6 +16,10 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/metatensor/metatomic/)
 
+### Added
+
+- `MetatomicCalculator` is skipping model output computation for spatially fixed atoms.
+
 ## [Version 0.1.0](https://github.com/metatensor/metatomic/releases/tag/metatomic-ase-v0.1.0) - 2026-03-25
 
 - `metatomic-ase` is now a standalone package, containing the ASE integration

--- a/python/metatomic_ase/src/metatomic_ase/_calculator.py
+++ b/python/metatomic_ase/src/metatomic_ase/_calculator.py
@@ -31,6 +31,7 @@ from ase.calculators.calculator import (  # isort: skip
     PropertyNotImplementedError,
     all_properties as ALL_ASE_PROPERTIES,
 )
+from ase.constraints import FixAtoms  # isort: skip
 
 
 FilePath = Union[str, bytes, pathlib.PurePath]
@@ -114,6 +115,13 @@ class MetatomicCalculator(ase.calculators.calculator.Calculator):
     or GPU depending on the device of the model. If `nvalchemiops
     <https://github.com/NVIDIA/nvalchemi-toolkit-ops>`_ is installed, full neighbor
     lists on GPU will be computed with it instead.
+
+    .. note::
+
+        :py:class:`ase.constraints.FixAtoms` constraints on the :py:class:`ase.Atoms`
+        are excluded from model inference
+
+        All other constraint types are ignored here and handled by ASE as usual.
     """
 
     def __init__(
@@ -358,6 +366,25 @@ class MetatomicCalculator(ase.calculators.calculator.Calculator):
         """Get the metadata of the underlying model"""
         return self._model.metadata()
 
+    def _select_from_constraints(self, atoms: ase.Atoms) -> Optional[Labels]:
+        """Create Labels selecting all non-FixAtoms entries."""
+        atom_indices = torch.arange(len(atoms), dtype=torch.int32)
+        mask = torch.ones(len(atoms), dtype=torch.bool)
+
+        for constraint in atoms.constraints:
+            if isinstance(constraint, FixAtoms):
+                mask[constraint.index] = False
+
+        if mask.all():
+            return None
+
+        unfixed = atom_indices[mask]
+        system_col = torch.zeros(len(unfixed), dtype=torch.int32)
+        return Labels(
+            ["system", "atom"],
+            torch.stack([system_col, unfixed], dim=1),
+        )
+
     def run_model(
         self,
         atoms: Union[ase.Atoms, List[ase.Atoms]],
@@ -500,6 +527,10 @@ class MetatomicCalculator(ase.calculators.calculator.Calculator):
                     explicit_gradients=[],
                 )
 
+            selected_atoms = self._select_from_constraints(atoms)
+            if selected_atoms is not None and self._energy_key in outputs:
+                outputs[self._energy_key].sample_kind = "atom"
+
             capabilities = self._model.capabilities()
             for name in outputs.keys():
                 if name not in capabilities.outputs:
@@ -532,7 +563,7 @@ class MetatomicCalculator(ase.calculators.calculator.Calculator):
             run_options = ModelEvaluationOptions(
                 length_unit="angstrom",
                 outputs=outputs,
-                selected_atoms=None,
+                selected_atoms=selected_atoms,
             )
 
         with record_function("MetatomicCalculator::compute_neighbors"):
@@ -561,7 +592,10 @@ class MetatomicCalculator(ase.calculators.calculator.Calculator):
                 assert energy.sample_names == ["system", "atom"]
                 assert torch.all(energy.block().samples["system"] == 0)
                 energies = energy
-                assert energies.block().values.shape == (len(atoms), 1)
+                n_selected = (
+                    len(selected_atoms) if selected_atoms is not None else len(atoms)
+                )
+                assert energies.block().values.shape == (n_selected, 1)
 
                 energy = mts.sum_over_samples(energy, sample_names=["atom"])
 
@@ -606,7 +640,12 @@ class MetatomicCalculator(ase.calculators.calculator.Calculator):
             if calculate_energies:
                 energies_values = energies.block().values.detach().reshape(-1)
                 atom_indexes = energies.block().samples.column("atom")
-                result = torch.zeros_like(energies_values)
+                # Allocate for ALL atoms so fixed atoms appear as zero energy.
+                result = torch.zeros(
+                    len(atoms),
+                    dtype=energies_values.dtype,
+                    device=energies_values.device,
+                )
                 result.index_add_(0, atom_indexes, energies_values)
                 self.results["energies"] = result.cpu().double().numpy()
 

--- a/python/metatomic_ase/tests/calculator.py
+++ b/python/metatomic_ase/tests/calculator.py
@@ -6,11 +6,13 @@ from typing import Dict, List, Optional
 import ase.build
 import ase.calculators.lj
 import ase.md
+import ase.optimize
 import ase.units
 import numpy as np
 import pytest
 import torch
 from ase.calculators.calculator import PropertyNotImplementedError
+from ase.constraints import FixAtoms, FixBondLength
 from ase.md.velocitydistribution import MaxwellBoltzmannDistribution
 from metatensor.torch import Labels, TensorBlock, TensorMap
 
@@ -850,3 +852,79 @@ def test_mixed_pbc(model, device, dtype):
     )
     atoms.get_potential_energy()
     atoms.get_forces()
+
+
+def test_fixatoms_dimer_optimization(model):
+    """Optimize a Ni dimer where atom 0 is fixed with FixAtoms.
+
+    Both the default behavior (selected_atoms built from constraints) and the
+    monkeypatched baseline (no selected_atoms, ASE optimizer handles the constraint)
+    must converge to the same LJ equilibrium distance.
+    """
+
+    r_eq = 2 ** (1 / 6) * SIGMA  # LJ minimum ≈ 1.774 Å
+    r_start = 2.5
+
+    def make_dimer(monkeypatch=False):
+        # Large periodic cell; PBC needed for stress
+        atoms = ase.Atoms(
+            "Ni2",
+            positions=[[0, 0, 0], [r_start, 0, 0]],
+            cell=[20, 20, 20],
+            pbc=True,
+        )
+        atoms.set_constraint(FixAtoms(indices=[0]))
+        calc = MetatomicCalculator(model, uncertainty_threshold=None)
+        if monkeypatch:
+            calc._select_from_constraints = lambda _: None
+        atoms.calc = calc
+        return atoms
+
+    atoms_sa = make_dimer(monkeypatch=False)
+    atoms_no_sa = make_dimer(monkeypatch=True)
+
+    # energy: with selected_atoms only atom 1's contribution is summed
+    e_sa = atoms_sa.get_potential_energy()
+    e_no_sa = atoms_no_sa.get_potential_energy()
+    assert not np.isclose(e_sa, e_no_sa)
+
+    # forces: same shape; fixed atom is zero; unfixed atom is non-zero
+    f_sa = atoms_sa.get_forces()
+    f_no_sa = atoms_no_sa.get_forces()
+    assert f_sa.shape == f_no_sa.shape == (2, 3)
+    np.testing.assert_allclose(f_sa[0], 0.0)  # fixed atom zeroed by ASE constraint
+    np.testing.assert_allclose(f_no_sa[0], 0.0)
+    assert not np.allclose(f_sa[1], 0.0)
+
+    # stress: differs because selected_atoms changes the virial contribution
+    s_sa = atoms_sa.get_stress()
+    s_no_sa = atoms_no_sa.get_stress()
+    assert not np.allclose(s_sa, s_no_sa)
+
+    # optimization: both approaches converge to the same geometry
+    def run_and_check(atoms):
+        opt = ase.optimize.BFGS(atoms, logfile=None)
+        opt.run(fmax=1e-4)
+        r_final = np.linalg.norm(atoms.positions[1] - atoms.positions[0])
+        np.testing.assert_allclose(r_final, r_eq, atol=1e-3)
+        np.testing.assert_allclose(atoms.positions[0], [0, 0, 0], atol=1e-6)
+
+    run_and_check(make_dimer(monkeypatch=False))
+    run_and_check(make_dimer(monkeypatch=True))
+
+
+def test_fixatoms_only_fix_atoms_considered(model):
+    """
+    Only FixAtoms constraints must contribute to selected_atoms; all other
+    constraint types (e.g. FixBondLength) must be ignored.
+    """
+    atoms = ase.Atoms("Ni3", positions=[[0, 0, 0], [2.0, 0, 0], [4.0, 0, 0]])
+    # atom 0 is fixed; atoms 1-2 have an unrelated bond-length constraint
+    atoms.set_constraint([FixAtoms(indices=[0]), FixBondLength(1, 2)])
+
+    calc = MetatomicCalculator(model, uncertainty_threshold=None)
+    selected = calc._select_from_constraints(atoms)
+
+    assert selected is not None
+    atom_indices = selected.column("atom").tolist()
+    assert sorted(atom_indices) == [1, 2]


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

Fixes #206

Particles in an `ase.Atoms` object that are part of a `FixAtoms` constraint are now                                                                                                                  
excluded from `selected_atoms` during model inference. avoiding redundant per-atom                                                                                                                     
output computation for atoms whose forces will be zeroed by the optimizer anyway.  

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [x] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation docs start -->
[📚 Download documentation for this pull-request](https://nightly.link/metatensor/metatomic/actions/artifacts/6628203233.zip)

<!-- download-section Documentation docs end -->