### PR TITLE
Resolve ambiguity in System::add_data

### DIFF
--- a/metatomic-torch/include/metatomic/torch/system.hpp
+++ b/metatomic-torch/include/metatomic/torch/system.hpp
@@ -276,16 +276,20 @@ public:
     void add_data(
         std::string name,
         metatensor_torch::TensorMap tensor,
-        bool override=false
+        bool override = false
     ) {
-        this->add_data(name, tensor, override, /*private_warn_on_deprecated=*/true);
+        this->add_data(name, tensor, override, private_warn_on_deprecated{true});
     }
+
+    struct private_warn_on_deprecated {
+        bool do_warning = true;
+    };
 
     void add_data(
         std::string name,
         metatensor_torch::TensorMap tensor,
         bool override,
-        bool private_warn_on_deprecated = true
+        private_warn_on_deprecated
     );
 
     /// Retrieve custom data stored in this System, or throw an error.

--- a/metatomic-torch/src/register.cpp
+++ b/metatomic-torch/src/register.cpp
@@ -176,7 +176,9 @@ TORCH_LIBRARY(metatomic, m) {
             {torch::arg("options")}
         )
         .def("known_neighbor_lists", &SystemHolder::known_neighbor_lists)
-        .def("add_data", (void (SystemHolder::*)(std::string, metatensor_torch::TensorMap, bool, bool))&SystemHolder::add_data, DOCSTRING,
+        .def("add_data", [](System self, std::string name, metatensor_torch::TensorMap tensor, bool override, bool warn_on_deprecated) {
+            self->add_data(std::move(name), std::move(tensor), override, SystemHolder::private_warn_on_deprecated{warn_on_deprecated});
+        }, DOCSTRING,
             {torch::arg("name"), torch::arg("tensor"), torch::arg("override") = false, torch::arg("_private_warn_on_deprecated") = true}
         )
         .def("get_data", &SystemHolder::get_data, DOCSTRING,

--- a/metatomic-torch/src/system.cpp
+++ b/metatomic-torch/src/system.cpp
@@ -909,7 +909,7 @@ void SystemHolder::add_data(
     std::string name,
     metatensor_torch::TensorMap tensor,
     bool override,
-    bool private_warn_on_deprecated
+    private_warn_on_deprecated warn_on_deprecated
 ) {
     if (INVALID_DATA_NAMES.find(string_lower(name)) != INVALID_DATA_NAMES.end()) {
         C10_THROW_ERROR(ValueError,
@@ -917,7 +917,7 @@ void SystemHolder::add_data(
         );
     }
 
-    details::validate_quantity_name(name, "model input", /*warn_on_deprecated=*/private_warn_on_deprecated);
+    details::validate_quantity_name(name, "model input", /*warn_on_deprecated=*/warn_on_deprecated.do_warning);
 
     if (!override && data_.find(name) != data_.end()) {
         C10_THROW_ERROR(ValueError,


### PR DESCRIPTION
Before, calling `system.add_data(name, data, /*override*/ true)` as done by LAMMPS was ambiguous between the two overloads.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~
