### PR TITLE
Add spin/charge to ase calculator

### DIFF
--- a/docs/src/quantities/charge.rst
+++ b/docs/src/quantities/charge.rst
@@ -21,9 +21,12 @@ name (see :ref:`quantity-variants`), and must have the following metadata:
       :py:class:`metatensor.torch.TensorMap` with a single block.
 
   * - samples
-    - ``["system", "atom"]``
-    - the samples must be named ``["system", "atom"]``, since ``"charge"`` is
-      always per-atom.
+    - ``["system", "atom"]`` or ``["system"]``
+    - the samples should be named ``["system", "atom"]`` for per-atom charges
+      (one value per atom), or ``["system"]`` for the per-system total charge
+      (a single value per system). The form is selected by the requested
+      :py:attr:`~metatomic.torch.ModelOutput.sample_kind` (``"atom"`` or
+      ``"system"``).
 
       ``"system"`` must range from 0 to the number of systems given as input
       to the model. ``"atom"`` must range between 0 and the number of

--- a/docs/src/quantities/spin_multiplicity.rst
+++ b/docs/src/quantities/spin_multiplicity.rst
@@ -48,3 +48,16 @@ Common examples:
 - ``1`` for a singlet (:math:`S = 0`)
 - ``2`` for a doublet (:math:`S = 1/2`, e.g. a radical with one unpaired electron)
 - ``3`` for a triplet (:math:`S = 1`)
+
+The following simulation engine can provide ``"spin_multiplicity"`` as inputs to
+the models:
+
+.. grid:: 1 3 3 3
+
+  .. grid-item-card::
+    :text-align: center
+    :padding: 1
+    :link: engine-ase
+    :link-type: ref
+
+    |ase-logo|

--- a/python/metatomic_ase/src/metatomic_ase/_calculator.py
+++ b/python/metatomic_ase/src/metatomic_ase/_calculator.py
@@ -2,7 +2,7 @@ import logging
 import os
 import pathlib
 import warnings
-from typing import Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 import metatensor.torch as mts
 import numpy as np
@@ -92,11 +92,18 @@ PER_ATOM_QUANTITIES = {
 }
 
 
-def _get_total_charge(atoms: ase.Atoms) -> float:
-    if "charge" in atoms.info:
-        return float(atoms.info["charge"])
-    else:
-        return float(np.sum(_get_per_atom_charges(atoms)))
+def _get_total_charge(atoms: ase.Atoms) -> np.ndarray:
+    return np.array([float(atoms.info.get("charge", 0.0))])
+
+
+def _get_spin_multiplicity(atoms: ase.Atoms) -> np.ndarray:
+    # For spin multiplicity, we first check if the user provided it explicitly in
+    # `atoms.info["spin_multiplicity"]`, and if not, we fall back to
+    # `atoms.info["spin"]` (which is used by the OMOL dataset)
+    if "spin_multiplicity" in atoms.info:
+        return np.array([float(atoms.info["spin_multiplicity"])])
+
+    return np.array([float(atoms.info.get("spin", 1))])
 
 
 PER_SYSTEM_QUANTITIES = {
@@ -106,6 +113,22 @@ PER_SYSTEM_QUANTITIES = {
         "getter": _get_total_charge,
         "unit": "e",
     },
+    "spin_multiplicity": {
+        "properties_name": "spin_multiplicity",
+        "getter": _get_spin_multiplicity,
+        "unit": "",
+    },
+}
+
+
+_MISSING_INFO = object()
+
+# For standard per-system quantities the model can request, the `atoms.info` keys that
+# can be read by the getter and the value returned when the key is absent. Used by
+# `check_state` to invalidate the cached results when the key changes.
+_INFO_KEY_FOR_QUANTITY = {
+    "charge": (["charge"], 0.0),
+    "spin_multiplicity": (["spin_multiplicity", "spin"], 1),
 }
 
 
@@ -136,7 +159,10 @@ class MetatomicCalculator(ase.calculators.calculator.Calculator):
     - **per-atom**: :ref:`momentum <momentum-quantity>`, :ref:`velocity
       <velocity-quantity>`, :ref:`charge <charge-quantity>`, :ref:`mass
       <mass-quantity>`;
-    - **per-system**: :ref:`charge <charge-quantity>`;
+    - **per-system**: :ref:`charge <charge-quantity>` (read from
+      ``atoms.info["charge"]``, defaults to 0), :ref:`spin_multiplicity
+      <spin-multiplicity-quantity>` (read from ``atoms.info["spin_multiplicity"]`` if
+      present, ``atoms.info["spin"]`` otherwise, defaults to 1);
 
     As well as the following ASE-specific quantities:
 
@@ -381,6 +407,20 @@ class MetatomicCalculator(ase.calculators.calculator.Calculator):
 
         self._model = model.to(device=self._device)
 
+        # Pre-compute the list of `atoms.info` keys we need to watch for changes
+        # so ASE's cache gets invalidated when they change between MD steps.
+        # Doing this once here avoids a TorchScript dispatch on every step.
+        self._system_info_watch: List[Tuple[str, Any]] = []
+        for name, option in self._model.requested_inputs(use_new_names=True).items():
+            if option.sample_kind != "system":
+                continue
+            if name in _INFO_KEY_FOR_QUANTITY:
+                default = _INFO_KEY_FOR_QUANTITY[name][1]
+                for key_name in _INFO_KEY_FOR_QUANTITY[name][0]:
+                    self._system_info_watch.append((key_name, default))
+            elif name.startswith("ase::info::"):
+                self._system_info_watch.append((name[11:], _MISSING_INFO))
+
         self._calculate_uncertainty = (
             self._energy_uq_key in outputs
             # we require per-atom uncertainties to capture local effects
@@ -500,6 +540,32 @@ class MetatomicCalculator(ase.calculators.calculator.Calculator):
             options=options,
             check_consistency=self.parameters["check_consistency"],
         )
+
+    def check_state(self, atoms: ase.Atoms, tol: float = 1e-15) -> List[str]:
+        """Detect system changes, including ``atoms.info`` keys used as model inputs.
+
+        ASE's default :py:meth:`~ase.calculators.calculator.Calculator.check_state` only
+        tracks per-atom arrays, cell and pbc, so mutations to ``atoms.info`` (e.g.
+        ``atoms.info["spin"]``) would otherwise return a stale cached result. Any
+        watched info key that differs from the last calculation is appended to the
+        change list, forcing a fresh run.
+        """
+        changes = super().check_state(atoms, tol=tol)
+
+        if self.atoms is None:
+            return changes
+
+        for key, default in self._system_info_watch:
+            old = self.atoms.info.get(key, default)
+            new = atoms.info.get(key, default)
+            try:
+                equal = old == new
+                if not isinstance(equal, bool) or not equal:
+                    changes.append(key)
+            except Exception:
+                changes.append(key)
+
+        return changes
 
     def calculate(
         self,

--- a/python/metatomic_ase/tests/calculator.py
+++ b/python/metatomic_ase/tests/calculator.py
@@ -884,6 +884,211 @@ def test_additional_input(atoms):
         assert np.allclose(values, expected)
 
 
+class SpinEnergyModel(torch.nn.Module):
+    """Model that requests ``spin_multiplicity`` and returns an energy scaled by it."""
+
+    _requested_inputs: Dict[str, ModelOutput]
+
+    def __init__(self):
+        super().__init__()
+        self._requested_inputs = {
+            "spin_multiplicity": ModelOutput(unit="", sample_kind="system"),
+        }
+
+    def requested_inputs(self) -> Dict[str, ModelOutput]:
+        return self._requested_inputs
+
+    def forward(
+        self,
+        systems: List[System],
+        outputs: Dict[str, ModelOutput],
+        selected_atoms: Optional[Labels] = None,
+    ) -> Dict[str, TensorMap]:
+        system = systems[0]
+        spin = system.get_data("spin_multiplicity").block(0).values[0, 0]
+        device = system.positions.device
+        block = TensorBlock(
+            values=(10.0 * spin).reshape(1, 1).to(torch.float64),
+            samples=Labels("system", torch.tensor([[0]], device=device)),
+            components=torch.jit.annotate(List[Labels], []),
+            properties=Labels("energy", torch.tensor([[0]], device=device)),
+        )
+        return {
+            "energy": TensorMap(
+                Labels("_", torch.tensor([[0]], device=device)), [block]
+            )
+        }
+
+
+def _spin_energy_model():
+    capabilities = ModelCapabilities(
+        outputs={"energy": ModelOutput(sample_kind="system", unit="eV")},
+        atomic_types=[28],
+        interaction_range=0.0,
+        supported_devices=["cpu"],
+        dtype="float64",
+        length_unit="Angstrom",
+    )
+    return AtomisticModel(SpinEnergyModel().eval(), ModelMetadata(), capabilities)
+
+
+def test_spin_multiplicity_input_value(atoms):
+    """The spin set in atoms.info propagates into the model."""
+    calculator = MetatomicCalculator(_spin_energy_model(), check_consistency=True)
+
+    for spin in (1, 2, 5):
+        atoms.info["spin"] = spin
+        energy = calculator.run_model(
+            atoms, {"energy": ModelOutput(sample_kind="system", unit="eV")}
+        )
+        assert float(energy["energy"].block(0).values[0, 0]) == pytest.approx(
+            10.0 * spin
+        )
+
+
+def test_spin_multiplicity_input_default(atoms):
+    """When atoms.info has no "spin" key, spin_multiplicity defaults to 1."""
+    atoms.info.pop("spin", None)
+    calculator = MetatomicCalculator(_spin_energy_model(), check_consistency=True)
+    energy = calculator.run_model(
+        atoms, {"energy": ModelOutput(sample_kind="system", unit="eV")}
+    )
+    assert float(energy["energy"].block(0).values[0, 0]) == pytest.approx(10.0)
+
+
+def test_spin_multiplicity_cache_invalidation(atoms):
+    """Mutating ``atoms.info["spin"]`` between energy calls forces a recompute."""
+    atoms.calc = MetatomicCalculator(
+        _spin_energy_model(),
+        check_consistency=True,
+        uncertainty_threshold=None,
+    )
+
+    atoms.info["spin"] = 1
+    assert atoms.get_potential_energy() == pytest.approx(10.0)
+
+    atoms.info["spin"] = 3
+    # without the check_state override, ASE would return the cached 10.0
+    assert atoms.get_potential_energy() == pytest.approx(30.0)
+
+    # check_state should explicitly report the "spin" key as changed
+    atoms_changed = atoms.copy()
+    atoms_changed.info["spin"] = 7
+    assert "spin" in atoms.calc.check_state(atoms_changed)
+
+
+def test_spin_multiplicity_export_roundtrip(atoms, tmp_path):
+    """Reloaded models still request ``spin_multiplicity`` as a per-system input."""
+    from metatomic.torch import load_atomistic_model
+
+    path = tmp_path / "spin_model.pt"
+    _spin_energy_model().save(str(path))
+    loaded = load_atomistic_model(str(path))
+
+    requested = loaded.requested_inputs(use_new_names=True)
+    assert "spin_multiplicity" in requested
+    assert requested["spin_multiplicity"].sample_kind == "system"
+
+    atoms.info["spin"] = 2
+    calculator = MetatomicCalculator(loaded, check_consistency=True)
+    energy = calculator.run_model(
+        atoms, {"energy": ModelOutput(sample_kind="system", unit="eV")}
+    )
+    assert float(energy["energy"].block(0).values[0, 0]) == pytest.approx(20.0)
+
+
+class ChargeEnergyModel(torch.nn.Module):
+    """Model that requests per-system ``charge`` and returns an energy scaled by it."""
+
+    _requested_inputs: Dict[str, ModelOutput]
+
+    def __init__(self):
+        super().__init__()
+        self._requested_inputs = {
+            "charge": ModelOutput(unit="e", sample_kind="system"),
+        }
+
+    def requested_inputs(self) -> Dict[str, ModelOutput]:
+        return self._requested_inputs
+
+    def forward(
+        self,
+        systems: List[System],
+        outputs: Dict[str, ModelOutput],
+        selected_atoms: Optional[Labels] = None,
+    ) -> Dict[str, TensorMap]:
+        system = systems[0]
+        charge = system.get_data("charge").block(0).values[0, 0]
+        device = system.positions.device
+        block = TensorBlock(
+            values=(100.0 * charge).reshape(1, 1).to(torch.float64),
+            samples=Labels("system", torch.tensor([[0]], device=device)),
+            components=torch.jit.annotate(List[Labels], []),
+            properties=Labels("energy", torch.tensor([[0]], device=device)),
+        )
+        return {
+            "energy": TensorMap(
+                Labels("_", torch.tensor([[0]], device=device)), [block]
+            )
+        }
+
+
+def _charge_energy_model():
+    capabilities = ModelCapabilities(
+        outputs={"energy": ModelOutput(sample_kind="system", unit="eV")},
+        atomic_types=[28],
+        interaction_range=0.0,
+        supported_devices=["cpu"],
+        dtype="float64",
+        length_unit="Angstrom",
+    )
+    return AtomisticModel(ChargeEnergyModel().eval(), ModelMetadata(), capabilities)
+
+
+def test_per_system_charge_input_value(atoms):
+    """The total charge set in atoms.info propagates into the model."""
+    calculator = MetatomicCalculator(_charge_energy_model(), check_consistency=True)
+
+    for charge in (-1.0, 0.0, 0.5, 2.0):
+        atoms.info["charge"] = charge
+        energy = calculator.run_model(
+            atoms, {"energy": ModelOutput(sample_kind="system", unit="eV")}
+        )
+        assert float(energy["energy"].block(0).values[0, 0]) == pytest.approx(
+            100.0 * charge
+        )
+
+
+def test_per_system_charge_input_default(atoms):
+    """When atoms.info has no "charge" key, the total charge defaults to 0."""
+    atoms.info.pop("charge", None)
+    atoms.set_initial_charges([0.25] * len(atoms))
+    calculator = MetatomicCalculator(_charge_energy_model(), check_consistency=True)
+    energy = calculator.run_model(
+        atoms, {"energy": ModelOutput(sample_kind="system", unit="eV")}
+    )
+    assert float(energy["energy"].block(0).values[0, 0]) == pytest.approx(0.0)
+
+
+def test_per_system_charge_cache_invalidation(atoms):
+    """Mutating ``atoms.info["charge"]`` between energy calls forces a recompute."""
+    atoms.calc = MetatomicCalculator(
+        _charge_energy_model(),
+        check_consistency=True,
+        uncertainty_threshold=None,
+    )
+
+    atoms.info["charge"] = 1.0
+    assert atoms.get_potential_energy() == pytest.approx(100.0)
+
+    atoms.info["charge"] = -2.0
+    assert atoms.get_potential_energy() == pytest.approx(-200.0)
+
+    atoms_changed = atoms.copy()
+    atoms_changed.info["charge"] = 5.0
+    assert "charge" in atoms.calc.check_state(atoms_changed)
+
+
 @pytest.mark.parametrize("device,dtype", ALL_DEVICE_DTYPE)
 def test_mixed_pbc(model, device, dtype):
     """Test that the calculator works on a mixed-PBC system"""


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->
We add spin and charge and corresponding tests to the ase calculator. Internally spin is called spin_multiplicity.
We also add a method to confirm that any new requested_inputs are not stale so that only updating these is sufficient for a recalculation of energies/forces.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
