### PR TITLE
Separate C++ and C API tests

### DIFF
--- a/metatomic-core/tests/CMakeLists.txt
+++ b/metatomic-core/tests/CMakeLists.txt
@@ -65,13 +65,11 @@ else()
     set(METATENSOR_DIR "")
 endif()
 
-file(GLOB ALL_TESTS *.cpp)
-foreach(_file_ ${ALL_TESTS})
-    get_filename_component(_name_ ${_file_} NAME_WE)
-    add_executable(${_name_} ${_file_})
-    target_link_libraries(${_name_} metatomic catch)
+function(metatomic_add_test source target)
+    add_executable(${target} ${source})
+    target_link_libraries(${target} metatomic catch)
 
-    set_target_properties(${_name_} PROPERTIES
+    set_target_properties(${target} PROPERTIES
         # Ensure that the binaries find the right shared library.
         #
         # Without this, when configuring with cmake before the library is built,
@@ -81,19 +79,31 @@ foreach(_file_ ${ALL_TESTS})
         NO_SYSTEM_FROM_IMPORTED ON
     )
 
-    target_compile_definitions(${_name_} PRIVATE PLUGIN_DIR="$<TARGET_FILE_DIR:test-c-plugin>")
+    target_compile_definitions(${target} PRIVATE PLUGIN_DIR="$<TARGET_FILE_DIR:test-c-plugin>")
 
     add_test(
-        NAME ${_name_}
-        COMMAND ${TEST_COMMAND} $<TARGET_FILE:${_name_}>
+        NAME ${target}
+        COMMAND ${TEST_COMMAND} $<TARGET_FILE:${target}>
     )
 
     if(WIN32)
         # We need to set the path to allow access to metatomic.dll and
         # metatensor.dll. This does a similar job to the BUILD_RPATH above.
         STRING(REPLACE ";" "\\;" PATH_STRING "$ENV{PATH}")
-        set_tests_properties(${_name_} PROPERTIES
+        set_tests_properties(${target} PROPERTIES
             ENVIRONMENT "PATH=${PATH_STRING}\;$<TARGET_FILE_DIR:metatomic>\;${METATENSOR_DIR}"
         )
     endif()
+endfunction()
+
+file(GLOB ALL_TESTS *.cpp)
+foreach(_file_ ${ALL_TESTS})
+    get_filename_component(_name_ ${_file_} NAME_WE)
+    metatomic_add_test(${_file_} ${_name_})
+endforeach()
+
+file(GLOB ALL_CPP_TESTS cxx/*.cpp)
+foreach(_file_ ${ALL_CPP_TESTS})
+    get_filename_component(_name_ ${_file_} NAME_WE)
+    metatomic_add_test(${_file_} "cxx-${_name_}")
 endforeach()

--- a/metatomic-core/tests/cxx/misc.cpp
+++ b/metatomic-core/tests/cxx/misc.cpp
@@ -1,0 +1,64 @@
+#include <catch.hpp>
+
+#include "metatomic.hpp"
+
+
+TEST_CASE("unit conversion factor") {
+    // same unit -> factor = 1.0
+    auto factor = metatomic::unit_conversion_factor("m", "m");
+    CHECK(factor == 1.0);
+
+    // kJ/mol -> eV
+    factor = metatomic::unit_conversion_factor("kJ/mol", "eV");
+    CHECK(factor == Approx(0.010364269656262174).epsilon(1e-15));
+
+    REQUIRE_THROWS_WITH(
+        metatomic::unit_conversion_factor("m", "kg"),
+        "invalid parameter: dimension mismatch in unit conversion: "
+        "'m' has dimension [L] but 'kg' has dimension [M]"
+    );
+}
+
+
+TEST_CASE("metatdata formatting") {
+    std::string json =R"({
+    "type": "metatomic_model_metadata",
+    "name": "name",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation.",
+    "authors": ["Short author", "Some extremely long author that will take more than one line in the printed output"],
+    "references": {
+        "architecture": ["ref-2", "ref-3"],
+        "model": ["a very long reference that will take more than one line in the printed output"],
+        "implementation": []
+    },
+    "extra": {}
+})";
+
+    const auto* expected = R"(This is the name model
+======================
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+nostrud exercitation.
+
+Model authors
+-------------
+
+- Short author
+- Some extremely long author that will take more than one line in the printed
+  output
+
+Model references
+----------------
+
+Please cite the following references when using this model:
+- about this specific model:
+  * a very long reference that will take more than one line in the printed
+    output
+- about the architecture of this model:
+  * ref-2
+  * ref-3
+)";
+
+    CHECK(metatomic::format_metadata(json) == expected);
+}

--- a/metatomic-core/tests/cxx/plugins.cpp
+++ b/metatomic-core/tests/cxx/plugins.cpp
@@ -1,0 +1,25 @@
+#include <catch.hpp>
+
+#include "metatomic.hpp"
+
+
+TEST_CASE("Load plugins") {
+    metatomic::load_plugin(PLUGIN_DIR "/test-c-plugin.so");
+
+    REQUIRE_THROWS_WITH(
+        metatomic::load_model("some_model", "{}", "test-c-plugin"),
+        "invalid parameter: failed to load model from 'some_model': plugin 'test-c-plugin' could not load the model"
+    );
+
+    REQUIRE_THROWS_WITH(
+        metatomic::load_model("some_model"),
+        "invalid parameter: failed to load model from 'some_model': tried the "
+        "following plugins, but none could load the model: test-c-plugin"
+    );
+
+    REQUIRE_THROWS_WITH(
+        metatomic::load_plugin(PLUGIN_DIR "/bad-abi-plugin.so"),
+        "invalid parameter: can not register plugin 'bad-abi-plugin': "
+        "plugin ABI version is 2, but metatomic expects 1"
+    );
+}

--- a/metatomic-core/tests/misc.cpp
+++ b/metatomic-core/tests/misc.cpp
@@ -3,7 +3,6 @@
 #include <catch.hpp>
 
 #include "metatomic.h"
-#include "metatomic.hpp"
 
 
 TEST_CASE("Version macros") {
@@ -50,47 +49,28 @@ TEST_CASE("mta_string_t") {
 }
 
 TEST_CASE("unit conversion factor") {
-    SECTION("C API") {
-        double factor = 0.0;
+    double factor = 0.0;
 
-        // same unit -> factor = 1.0
-        auto status = mta_unit_conversion_factor("m", "m", &factor);
-        REQUIRE(status == MTA_SUCCESS);
-        CHECK(factor == 1.0);
+    // same unit -> factor = 1.0
+    auto status = mta_unit_conversion_factor("m", "m", &factor);
+    REQUIRE(status == MTA_SUCCESS);
+    CHECK(factor == 1.0);
 
-        // kJ/mol -> eV
-        CHECK(mta_unit_conversion_factor("kJ/mol", "eV", &factor) == MTA_SUCCESS);
-        CHECK(factor == Approx(0.010364269656262174).epsilon(1e-15));
+    // kJ/mol -> eV
+    CHECK(mta_unit_conversion_factor("kJ/mol", "eV", &factor) == MTA_SUCCESS);
+    CHECK(factor == Approx(0.010364269656262174).epsilon(1e-15));
 
-        // dimension mismatch -> error
-        status = mta_unit_conversion_factor("m", "kg", &factor);
-        REQUIRE(status != MTA_SUCCESS);
+    // dimension mismatch -> error
+    status = mta_unit_conversion_factor("m", "kg", &factor);
+    REQUIRE(status != MTA_SUCCESS);
 
-        const char* error_msg = nullptr;
-        mta_last_error(&error_msg, nullptr, nullptr);
-        CHECK(std::string(error_msg) ==
-            "invalid parameter: dimension mismatch in unit conversion: "
-            "'m' has dimension [L] but 'kg' has dimension [M]"
-        );
-    }
-
-    SECTION("C++ API") {
-        // same unit -> factor = 1.0
-        auto factor = metatomic::unit_conversion_factor("m", "m");
-        CHECK(factor == 1.0);
-
-        // kJ/mol -> eV
-        factor = metatomic::unit_conversion_factor("kJ/mol", "eV");
-        CHECK(factor == Approx(0.010364269656262174).epsilon(1e-15));
-
-        REQUIRE_THROWS_WITH(
-            metatomic::unit_conversion_factor("m", "kg"),
-            "invalid parameter: dimension mismatch in unit conversion: "
-            "'m' has dimension [L] but 'kg' has dimension [M]"
-        );
-    }
+    const char* error_msg = nullptr;
+    mta_last_error(&error_msg, nullptr, nullptr);
+    CHECK(std::string(error_msg) ==
+        "invalid parameter: dimension mismatch in unit conversion: "
+        "'m' has dimension [L] but 'kg' has dimension [M]"
+    );
 }
-
 
 TEST_CASE("metatdata formatting") {
     std::string json =R"({
@@ -105,6 +85,7 @@ TEST_CASE("metatdata formatting") {
     },
     "extra": {}
 })";
+
     const auto* expected = R"(This is the name model
 ======================
 
@@ -131,17 +112,10 @@ Please cite the following references when using this model:
   * ref-3
 )";
 
-    SECTION("C API") {
-        auto* mta_string = mta_string_create("");
-        REQUIRE(mta_string != nullptr);
-        auto status = mta_format_metadata(json.c_str(), &mta_string);
-        REQUIRE(status == MTA_SUCCESS);
-        CHECK(std::string(mta_string_view(mta_string)) == expected);
-        mta_string_free(mta_string);
-    }
-
-    SECTION("C++ API") {
-        auto result = metatomic::format_metadata(json);
-        CHECK(result == expected);
-    }
+    auto* mta_string = mta_string_create("");
+    REQUIRE(mta_string != nullptr);
+    auto status = mta_format_metadata(json.c_str(), &mta_string);
+    REQUIRE(status == MTA_SUCCESS);
+    CHECK(std::string(mta_string_view(mta_string)) == expected);
+    mta_string_free(mta_string);
 }

--- a/metatomic-core/tests/plugins.cpp
+++ b/metatomic-core/tests/plugins.cpp
@@ -1,71 +1,49 @@
 #include <catch.hpp>
 
 #include "metatomic.h"
-#include "metatomic.hpp"
 
 
 TEST_CASE("Load plugins") {
-    SECTION("C API") {
-        auto status = mta_load_plugin(PLUGIN_DIR "/test-c-plugin.so");
-        CHECK(status == MTA_SUCCESS);
+    auto status = mta_load_plugin(PLUGIN_DIR "/test-c-plugin.so");
+    CHECK(status == MTA_SUCCESS);
 
-        const char* error_message;
-        const char* error_origin;
+    const char* error_message;
+    const char* error_origin;
 
-        struct mta_model_t model;
-        status = mta_load_model("some_model", "{}", "test-c-plugin", &model);
-        CHECK(status == MTA_INVALID_PARAMETER_ERROR);
+    struct mta_model_t model;
+    status = mta_load_model("some_model", "{}", "test-c-plugin", &model);
+    CHECK(status == MTA_INVALID_PARAMETER_ERROR);
 
-        status = mta_last_error(&error_message, &error_origin, nullptr);
-        REQUIRE(status == MTA_SUCCESS);
+    status = mta_last_error(&error_message, &error_origin, nullptr);
+    REQUIRE(status == MTA_SUCCESS);
 
-        CHECK(std::string(error_origin) == "metatomic-core");
-        CHECK(std::string(error_message) == (
-            "invalid parameter: failed to load model from 'some_model': plugin 'test-c-plugin' could not load the model"
-        ));
+    CHECK(std::string(error_origin) == "metatomic-core");
+    CHECK(std::string(error_message) == (
+        "invalid parameter: failed to load model from 'some_model': plugin 'test-c-plugin' could not load the model"
+    ));
 
-        status = mta_load_model("some_model", "{}", nullptr, &model);
-        CHECK(status == MTA_INVALID_PARAMETER_ERROR);
+    status = mta_load_model("some_model", "{}", nullptr, &model);
+    CHECK(status == MTA_INVALID_PARAMETER_ERROR);
 
-        status = mta_last_error(&error_message, &error_origin, nullptr);
-        REQUIRE(status == MTA_SUCCESS);
+    status = mta_last_error(&error_message, &error_origin, nullptr);
+    REQUIRE(status == MTA_SUCCESS);
 
-        CHECK(std::string(error_origin) == "metatomic-core");
-        CHECK(std::string(error_message) == (
-            "invalid parameter: failed to load model from 'some_model': tried the "
-            "following plugins, but none could load the model: test-c-plugin"
-        ));
+    CHECK(std::string(error_origin) == "metatomic-core");
+    CHECK(std::string(error_message) == (
+        "invalid parameter: failed to load model from 'some_model': tried the "
+        "following plugins, but none could load the model: test-c-plugin"
+    ));
 
 
-        status = mta_load_plugin(PLUGIN_DIR "/bad-abi-plugin.so");
-        CHECK(status == MTA_INVALID_PARAMETER_ERROR);
+    status = mta_load_plugin(PLUGIN_DIR "/bad-abi-plugin.so");
+    CHECK(status == MTA_INVALID_PARAMETER_ERROR);
 
-        status = mta_last_error(&error_message, &error_origin, nullptr);
-        REQUIRE(status == MTA_SUCCESS);
+    status = mta_last_error(&error_message, &error_origin, nullptr);
+    REQUIRE(status == MTA_SUCCESS);
 
-        CHECK(std::string(error_origin) == "metatomic-core");
-        CHECK(std::string(error_message) == (
-            "invalid parameter: can not register plugin 'bad-abi-plugin': "
-            "plugin ABI version is 2, but metatomic expects 1"
-        ));
-    }
-
-    SECTION("C++ API") {
-        REQUIRE_THROWS_WITH(
-            metatomic::load_model("some_model", "{}", "test-c-plugin"),
-            "invalid parameter: failed to load model from 'some_model': plugin 'test-c-plugin' could not load the model"
-        );
-
-        REQUIRE_THROWS_WITH(
-            metatomic::load_model("some_model"),
-            "invalid parameter: failed to load model from 'some_model': tried the "
-            "following plugins, but none could load the model: test-c-plugin"
-        );
-
-        REQUIRE_THROWS_WITH(
-            metatomic::load_plugin(PLUGIN_DIR "/bad-abi-plugin.so"),
-            "invalid parameter: can not register plugin 'bad-abi-plugin': "
-            "plugin ABI version is 2, but metatomic expects 1"
-        );
-    }
+    CHECK(std::string(error_origin) == "metatomic-core");
+    CHECK(std::string(error_message) == (
+        "invalid parameter: can not register plugin 'bad-abi-plugin': "
+        "plugin ABI version is 2, but metatomic expects 1"
+    ));
 }


### PR DESCRIPTION
As we add more and more tests, it will get painful to have both API in the same file.



# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] ~Documentation updated (for new features)?~
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~
