### PR TITLE
Make `git-version-info.py` compatiable with worktree

### DIFF
--- a/scripts/git-version-info.py
+++ b/scripts/git-version-info.py
@@ -46,6 +46,19 @@ def run_subprocess(args, check=True, env=None, cwd=None):
     return output
 
 
+def git_paths():
+    gitdir = Path(run_subprocess(["git", "rev-parse", "--git-dir"]).stdout.strip())
+    if not gitdir.is_absolute():
+        gitdir = Path.cwd() / gitdir
+    gitdir = gitdir.resolve()
+
+    worktree = Path(
+        run_subprocess(["git", "rev-parse", "--show-toplevel"]).stdout.strip()
+    ).resolve()
+
+    return gitdir, worktree
+
+
 def n_commits_since_last_tag(tag_prefix):
     # get the full list of tags
     result = run_subprocess(["git", "tag", "--sort=-creatordate"])
@@ -89,11 +102,7 @@ def acquire_git_index_lock(lock: Path, timeout=2.0, poll=1e-3) -> bool:
 
 
 def update_git_index():
-    gitdir = Path(
-        subprocess.run(
-            ["git", "rev-parse", "--git-dir"], capture_output=True, encoding="utf8"
-        ).stdout.strip()
-    )
+    gitdir, worktree = git_paths()
     lock = gitdir / "index.lock"
 
     # create a temp file inside the git dir and close its fd immediately
@@ -109,7 +118,7 @@ def update_git_index():
         run_subprocess(
             ["git", "update-index", "-q", "--really-refresh"],
             env=env,
-            cwd=gitdir.parent.absolute(),
+            cwd=worktree,
         )
 
         # Now acquire the real index lock and swap the updated temp index in place.
@@ -132,14 +141,17 @@ def update_git_index():
         except Exception:
             pass
 
+    return gitdir, worktree
+
 
 def git_hash_all_code():
     # make sure the index is up to date before doing `git diff-index`
-    update_git_index()
+    gitdir, worktree = update_git_index()
 
     output = subprocess.run(
         ["git", "diff-index", "--quiet", "HEAD", "--"],
         capture_output=True,
+        cwd=worktree,
     )
 
     if output.returncode not in [0, 1]:
@@ -156,18 +168,18 @@ def git_hash_all_code():
         # pretending to stage all the file using a temporary index. This way the actual
         # git index is left untouched.
         with tempfile.NamedTemporaryFile("wb") as tmp:
-            with open(os.path.join(ROOT, ".git", "index"), "rb") as git_index:
+            with open(gitdir / "index", "rb") as git_index:
                 shutil.copyfileobj(git_index, tmp)
             tmp.close()
 
             git_env = os.environ.copy()
             git_env["GIT_INDEX_FILE"] = tmp.name
-            run_subprocess(["git", "add", "--all"], env=git_env)
+            run_subprocess(["git", "add", "--all"], env=git_env, cwd=worktree)
 
-            output = run_subprocess(["git", "write-tree"], env=git_env)
+            output = run_subprocess(["git", "write-tree"], env=git_env, cwd=worktree)
             short_hash = output.stdout[:7]
     else:
-        output = run_subprocess(["git", "rev-parse", "HEAD"])
+        output = run_subprocess(["git", "rev-parse", "HEAD"], cwd=worktree)
         short_hash = output.stdout[:7]
 
     return ("dirty." if is_dirty else "git.") + short_hash


### PR DESCRIPTION
When working with `git worktree` and running `tox` tests, one would encounter with the following error. This PR aims at passing a correct directory for running `git update-index -q --really-refresh`
```
(tox) qxu@cosmopc3:~/repos/metatomic-heat-flux$ tox -e torch-tests
torch-tests: commands[0] /home/qxu/repos/metatomic-heat-flux/python/metatomic_torch> pip install --no-deps --no-build-isolation --check-build-dependencies .
Looking in indexes: https://pypi.org/simple, https://download.pytorch.org/whl/cpu
Processing ./.
  Preparing metadata (pyproject.toml) ... error
  error: subprocess-exited-with-error

  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [50 lines of output]
      Traceback (most recent call last):
        File "/home/qxu/repos/metatomic-heat-flux/.tox/torch-tests/lib/python3.14/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
          main()
          ~~~~^^
        File "/home/qxu/repos/metatomic-heat-flux/.tox/torch-tests/lib/python3.14/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
          json_out["return_val"] = hook(**hook_input["kwargs"])
                                   ~~~~^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/qxu/repos/metatomic-heat-flux/.tox/torch-tests/lib/python3.14/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 175, in prepare_metadata_for_build_wheel
          return hook(metadata_directory, config_settings)
        File "/home/qxu/repos/metatomic-heat-flux/.tox/torch-tests/lib/python3.14/site-packages/setuptools/build_meta.py", line 380, in prepare_metadata_for_build_wheel
          self.run_setup()
          ~~~~~~~~~~~~~~^^
        File "/home/qxu/repos/metatomic-heat-flux/.tox/torch-tests/lib/python3.14/site-packages/setuptools/build_meta.py", line 317, in run_setup
          exec(code, locals())
          ~~~~^^^^^^^^^^^^^^^^
        File "<string>", line 336, in <module>
        File "<string>", line 220, in create_version_number
        File "<string>", line 200, in git_version_info
      Exception: failed to get git version info.
      stdout: 44

      stderr: Traceback (most recent call last):
        File "/home/qxu/repos/metatomic-heat-flux/python/metatomic_torch/../../scripts/git-version-info.py", line 201, in <module>
          print(git_hash_all_code())
                ~~~~~~~~~~~~~~~~~^^
        File "/home/qxu/repos/metatomic-heat-flux/python/metatomic_torch/../../scripts/git-version-info.py", line 138, in git_hash_all_code
          update_git_index()
          ~~~~~~~~~~~~~~~~^^
        File "/home/qxu/repos/metatomic-heat-flux/python/metatomic_torch/../../scripts/git-version-info.py", line 109, in update_git_index
          run_subprocess(
          ~~~~~~~~~~~~~~^
              ["git", "update-index", "-q", "--really-refresh"],
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
              env=env,
              ^^^^^^^^
              cwd=gitdir.parent.absolute(),
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          )
          ^
        File "/home/qxu/repos/metatomic-heat-flux/python/metatomic_torch/../../scripts/git-version-info.py", line 37, in run_subprocess
          raise Exception(
          ...<3 lines>...
          )
      Exception: failed to run 'git update-index -q --really-refresh' (exit code 128)
      stdout:
      stderr: fatal: this operation must be run in a work tree




      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> from file:///home/qxu/repos/metatomic-heat-flux/python/metatomic_torch

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
torch-tests: exit 1 (1.43 seconds) /home/qxu/repos/metatomic-heat-flux/python/metatomic_torch> pip install --no-deps --no-build-isolation --check-build-dependencies . pid=3652321
  torch-tests: FAIL code 1 (1.46=setup[0.03]+cmd[1.43] seconds)
  evaluation failed :( (1.49 seconds)
(tox) qxu@cosmopc3:~/repos/metatomic-heat-flux$
```


# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?


<!-- download-section Documentation docs start -->
[📚 Download documentation for this pull-request](https://nightly.link/metatensor/metatomic/actions/artifacts/6747019481.zip)

<!-- download-section Documentation docs end -->