### PR TITLE
Support explicit_gradients in run_model to compute energy_ensemble Jacobians

### DIFF
--- a/python/metatomic_ase/CHANGELOG.md
+++ b/python/metatomic_ase/CHANGELOG.md
@@ -6,9 +6,19 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/metatensor/metatomic/)
 
-<!-- Possible sections
 ### Added
 
+- `MetatomicCalculator` now resolves and exposes an `energy_ensemble` output
+  (respecting `variants`), like it already does for `energy` and
+  `energy_uncertainty`.
+- `MetatomicCalculator.run_model()` now makes `positions` and `cell` require grad
+  before building the `System` whenever any requested output has a non-empty
+  `explicit_gradients`, so models that compute their own gradients (e.g. an
+  ensemble of forces/stress alongside `energy_ensemble`) can do so through the
+  standard `run_model()` call, without any extra autograd handling on the
+  caller's side.
+
+<!-- Possible sections
 ### Fixed
 
 ### Changed

--- a/python/metatomic_ase/src/metatomic_ase/_calculator.py
+++ b/python/metatomic_ase/src/metatomic_ase/_calculator.py
@@ -212,10 +212,10 @@ class MetatomicCalculator(ase.calculators.calculator.Calculator):
             the options in the model's ``supported_device`` in order.
         :param variants: dictionary mapping output names to a variant that should be
             used for the calculations (e.g. ``{"energy": "PBE"}``). If ``"energy"`` is
-            set to a variant also the uncertainty and non conservative outputs will be
-            taken from this variant. This behaviour can be overriden by setting the
-            corresponding keys explicitly to ``None`` or to another value (e.g.
-            ``{"energy_uncertainty": "r2scan"}``).
+            set to a variant also the uncertainty, energy ensemble, and non conservative
+            outputs will be taken from this variant. This behaviour can be overriden by
+            setting the corresponding keys explicitly to ``None`` or to another value
+            (e.g. ``{"energy_uncertainty": "r2scan"}``).
         :param non_conservative: controls which outputs are obtained directly from the
             model rather than via autograd on the energy. Accepted values are:
 
@@ -314,6 +314,7 @@ class MetatomicCalculator(ase.calculators.calculator.Calculator):
             for key in [
                 "energy",
                 "energy_uncertainty",
+                "energy_ensemble",
                 "non_conservative_force",
                 "non_conservative_stress",
             ]
@@ -355,6 +356,17 @@ class MetatomicCalculator(ase.calculators.calculator.Calculator):
             )
         else:
             self._energy_uq_key = None
+
+        has_energy_ensemble = any(
+            "energy_ensemble" == key or key.startswith("energy_ensemble/")
+            for key in outputs.keys()
+        )
+        if has_energy_ensemble:
+            self._energy_ensemble_key = pick_output(
+                "energy_ensemble", outputs, resolved_variants["energy_ensemble"]
+            )
+        else:
+            self._energy_ensemble_key = None
 
         self._nc_forces = non_conservative in (True, "forces")
         self._nc_stress = non_conservative in (True, "stress")
@@ -494,6 +506,12 @@ class MetatomicCalculator(ase.calculators.calculator.Calculator):
         :py:class:`ase.Atoms` when the model can compute outputs not supported by the
         standard ASE's calculator interface.
 
+        If any of the requested ``outputs`` has a non-empty
+        :py:attr:`~metatomic.torch.ModelOutput.explicit_gradients`, ``positions`` and
+        ``cell`` are made to require grad before building the corresponding
+        :py:class:`~metatomic.torch.System`, so that the model can compute and attach
+        those gradients itself.
+
         All the parameters have the same meaning as the corresponding ones in
         :py:meth:`metatomic.torch.ModelInterface.forward`.
 
@@ -507,11 +525,18 @@ class MetatomicCalculator(ase.calculators.calculator.Calculator):
         else:
             atoms_list = atoms
 
+        want_gradients = any(
+            len(output.explicit_gradients) > 0 for output in outputs.values()
+        )
+
         systems = []
         for atoms in atoms_list:
             types, positions, cell, pbc = _ase_to_torch_data(
                 atoms=atoms, dtype=self._dtype, device=self._device
             )
+            if want_gradients:
+                positions.requires_grad_(True)
+                cell.requires_grad_(True)
             system = System(types, positions, cell, pbc)
             # Get the additional inputs requested by the model
             requested_inputs = self._model.requested_inputs(use_new_names=True)

--- a/python/metatomic_ase/tests/calculator.py
+++ b/python/metatomic_ase/tests/calculator.py
@@ -1123,3 +1123,177 @@ def test_mixed_pbc(model, device, dtype):
     )
     atoms.get_potential_energy()
     atoms.get_forces()
+
+
+class _QuadraticGradientModel(torch.nn.Module):
+    """Toy model computing ``E = 0.5 * sum(positions**2) + 0.1 * sum(cell**2)``.
+
+    This has no physical meaning; it only needs to be an arbitrary, fully
+    differentiable function of both positions and cell, so that models computing
+    their own "positions"/"strain" gradients (via ``explicit_gradients``) can be
+    tested against a known analytical answer, independently of ``run_model()``.
+    """
+
+    def forward(
+        self,
+        systems: List[System],
+        outputs: Dict[str, ModelOutput],
+        selected_atoms: Optional[Labels] = None,
+    ) -> Dict[str, TensorMap]:
+        request = outputs["energy"]
+        all_positions = [system.positions for system in systems]
+        all_cells = [system.cell for system in systems]
+
+        energies = torch.stack(
+            [
+                0.5 * (positions**2).sum() + 0.1 * (cell**2).sum()
+                for positions, cell in zip(all_positions, all_cells, strict=True)
+            ]
+        )
+
+        block = TensorBlock(
+            values=energies.reshape(-1, 1),
+            samples=Labels(["system"], torch.arange(len(systems)).reshape(-1, 1)),
+            components=[],
+            properties=Labels("energy", torch.tensor([[0]])),
+        )
+
+        if len(request.explicit_gradients) > 0:
+            n_systems = len(systems)
+            grads = torch.autograd.grad([energies.sum()], all_positions + all_cells)
+
+            if "positions" in request.explicit_gradients:
+                n_atoms_per_system = [p.shape[0] for p in all_positions]
+                sample_col = torch.repeat_interleave(
+                    torch.arange(n_systems), torch.tensor(n_atoms_per_system)
+                )
+                atom_col = torch.cat([torch.arange(n) for n in n_atoms_per_system])
+                block.add_gradient(
+                    "positions",
+                    TensorBlock(
+                        values=torch.cat(grads[:n_systems]).reshape(-1, 3, 1),
+                        samples=Labels(
+                            ["sample", "system", "atom"],
+                            torch.stack([sample_col, sample_col, atom_col], dim=1),
+                        ),
+                        components=[Labels(["xyz"], torch.tensor([[0], [1], [2]]))],
+                        properties=block.properties,
+                    ),
+                )
+
+            if "strain" in request.explicit_gradients:
+                xyz = torch.tensor([[0], [1], [2]])
+                strain_values = torch.stack(
+                    [
+                        all_positions[s].detach().t() @ grads[s]
+                        + all_cells[s].detach().t() @ grads[n_systems + s]
+                        for s in range(n_systems)
+                    ]
+                )
+                block.add_gradient(
+                    "strain",
+                    TensorBlock(
+                        values=strain_values.reshape(n_systems, 3, 3, 1),
+                        samples=Labels(
+                            ["sample"], torch.arange(n_systems).reshape(-1, 1)
+                        ),
+                        components=[Labels(["xyz_1"], xyz), Labels(["xyz_2"], xyz)],
+                        properties=block.properties,
+                    ),
+                )
+
+        return {"energy": TensorMap(Labels("_", torch.tensor([[0]])), [block])}
+
+
+def _quadratic_gradient_calculator():
+    capabilities = ModelCapabilities(
+        outputs={
+            "energy": ModelOutput(
+                unit="eV",
+                sample_kind="system",
+                explicit_gradients=["positions", "strain"],
+            ),
+        },
+        atomic_types=[28],
+        interaction_range=0.0,
+        length_unit="Angstrom",
+        supported_devices=["cpu"],
+        dtype="float64",
+    )
+    model = AtomisticModel(
+        _QuadraticGradientModel().eval(), ModelMetadata(), capabilities
+    )
+    return MetatomicCalculator(model, check_consistency=True)
+
+
+def _expected_quadratic_gradients(atoms_list):
+    forces = []
+    strains = []
+    for atoms in atoms_list:
+        positions = torch.tensor(atoms.positions, dtype=torch.float64)
+        cell = torch.tensor(np.array(atoms.cell), dtype=torch.float64)
+        forces.append(positions)
+        strains.append(positions.t() @ positions + cell.t() @ (0.2 * cell))
+    return torch.cat(forces), torch.stack(strains)
+
+
+def test_run_model_explicit_gradients_not_requested(atoms):
+    """Without `explicit_gradients`, `run_model()` must not build differentiable
+    inputs: positions/cell stay plain tensors, and no gradients are attached."""
+    calculator = _quadratic_gradient_calculator()
+    result = calculator.run_model(
+        atoms, {"energy": ModelOutput(unit="eV", sample_kind="system")}
+    )
+    block = result["energy"].block()
+    assert block.values.requires_grad is False
+    assert block.gradients_list() == []
+
+
+def test_run_model_explicit_gradients(atoms):
+    calculator = _quadratic_gradient_calculator()
+    result = calculator.run_model(
+        atoms,
+        {
+            "energy": ModelOutput(
+                unit="eV",
+                sample_kind="system",
+                explicit_gradients=["positions", "strain"],
+            )
+        },
+    )
+    block = result["energy"].block()
+
+    expected_forces, expected_strain = _expected_quadratic_gradients([atoms])
+
+    forces = block.gradient("positions").values.detach().reshape(-1, 3)
+    assert torch.allclose(forces, expected_forces)
+
+    strain = block.gradient("strain").values.detach().reshape(3, 3)
+    assert torch.allclose(strain, expected_strain[0])
+
+
+def test_run_model_explicit_gradients_batch(atoms):
+    """The same, for a batch of (independent) structures at once."""
+    atoms_2 = atoms.copy()
+    atoms_2.positions += 0.1
+
+    calculator = _quadratic_gradient_calculator()
+    result = calculator.run_model(
+        [atoms, atoms_2],
+        {
+            "energy": ModelOutput(
+                unit="eV",
+                sample_kind="system",
+                explicit_gradients=["positions", "strain"],
+            )
+        },
+    )
+    block = result["energy"].block()
+
+    expected_forces, expected_strain = _expected_quadratic_gradients([atoms, atoms_2])
+
+    forces = block.gradient("positions").values.detach().reshape(-1, 3)
+    assert torch.allclose(forces, expected_forces)
+
+    strain = block.gradient("strain").values.detach().reshape(2, 3, 3)
+    assert torch.allclose(strain, expected_strain)

--- a/python/metatomic_ase/tests/energy_ensemble.py
+++ b/python/metatomic_ase/tests/energy_ensemble.py
@@ -1,0 +1,151 @@
+from typing import Dict, List, Optional
+
+import ase.build
+import numpy as np
+import pytest
+import torch
+from metatensor.torch import Labels, TensorBlock, TensorMap
+
+import metatomic_lj_test
+from metatomic.torch import (
+    AtomisticModel,
+    ModelCapabilities,
+    ModelMetadata,
+    ModelOutput,
+    System,
+)
+from metatomic_ase import MetatomicCalculator
+
+
+CUTOFF = 5.0
+SIGMA = 1.5808
+EPSILON = 0.1729
+
+
+@pytest.fixture
+def model():
+    return metatomic_lj_test.lennard_jones_model(
+        atomic_type=28,
+        cutoff=CUTOFF,
+        sigma=SIGMA,
+        epsilon=EPSILON,
+        length_unit="Angstrom",
+        energy_unit="eV",
+        with_extension=False,
+    )
+
+
+@pytest.fixture
+def atoms():
+    np.random.seed(0xDEADBEEF)
+
+    atoms = ase.build.make_supercell(
+        ase.build.bulk("Ni", "fcc", a=3.6, cubic=True), 2 * np.eye(3)
+    )
+    atoms.positions += 0.2 * np.random.rand(*atoms.positions.shape)
+
+    return atoms
+
+
+def test_resolves_energy_ensemble_key(model, atoms):
+    calc = MetatomicCalculator(
+        model, device="cpu", check_consistency=True, uncertainty_threshold=None
+    )
+    assert calc._energy_ensemble_key == "energy_ensemble"
+
+    # this reference model requires "energy" to be requested alongside
+    # "energy_ensemble"; its value is unused here
+    result = calc.run_model(
+        atoms,
+        {
+            "energy_ensemble": ModelOutput(unit="eV", sample_kind="system"),
+            "energy": ModelOutput(unit="eV", sample_kind="system"),
+        },
+    )
+    assert result["energy_ensemble"].block().values.shape == (1, 16)
+
+
+def test_variant(model, atoms):
+    calc_doubled = MetatomicCalculator(
+        model,
+        device="cpu",
+        check_consistency=True,
+        variants={"energy": "doubled"},
+        uncertainty_threshold=None,
+    )
+    assert calc_doubled._energy_ensemble_key == "energy_ensemble/doubled"
+
+    calc = MetatomicCalculator(
+        model, device="cpu", check_consistency=True, uncertainty_threshold=None
+    )
+    result = calc.run_model(
+        atoms,
+        {
+            "energy_ensemble": ModelOutput(unit="eV", sample_kind="system"),
+            "energy": ModelOutput(unit="eV", sample_kind="system"),
+        },
+    )
+    result_doubled = calc_doubled.run_model(
+        atoms,
+        {
+            "energy_ensemble/doubled": ModelOutput(unit="eV", sample_kind="system"),
+            "energy/doubled": ModelOutput(unit="eV", sample_kind="system"),
+        },
+    )
+
+    assert torch.allclose(
+        2.0 * result["energy_ensemble"].block().values,
+        result_doubled["energy_ensemble/doubled"].block().values,
+        atol=1e-4,
+    )
+
+
+class _EnergyOnlyModel(torch.nn.Module):
+    """Minimal model exposing only a plain 'energy' output, no 'energy_ensemble'."""
+
+    def forward(
+        self,
+        systems: List[System],
+        outputs: Dict[str, ModelOutput],
+        selected_atoms: Optional[Labels],
+    ) -> Dict[str, TensorMap]:
+        device = systems[0].device
+        dtype = systems[0].positions.dtype
+        samples = Labels(
+            ["system"], torch.arange(len(systems), device=device).reshape(-1, 1)
+        )
+        block = TensorBlock(
+            values=torch.zeros((len(systems), 1), dtype=dtype, device=device),
+            samples=samples,
+            components=[],
+            properties=Labels("energy", torch.tensor([[0]], device=device)),
+        )
+        return {"energy": TensorMap(Labels("_", torch.tensor([[0]])), [block])}
+
+
+@pytest.fixture
+def model_without_ensemble():
+    return AtomisticModel(
+        _EnergyOnlyModel().eval(),
+        ModelMetadata(),
+        ModelCapabilities(
+            outputs={
+                "energy": ModelOutput(sample_kind="system", unit="eV"),
+            },
+            atomic_types=[28],
+            interaction_range=0.0,
+            length_unit="Angstrom",
+            supported_devices=["cpu"],
+            dtype="float64",
+        ),
+    )
+
+
+def test_missing_energy_ensemble_output(model_without_ensemble):
+    calc = MetatomicCalculator(
+        model_without_ensemble,
+        device="cpu",
+        check_consistency=True,
+        uncertainty_threshold=None,
+    )
+    assert calc._energy_ensemble_key is None


### PR DESCRIPTION
Support models that can compute ensemble forces and stresses with `explicit_gradients`.

Added also some tests that implement artificial gradients to check functionality.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
