### PR TITLE
Allow creating the documentation-only classes

### DIFF
--- a/python/metatomic_torch/metatomic/torch/documentation.py
+++ b/python/metatomic_torch/metatomic/torch/documentation.py
@@ -209,7 +209,7 @@ class NeighborListOptions:
         :param requestor: who requested this neighbors list, you can add additional
             requestors later using :py:meth:`add_requestor`
         """
-        raise THIS_CODE_SHOULD_NOT_RUN
+        pass
 
     @property
     def cutoff(self) -> float:
@@ -287,7 +287,7 @@ class ModelOutput:
         explicit_gradients: List[str] = [],  # noqa B006
         description: str = "",
     ):
-        raise THIS_CODE_SHOULD_NOT_RUN
+        pass
 
     @property
     def quantity(self) -> str:
@@ -360,7 +360,7 @@ class ModelCapabilities:
         supported_devices: List[str] = [],  # noqa B006
         dtype: str = "",
     ):
-        raise THIS_CODE_SHOULD_NOT_RUN
+        pass
 
     @property
     def outputs(self) -> Dict[str, ModelOutput]:
@@ -445,7 +445,7 @@ class ModelEvaluationOptions:
         outputs: Dict[str, ModelOutput] = {},  # noqa B006
         selected_atoms: Optional[Labels] = None,
     ):
-        raise THIS_CODE_SHOULD_NOT_RUN
+        pass
 
     @property
     def length_unit(self) -> str:
@@ -488,7 +488,7 @@ class ModelMetadata:
         references: Dict[str, List[str]] = {},  # noqa: B006
         extra: Dict[str, str] = {},  # noqa: B006
     ):
-        raise THIS_CODE_SHOULD_NOT_RUN
+        pass
 
     name: str
     """Name of this model"""


### PR DESCRIPTION
Downstream code might create these at the top level, so erroring in the `__init__` means that is it not even possible to import the package for documentation.

xref https://github.com/metatensor/metatrain/pull/1144

@sofiia-chorna can you try building the docs with this PR?

# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [x] Documentation updated (for new features)?
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~
