### PR TITLE
Review and Optimize SymmetrizedModel on top of #119

### DIFF
--- a/docs/src/engines/ase.rst
+++ b/docs/src/engines/ase.rst
@@ -71,9 +71,25 @@ whose bandwidth can be the model-response bandwidth plus the target rank.
 The calculator uses a Lebedev rule of degree at least :math:`2L` and
 :math:`2L+1` in-plane rotations, as required by the product-quadrature theorem.
 The largest supported ``l_max`` is 65. Increase it until every requested mean
-and standard deviation has converged. With ``l_max=0`` there is no proper
-rotational average; identity and inversion are still averaged when
-``include_inversion=True``.
+and standard deviation has converged. With ``include_inversion=True``, every
+proper grid rotation is paired with its inverted partner, adding the full
+improper coset. With ``l_max=0`` there is no proper rotational average; only
+identity and inversion are averaged in this case.
+
+ASE stores Cartesian vectors and cell vectors by row. For an active operation
+:math:`R`, the calculator constructs each orbit member as
+
+.. math::
+
+    r_R = r R^\mathrm{T}, \qquad
+    H_R = H R^\mathrm{T}, \qquad
+    v_R = v R^\mathrm{T},
+
+where :math:`v` is any requested polar-vector input. Predictions are returned
+to the input frame before averaging: forces contribute :math:`F_R R`, stress
+contributes :math:`R^\mathrm{T} S_R R`, and scalar energies are unchanged. The
+rotation does not wrap positions into the cell, so the identity operation
+preserves the supplied Cartesian coordinates and lattice images exactly.
 
 ``batch_size`` limits the rotated :py:class:`ase.Atoms` objects and predictions
 in one model call, but does not change the grid or total work. Each batch is
@@ -98,8 +114,9 @@ Requested ASE inputs
 --------------------
 
 Polar vector inputs requested by the model, such as momenta and velocities, are
-rotated with the geometry. The same applies to requested real numerical or
-Boolean three-component ``ase::arrays::*`` inputs. The reserved
+rotated with the geometry. Every requested real numerical or Boolean
+``(n_atoms, 3)`` ``ase::arrays::*`` input is interpreted as a polar vector. All
+other requested per-atom arrays are treated as scalars. The reserved
 ``ase::arrays::positions`` alias is rejected: models must use
 ``System.positions`` so position and strain derivatives remain connected.
 Unrequested arrays do not affect the averaging orbit.
@@ -115,6 +132,11 @@ axial parity is not represented by the ``xyz`` TensorMap produced by the ASE
 converter, so including inversion would make the ASE and TensorMap actions
 inconsistent.
 
+During space-group filtering, scalar per-atom inputs must be preserved exactly
+by the induced site permutation. Vector inputs admit only matrix-arithmetic
+round-off, rather than a physical tolerance. ``initial_magmoms`` is the only
+requested ASE input recognized as axial.
+
 Space-group projection
 ----------------------
 
@@ -125,11 +147,14 @@ is active, the retained actions are checked for group closure so the average
 remains an idempotent projector.
 
 For Cartesian row vectors, a fractional rotation :math:`R_f` is converted with
-:math:`Q=A R_f A^{-1}`, where :math:`A` is the transposed ASE cell. Per-atom
-scalars use ``values[permutation]``, forces use
-``forces[permutation] @ Q``, and stress uses ``Q.T @ stress @ Q``. Translations
-therefore enter per-atom outputs through the site permutation. Polar and axial
-inputs are filtered with their corresponding parity.
+:math:`Q=A R_f A^{-1}`, where :math:`A` is the transposed ASE cell. If
+:math:`p(i)` is the original site matched by the image of site :math:`i` under
+:math:`(R_f,t_f)`, one projector term uses ``values[p]`` for per-atom scalars,
+``forces[p] @ Q`` for forces, and ``Q.T @ stress @ Q`` for stress. Translations
+therefore enter per-atom outputs through :math:`p`. Operations with the same
+rotation but different translations are retained as distinct actions whenever
+they induce different permutations. Polar and axial inputs are filtered with
+their corresponding parity.
 
 The current discovery tolerances are ``symprec=1e-6`` and spglib's default
 ``angle_tolerance=-1``.
@@ -137,7 +162,9 @@ The current discovery tolerances are ``symprec=1e-6`` and spglib's default
 Sites are matched by species using minimum-image Cartesian distances. An
 optional periodic index accelerates candidate discovery, while a memory-bounded
 pairwise fallback keeps all supported cells correct; the worst case remains
-quadratic in the same-species population. The retained permutations require
+quadratic in the same-species population. Every retained mapping must be within
+the effective ``symprec`` threshold and form a bijection. The retained
+permutations require
 :math:`O(GN)` storage for :math:`G` actions and :math:`N` atoms, potentially
 :math:`O(N^2)` in highly symmetric supercells. ``batch_size`` does not bound
 this storage, so use a primitive cell or disable space-group projection if it

--- a/docs/src/engines/ase.rst
+++ b/docs/src/engines/ase.rst
@@ -17,32 +17,146 @@ Supported model outputs
 .. py:currentmodule:: metatomic_ase
 
 - the :ref:`energy <energy-quantity>`, non-conservative :ref:`forces
-  <non-conservative-force-quantity>` and :ref:`stress
-  <non-conservative-stress-quantity>` including their :ref:`variants
-  <quantity-variants>` are supported and fully integrated with ASE calculator
-  interface (i.e. :py:meth:`ase.Atoms.get_potential_energy`,
-  :py:meth:`ase.Atoms.get_forces`, …);
-- arbitrary outputs can be computed for any :py:class:`ase.Atoms` using
-  :py:meth:`MetatomicCalculator.run_model`;
+  <non-conservative-force-quantity>`, and :ref:`stress
+  <non-conservative-stress-quantity>`, including their :ref:`variants
+  <quantity-variants>`, are integrated with the ASE calculator interface;
+- arbitrary outputs can be computed for any :py:class:`ase.Atoms` with
+  :py:meth:`MetatomicCalculator.run_model`.
 
+Installation
+^^^^^^^^^^^^
 
-How to install the code
-^^^^^^^^^^^^^^^^^^^^^^^
+Install the calculator with ``pip install metatomic-ase``. Rotational averaging
+with :py:class:`SymmetrizedCalculator` requires SciPy 1.15 or newer when
+``l_max > 0``. Space-group projection requires ``spglib``. For example,
 
-The code is available in the ``metatomic-ase`` package, which can be installed
-using ``pip install metatomic-ase``.
+.. code-block:: bash
 
-How to use the code
-^^^^^^^^^^^^^^^^^^^
+    pip install "scipy>=1.15" spglib
 
-We offer two ASE calculators: :py:class:`metatomic_ase.MetatomicCalculator` is
-the default one, and support all the features described above, while
-:py:class:`metatomic_ase.SymmetrizedCalculator` is a wrapper around the former
-that allows to compute rotationally-averaged energies, forces, and stresses for
-non-equivariant architectures. Both calculators are designed to be used as
-drop-in replacements for any ASE calculator, and can be used in any ASE
-workflow. You can also check the :ref:`corresponding tutorial
-<atomistic-tutorial-md>`.
+Calculators
+^^^^^^^^^^^
+
+:py:class:`MetatomicCalculator` is the standard ASE calculator.
+:py:class:`SymmetrizedCalculator` wraps it and computes finite-quadrature
+rotational averages for total/per-atom energy, forces, and global stress.
+Per-atom stress is not supported.
+
+.. code-block:: python
+
+    from metatomic_ase import MetatomicCalculator, SymmetrizedCalculator
+
+    base = MetatomicCalculator("model.pt")
+    atoms.calc = SymmetrizedCalculator(
+        base,
+        l_max=3,
+        batch_size=16,
+        include_inversion=True,
+    )
+    energy = atoms.get_potential_energy()
+    forces = atoms.get_forces()
+
+Increase ``l_max`` and compare the requested results before using the finite
+average in production.
+
+Quadrature and batching
+-----------------------
+
+``l_max`` is the assumed angular bandwidth :math:`L`. It must cover both the
+model response and target representation (at least 1 for forces and 2 for
+stress), and can not be inferred from output rank alone. For componentwise
+rotational standard deviations it must cover the complete back-rotated response,
+whose bandwidth can be the model-response bandwidth plus the target rank.
+
+The calculator uses a Lebedev rule of degree at least :math:`2L` and
+:math:`2L+1` in-plane rotations, as required by the product-quadrature theorem.
+The largest supported ``l_max`` is 65. Increase it until every requested mean
+and standard deviation has converged. With ``l_max=0`` there is no proper
+rotational average; identity and inversion are still averaged when
+``include_inversion=True``.
+
+``batch_size`` limits the rotated :py:class:`ase.Atoms` objects and predictions
+in one model call, but does not change the grid or total work. Each batch is
+reduced immediately using reference-centered moments, so the live prediction
+payload scales with the batch instead of the full orbit. Quadrature rotations
+and weights are precomputed for the full grid and are not bounded by
+``batch_size``; at ``l_max=65`` they occupy about 58 MiB without inversion and
+about 116 MiB with inversion. Setting ``batch_size=None`` evaluates the full
+grid in one batch.
+
+With ``store_rotational_std=True``, the results include componentwise
+finite-grid diagnostics such as ``energy_rot_std``, ``energies_rot_std``,
+``forces_rot_std``, and ``stress_rot_std`` in the reference frame. Except for a
+single scalar component, these are not the sample- and component-aggregated
+equivariance RMSE returned by
+:py:class:`~metatomic.torch.symmetrized_model.SymmetrizedModel`. Signed Lebedev
+weights can make an under-resolved finite-grid variance negative. The calculator
+clamps only a summation-scale round-off allowance and otherwise asks for a
+larger ``l_max``.
+
+Requested ASE inputs
+--------------------
+
+Polar vector inputs requested by the model, such as momenta and velocities, are
+rotated with the geometry. The same applies to requested real numerical or
+Boolean three-component ``ase::arrays::*`` inputs. The reserved
+``ase::arrays::positions`` alias is rejected: models must use
+``System.positions`` so position and strain derivatives remain connected.
+Unrequested arrays do not affect the averaging orbit.
+
+Requested arrays/info and standard dependencies, including the masses used for
+velocities, participate in ASE cache invalidation. Every requested value must be
+real and finite, and custom ``ase::info::*`` inputs must be scalar. In-place
+changes to requested mutable scalar values also invalidate the cache.
+
+Vector ``initial_magmoms``, including the custom-array alias, are accepted only
+for proper-rotation averaging (``include_inversion=False``). Their physical
+axial parity is not represented by the ``xyz`` TensorMap produced by the ASE
+converter, so including inversion would make the ASE and TensorMap actions
+inconsistent.
+
+Space-group projection
+----------------------
+
+With ``apply_space_group_symmetry=True``, rotations, translations, and atom
+permutations from ``spglib`` are applied after the O(3) average. Operations that
+do not preserve the requested per-atom inputs are discarded. When this filtering
+is active, the retained actions are checked for group closure so the average
+remains an idempotent projector.
+
+For Cartesian row vectors, a fractional rotation :math:`R_f` is converted with
+:math:`Q=A R_f A^{-1}`, where :math:`A` is the transposed ASE cell. Per-atom
+scalars use ``values[permutation]``, forces use
+``forces[permutation] @ Q``, and stress uses ``Q.T @ stress @ Q``. Translations
+therefore enter per-atom outputs through the site permutation. Polar and axial
+inputs are filtered with their corresponding parity.
+
+The current discovery tolerances are ``symprec=1e-6`` and spglib's default
+``angle_tolerance=-1``.
+
+Sites are matched by species using minimum-image Cartesian distances. An
+optional periodic index accelerates candidate discovery, while a memory-bounded
+pairwise fallback keeps all supported cells correct; the worst case remains
+quadratic in the same-species population. The retained permutations require
+:math:`O(GN)` storage for :math:`G` actions and :math:`N` atoms, potentially
+:math:`O(N^2)` in highly symmetric supercells. ``batch_size`` does not bound
+this storage, so use a primitive cell or disable space-group projection if it
+becomes the memory bottleneck.
+
+The space-group projector acts on per-atom energies, forces, and global stress;
+total energy is already scalar. The optional ``*_rot_std`` values describe the
+preceding O(3) orbit and are not space-group projected.
+
+Space-group projection and three-dimensional stress are defined only for
+systems periodic in all three directions. Stress additionally requires a finite,
+non-singular cell. Force evaluation also computes stress for fully periodic
+systems, so this cell check applies to force-only calls there. For systems that
+are not fully periodic, space-group projection is skipped and requesting stress
+raises :py:class:`ase.calculators.calculator.PropertyNotImplementedError`.
+
+Both calculators implement their corresponding ASE properties and can be used
+in workflows that request them. See also the
+:ref:`atomistic tutorial <atomistic-tutorial-md>`.
 
 .. _ase-integration-api:
 

--- a/docs/src/torch/reference/o3.rst
+++ b/docs/src/torch/reference/o3.rst
@@ -3,7 +3,7 @@ O(3) transformations
 
 The :py:mod:`metatomic.torch.o3` module rotates and inverts
 :py:class:`~metatomic.torch.System` and :py:class:`~metatensor.torch.TensorMap`
-objects, for example to generate randomly rotated copies of a structure for data
+objects, for example to generate rotated copies of a structure for data
 augmentation.
 
 .. _o3-conventions:
@@ -11,66 +11,86 @@ augmentation.
 Conventions
 -----------
 
-To transform a :py:class:`~metatensor.torch.TensorBlock`, :py:func:`transform_block`
-and :py:func:`transform_tensor` need to know, for each component axis, whether it
-carries a Cartesian or a spherical tensor. This is inferred from the axis name:
+:py:func:`transform_block` and :py:func:`transform_tensor` infer the tensor
+character of every component axis from its name:
 
-- Cartesian axes are named ``xyz``, or ``xyz_1``, ``xyz_2``, ... for blocks with
-  several Cartesian axes (e.g. rank-2 Cartesian tensors). These are rotated directly
-  with the (3, 3) transformation matrix :math:`R` passed to
-  :py:class:`O3Transformation`, following the usual column-vector convention
-  :math:`v' = R v` (equivalently, since values are stored as rows,
-  ``values_transformed = values @ R.T``).
-- Spherical axes are named ``o3_mu``, or ``o3_mu_1``, ``o3_mu_2``, ... They are rotated
-  with the real Wigner-D matrix for the angular momentum ``o3_lambda`` (respectively
-  ``o3_lambda_1``, ``o3_lambda_2``, ...) found in the block's key. Real, rather than
-  complex, spherical harmonics are used throughout, matching the convention used
-  elsewhere in metatomic and metatensor for spherical targets.
+- Cartesian axes are named ``xyz`` or ``xyz_1`` through ``xyz_9``. They use the
+  :math:`(3,3)` matrix :math:`R` passed to :py:class:`O3Transformation` with the
+  column-vector convention :math:`v'=Rv`; because values are stored as rows,
+  this is ``values @ R.T``. Their component labels must be ``[0, 1, 2]`` in
+  :math:`x,y,z` order.
+- Spherical axes are named ``o3_mu`` or ``o3_mu_1`` through ``o3_mu_9``. Their
+  angular momentum and parity are read from the matching ``o3_lambda*`` and
+  ``o3_sigma*`` block-key dimensions, and they use real Wigner-D matrices. For
+  angular momentum :math:`\ell`, their labels must be the ascending sequence
+  :math:`-\ell,\ldots,+\ell`.
+
+The unsuffixed name plus suffixes ``_1`` through ``_9`` allow at most ten
+component axes in one value or gradient block. Blocks with no component axes
+are treated as invariant scalars; an explicit :math:`\ell=0` spherical block
+may instead carry a one-entry ``o3_mu*`` axis. Unrecognized names are rejected
+instead of being left unchanged.
 
 Wigner-D matrices
 ~~~~~~~~~~~~~~~~~
 
-Complex Wigner-D matrices are computed by the `wigners <https://github.com/luthaf/wigners>`_
-package, using the convention
+Complex Wigner-D matrices are computed by the `wigners
+<https://github.com/luthaf/wigners>`_ package using
 
 .. math::
 
-    D^{\ell}_{m',m}(\alpha, \beta, \gamma) = \langle \ell, m' |
-        e^{-i J_z \alpha} e^{-i J_y \beta} e^{-i J_z \gamma} | \ell, m \rangle,
+    D^{\ell}_{m',m}(\alpha, \beta, \gamma)
+    = \langle \ell,m'|
+      e^{-iJ_z\alpha}e^{-iJ_y\beta}e^{-iJ_z\gamma}
+      |\ell,m\rangle.
 
-with ZYZ Euler angles :math:`(\alpha, \beta, \gamma)` extracted from the proper part of
-:math:`R`, i.e. from :math:`R` itself when :math:`\det R = 1`, or from :math:`-R` when
-:math:`\det R = -1`, such that this proper part equals :math:`R_z(\alpha) R_y(\beta)
-R_z(\gamma)`.
+The ZYZ angles satisfy
+:math:`R_+(\alpha,\beta,\gamma)=R_z(\alpha)R_y(\beta)R_z(\gamma)`, where the
+proper part is :math:`R_+=R` for :math:`\det R=1` and :math:`R_+=-R` for
+:math:`\det R=-1`.
 
-These are then converted to real Wigner-D matrices through the unitary
-change of basis :math:`T` mapping complex spherical harmonics
-:math:`Y_{\ell}^{m}` to real ones:
+The complex harmonics are converted to the real convention used by metatomic
+and metatensor:
 
 .. math::
 
-    Y_{\ell, m}^{\text{real}} = \begin{cases}
-        \dfrac{1}{\sqrt{2}} \left( Y_{\ell}^{-m} + (-1)^m Y_{\ell}^{m} \right)
-            & m > 0 \\[6pt]
-        Y_{\ell}^{0} & m = 0 \\[6pt]
-        \dfrac{i}{\sqrt{2}} \left( Y_{\ell}^{m} - (-1)^m Y_{\ell}^{-m} \right)
-            & m < 0
+    Y_{\ell,m}^{\mathrm{real}} = \begin{cases}
+        \dfrac{Y_\ell^{-m}+(-1)^mY_\ell^m}{\sqrt{2}} & m>0,\\[6pt]
+        Y_\ell^0 & m=0,\\[6pt]
+        \dfrac{i\left(Y_\ell^m-(-1)^mY_\ell^{-m}\right)}{\sqrt{2}} & m<0.
     \end{cases}
 
-so that the real Wigner-D matrix is :math:`D^{\ell}_{\text{real}} = T^{*} D^{\ell} T^{T}`.
+If :math:`T` denotes this change of basis, then
+:math:`D^\ell_{\mathrm{real}}=T^*D^\ell T^T`. Wigner-D matrices are constructed
+lazily on first spherical use and then reused; Cartesian-only transformations
+do not pay this cost.
 
-For an improper rotation (a rotation composed with an inversion), Cartesian axes are
-flipped as part of the transformation matrix itself, while spherical axes pick up an
-extra parity factor :math:`(-1)^{\ell} \sigma`, where :math:`\ell` is ``o3_lambda``
-and :math:`\sigma` is the block's ``o3_sigma`` (its behavior under inversion, +1 or
--1), also read from the key.
+The public constructor snapshots the validated matrix, and the ``matrix``
+property returns a copy. This immutability is required because inversion parity
+and Wigner-D matrices are cached; mutating caller-owned storage must not make
+the Cartesian and spherical paths disagree.
 
-A :py:class:`~metatensor.torch.TensorBlock` in general contains values associated with
-several systems. This information is contained in the ``"system"`` samples dimension;
-each row is rotated with the transformation of the system it belongs to. Gradient blocks
-are routed the same way, via their parent block's ``"system"`` column. When only one
-system is being transformed, the ``"system"`` column is optional and, if present, is
-ignored: every row is rotated with the (single) given transformation.
+For an improper transformation, Cartesian axes are flipped by :math:`R` itself.
+A spherical axis additionally acquires the factor
+:math:`(-1)^\ell\sigma`, where :math:`\sigma` is its ``o3_sigma`` label. Thus
+``o3_sigma=1`` denotes the usual parity :math:`(-1)^\ell`, while
+``o3_sigma=-1`` denotes the opposite parity. These are the only valid parity
+labels; other values are rejected.
+
+Multi-system routing
+--------------------
+
+In a TensorBlock containing several systems, the ``system`` sample label routes
+each value row to its transformation. Gradient rows are routed through the
+``sample`` index into their parent value block.
+
+The optional ``system_ids`` contains one distinct integer sample label for each
+entry in ``systems``; entry ``i`` is paired with transformation ``i``. Labels
+need not be sorted, consecutive, non-negative, or present in every block. Every
+sample label that is present must occur in ``system_ids``. Tensor-valued IDs and
+all transformations must match the values' device, and transformations must
+also match their dtype. With one system, the ``system`` column is optional and,
+if present, ignored.
 
 Reference
 ---------

--- a/docs/src/torch/reference/symmetrized-model.rst
+++ b/docs/src/torch/reference/symmetrized-model.rst
@@ -1,121 +1,374 @@
+.. _symmetrized-model:
+
 Symmetrized models
 ==================
 
 The :py:mod:`metatomic.torch.symmetrized_model` module provides
-:py:class:`SymmetrizedModel`, a wrapper that averages the outputs of any
-atomistic model over the full orthogonal group :math:`O(3)`, and computes
-equivariance metrics quantifying how far the model is from being exactly
-equivariant.
+:py:class:`SymmetrizedModel`, an evaluation wrapper that approximates the
+:math:`O(3)` Haar projection of an atomistic model with a deterministic finite
+quadrature. It also reports orientation-dependent diagnostics.
 
-The wrapped model can be either a module following the
-:py:class:`metatomic.torch.ModelInterface` call convention or an exported
-:py:class:`metatomic.torch.AtomisticModel`, for example one loaded with
-:py:func:`metatomic.torch.load_atomistic_model`.
+The wrapped model can follow the :py:class:`metatomic.torch.ModelInterface`
+convention or be an exported :py:class:`metatomic.torch.AtomisticModel`,
+including one loaded with :py:func:`metatomic.torch.load_atomistic_model`.
 
-The wrapped model is evaluated on copies of each system rotated over a
-quadrature grid on :math:`O(3)` (a Lebedev grid supplemented by in-plane
-rotations, covering both proper and improper rotations). Each output is then
-"back-rotated" using the :math:`O(3)` action appropriate for its tensorial
-type, following the conventions described in :ref:`o3-conventions`, and
-averaged over the grid with the quadrature weights.
+Before constructing the wrapper, install the optional quadrature dependency:
+``python -m pip install "scipy>=1.15"``.
 
-Constructing a :py:class:`SymmetrizedModel` requires `scipy`_ (version 1.15 or
-later, for the Lebedev quadrature rule); scipy is only imported when the class
-is instantiated.
+A minimal evaluation looks like this (``systems`` is a list of
+:py:class:`~metatomic.torch.System` objects in the model's length unit):
 
-.. _scipy: https://scipy.org/
+.. code-block:: python
 
-Outputs
--------
+    from metatomic.torch import ModelOutput, load_atomistic_model
+    from metatomic.torch.symmetrized_model import SymmetrizedModel
 
-Each requested output is first decomposed into irreducible representations of
-:math:`O(3)`: energies contribute an ``_l0`` (scalar) tensor, forces an ``_l1``
-(vector) tensor, and stresses both ``_l0`` (trace) and ``_l2`` (symmetric
-traceless) tensors. For every resulting tensor ``<name>``, the returned
-dictionary contains three entries:
+    base = load_atomistic_model("model.pt").eval()
+    model = SymmetrizedModel(
+        base,
+        max_o3_lambda_target=2,
+        max_o3_lambda_grid=8,
+        batch_size=16,
+    )
+    result = model(systems, {"energy": ModelOutput(sample_kind="system")})
+    energy_mean = result["energy_l0_mean"]  # a TensorMap
+    energy_values = energy_mean.block().values
 
-- ``<name>_mean``: the :math:`O(3)`-averaged, symmetrized output;
-- ``<name>_var``: the variance of the back-rotated output over the group,
-  which vanishes for a perfectly equivariant model;
-- ``<name>_norm_squared``: the average squared norm of the output over the
-  group.
+Repeat with a larger ``max_o3_lambda_grid`` and compare the returned mean and
+diagnostics before relying on a finite-grid result.
 
-For example, requesting ``energy`` with ``compute_gradients=True`` on a
-periodic system returns ``energy_l0_mean``, ``energy_l0_var``,
-``energy_l0_norm_squared``, the corresponding ``forces_l1_*`` entries, and the
-``stress_l0_*`` and ``stress_l2_*`` entries; forces and stress are computed
-from the energy via autograd, through the rotations.
+The projector, character decomposition, O(3) convention, and product-grid
+theorem follow Domina *et al.*, `How unconstrained machine-learning models
+learn physical symmetries <https://arxiv.org/abs/2603.24638v1>`_, especially
+main-text Sec. II and SI Secs. IV–V.
 
-Requested outputs are forwarded to the base model unchanged, so each
-base-model kind keeps its usual metatomic semantics: exported models apply
-their normal output-unit conversion when a requested unit differs from the
-declared one, while raw modules ignore units entirely. Outputs other than
-energies, forces, and stresses are back-rotated according to their component
-metadata and returned in their original (e.g. Cartesian) layout, without
-spherical decomposition.
+Projector and finite quadrature
+-------------------------------
+
+For an input :math:`x`, group element :math:`g`, and orthogonal target
+representation :math:`\rho`, define the back-rotated response
+
+.. math::
+
+    z(g) = \rho(g^{-1}) f(gx).
+
+The symmetrized output is the Haar average of :math:`z`. The finite grid
+combines a Lebedev rule on :math:`S^2`, equispaced in-plane rotations, and the
+proper and improper cosets of :math:`O(3)` to approximate
+
+.. math::
+
+    \overline f(x) = \int_{O(3)} z(g)\,\mathrm{d}\mu(g).
+
+The finite sum equals this integral when the relevant orbit response and its
+products are band-limited within the grid. A general neural-network response
+need not satisfy such a bound, so increase ``max_o3_lambda_grid`` until the
+mean, variance, and any character fractions converge.
+
+The implementation accumulates moments around a fixed grid response for
+numerical stability. For normalized finite-grid weights :math:`q_i`, choose
+:math:`r=z(g_0)` and set :math:`y_i=z(g_i)-r`. It computes
+
+.. math::
+
+    \mu = r + \sum_i q_i y_i,
+    \qquad
+    V = \sum_i q_i \lVert y_i\rVert^2
+        - \left\lVert\sum_i q_i y_i\right\rVert^2.
+
+This is algebraically the usual mean and component-summed variance. It applies
+to tensorial outputs because every :math:`z(g_i)` is already in the same
+back-rotated representation frame. The reference is only a numerical device:
+it is not a shift of the physical input or output and does not alter the
+projector. Character projections instead use the direct response and are not
+centered this way.
+
+Because Lebedev rules can contain signed weights, an under-resolved finite sum
+can make the nominal variance or squared norm negative even though the exact
+Haar quantities are non-negative. The wrapper also accumulates
+:math:`\sum_i |q_i|\lVert y_i\rVert^2` as a round-off scale. A negative residual
+within a bound proportional to the number of grid points and float64 epsilon is
+set to zero; a materially negative or non-finite diagnostic raises
+:py:class:`ValueError` and asks for a larger grid. This prevents severe aliasing
+from being reported as zero equivariance error.
+
+Angular parameters
+~~~~~~~~~~~~~~~~~~
+
+The three angular parameters are deliberately independent:
+
+- ``max_o3_lambda_target`` validates spherical components returned directly by
+  the base model and provides the target-only default-grid heuristic. Work is
+  sized from the ranks actually returned; this parameter is not a response
+  bandwidth.
+- ``max_o3_lambda_character`` selects the character sectors to compute. It does
+  not assert that the response has no content above the cutoff.
+- ``max_o3_lambda_grid`` is the declared integration degree :math:`D`. The
+  wrapper selects a Lebedev rule of at least that degree and uses :math:`D+1`
+  in-plane angles.
+
+The product-quadrature theorem requires Lebedev degree :math:`2L` and at least
+:math:`2L+1` in-plane points for products of Wigner-D functions through
+bandwidth :math:`L`. Character projections through :math:`L` therefore require
+``max_o3_lambda_grid >= 2 * max_o3_lambda_character``. Exactness still requires
+the response itself to be covered; otherwise check convergence.
+
+Constructor defaults, limits, and validation are documented in the API
+reference below. Quadrature construction requires `SciPy`_ 1.15 or newer.
+
+.. _SciPy: https://scipy.org/
+
+Evaluation, devices, and units
+------------------------------
+
+``SymmetrizedModel`` is intended for evaluation and diagnostics, not training
+or model export. Calls without ``compute_gradients=True`` run under
+``torch.no_grad()`` and return detached results. Put the base model in evaluation
+mode so stochastic layers are not mistaken for symmetry breaking.
+
+Input Systems and the base model must use compatible devices. Do not downcast
+the wrapper: its float64 buffers carry the quadrature accuracy. This wrapper
+does not support MPS; that restriction does not apply to general metatomic O(3)
+or metatrain use.
+
+For an exported :py:class:`~metatomic.torch.AtomisticModel`, the wrapper passes
+an empty input ``length_unit``. Positions, cells, and neighbor-list vectors must
+therefore already use the model length unit. Requested custom System data still
+uses the normal AtomisticModel conversion when both the TensorMap and model
+input request specify units. Raw modules receive the transformed Systems
+directly and define their own unit semantics.
+
+Required neighbor lists and custom data must already be attached. Cartesian and
+spherical custom data are transformed according to :ref:`o3-conventions`;
+spherical input rank is inferred from its ``o3_mu*`` axes independently of the
+output ceiling.
+
+For every base-model TensorBlock, each rotated copy must return the same
+non-``system`` sample labels in the same order, with identical keys, components,
+and properties. The ``system`` column itself is located by name and need not be
+the first sample column. Changing the sample layout between rotated copies is
+ambiguous and raises an error.
+
+Every requested output must be returned by the base model. Requests are
+forwarded unchanged, including requested output units: exported models perform
+their normal output conversion, while raw modules define their own behavior.
+New TensorMaps created by the wrapper do not carry machine-readable unit
+metadata. Numerically, means use the base output unit; variances, squared norms,
+and character projections use its square. Autograd-derived forces use the
+returned energy unit divided by the input-position unit, and stress uses the
+energy unit divided by the input-length unit cubed. For exported models, that
+input length unit is the model length unit described above.
+
+Explicit gradients attached to TensorMap blocks are not supported and are
+rejected before reduction. ``compute_gradients=True`` is a separate autograd
+path that derives ordinary force and stress outputs from an energy; it does not
+preserve attached TensorMap gradients.
+
+Output schema and bases
+-----------------------
+
+Standard quantities, including variants after ``/``, are decomposed as follows.
+The complete requested name is preserved before the ``_l<rank>`` suffix.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Requested base quantity
+     - Generated name(s)
+     - Irrep key(s)
+   * - ``energy``, ``energy_ensemble``, ``energy_uncertainty``
+     - ``<name>_l0``
+     - ``o3_lambda=0``, ``o3_sigma=1``
+   * - ``forces``, ``non_conservative_force``, ``non_conservative_forces``
+     - ``<name>_l1``
+     - ``o3_lambda=1``, ``o3_sigma=1``
+   * - ``stress``, ``non_conservative_stress``
+     - ``<name>_l0`` and ``<name>_l2``
+     - ``(0, 1)`` and ``(2, 1)``
+
+For example, ``energy/pbe`` produces ``energy/pbe_l0``. Generated spherical
+blocks carry an ``o3_mu`` component. When the source has only metatensor's
+dummy ``_`` key, their key names are exactly ``o3_lambda`` and ``o3_sigma``;
+semantic source keys are preserved before these two irrep keys. Custom
+quantities retain their original layout and are back-rotated from their
+Cartesian or spherical metadata. Requested names must remain distinct after
+these suffixes are generated; ambiguous collisions are rejected before model
+evaluation.
+
+The force conversion maps Cartesian ``(x, y, z)`` to
+``o3_mu=(-1, 0, 1) = (y, z, x)``. For a stress :math:`S`, let
+:math:`S^{\mathrm{sym}}=(S+S^T)/2`. The :math:`l=0` value is the raw trace
+:math:`t=\mathrm{tr}(S)`, and the :math:`l=2` values in
+``o3_mu=(-2, -1, 0, 1, 2)`` order are
+
+.. math::
+
+    c = \left(
+        S^{\mathrm{sym}}_{xy},
+        S^{\mathrm{sym}}_{yz},
+        \frac{2S_{zz}-S_{xx}-S_{yy}}{2\sqrt{3}},
+        S^{\mathrm{sym}}_{xz},
+        \frac{S_{xx}-S_{yy}}{2}
+    \right),
+
+with
+
+.. math::
+
+    \lVert S^{\mathrm{sym}}\rVert_F^2 = \frac{t^2}{3} + 2\lVert c\rVert^2.
+
+Only the trace and symmetric-traceless parts used for physical stress are
+returned. A skew input component is omitted; callers needing torque or
+antisymmetric diagnostics must analyze it separately.
+
+For every decomposed name ``<name>``, the result contains:
+
+- ``<name>_mean``: the finite-grid symmetrized mean;
+- ``<name>_var``: the component-summed orientation variance;
+- ``<name>_norm_squared``: the average squared component norm.
+
+Back-rotation and accumulation use float64 even when the base model runs in
+float32. This limits cancellation but can not recover information already
+rounded in the model output.
+
+Autograd-derived forces and stress
+-----------------------------------
+
+With ``compute_gradients=True``, ``energy_name`` must identify a returned,
+single-block energy-like TensorMap. Its values are summed before autograd, and
+the wrapper derives
+
+.. math::
+
+    F = -\frac{\partial E}{\partial r}, \qquad
+    S = \frac{1}{V}\frac{\partial E}{\partial\epsilon}.
+
+The names ``forces`` and ``stress`` are reserved for these derived outputs in
+this mode and can not also be requested from the base model. Forces are returned
+for every System, subject to ``selected_atoms``. Three-dimensional stress is
+returned only for Systems whose three PBC flags are all true. A mixed batch
+therefore contains stress samples only for fully periodic Systems. Their cell
+must have finite, nonzero volume; non-periodic and partially periodic Systems
+have no 3D stress entry.
+
+Following the metatrain composition-model convention, a detached energy emits a
+:py:class:`RuntimeWarning`, is treated as constant, and produces exact zero
+derivatives. This is correct for genuinely coordinate-independent outputs such
+as type-only composition energies; autograd can not distinguish them from a
+position-dependent energy that was detached accidentally. A graph-connected
+energy that does not use a particular position or strain target also produces
+zero for that target. Callers must therefore keep the graph connected for every
+genuinely coordinate-dependent energy.
 
 Equivariance error
 ------------------
 
-For evaluation pipelines that only need the equivariance error (e.g. computing
-it alongside accuracy metrics during model evaluation), the
-:py:meth:`SymmetrizedModel.equivariance_error` method reduces everything to
-per-system RMSE values. The reduction preserves the block and property
-structure of each output (e.g. the ``o3_lambda``/``o3_sigma`` blocks and
-radial channels of a spherical target), so values can be aggregated later in
-whichever way the analysis needs.
+:py:meth:`SymmetrizedModel.equivariance_error` reduces each variance to a
+per-system value with :py:func:`per_system_equivariance_rmse`. It preserves keys
+and properties, divides by the total component multiplicity, averages over the
+system's samples, and then takes the square root. The result is comparable to an
+element-wise accuracy RMSE in the same returned basis.
 
-The normalization matches an element-wise accuracy RMSE over the same target
-(per component, averaged over each system's samples), making the two numbers
-directly comparable. In fact, for an exactly equivariant reference,
+For the raw mean-square and variance sums on the same normalized finite grid, an
+exactly equivariant reference satisfies
 
 .. math::
 
-    \left\langle \mathrm{RMSE}_\mathrm{accuracy}^2 \right\rangle_{O(3)}
+    \left\langle \mathrm{RMSE}_{\mathrm{accuracy}}^2 \right\rangle
     =
-    \mathrm{RMSE}_\mathrm{accuracy}^2\big[\text{symmetrized model}\big]
+    \mathrm{RMSE}_{\mathrm{accuracy}}^2[\text{mean}]
     +
-    \mathrm{RMSE}_\mathrm{equivariance}^2,
+    \mathrm{RMSE}_{\mathrm{equivariance}}^2.
 
-so the equivariance error is the contribution of symmetry breaking to the
-(orientation-averaged) accuracy error.
+This algebraic identity does not prove that the grid equals the Haar integral.
+Some valid Lebedev rules contain signed weights, so an under-resolved finite-grid
+variance can be materially negative. The wrapper rejects this state using the
+scale-aware check described above; the reduction helper also rejects negative or
+non-finite manually supplied variances. Increase ``max_o3_lambda_grid`` until
+the diagnostic converges.
 
-To pool per-system values into a dataset-level number, combine the squares
-weighted by the number of samples :math:`N_A` of each system,
-:math:`\sqrt{\sum_A N_A\, \mathrm{rmse}_A^2 / \sum_A N_A}`; a plain mean of
-per-system RMSEs is not the pooled RMSE when system sizes differ.
-
-All statistics are accumulated in double precision, independently of the model
-dtype (the variance is a difference of second moments and would cancel
-catastrophically in single precision for outputs of large magnitude, such as
-total energies). The measurable error is still limited by the precision of the
-model outputs themselves: for a float32 model, deviations below roughly
-:math:`10^{-7}` times the magnitude of the output are dominated by round-off,
-and errors reported at that scale do not indicate symmetry breaking.
-
-The :py:func:`per_system_equivariance_rmse` helper applies the same reduction
-to an existing output dictionary.
+To pool systems of different sizes, combine squared per-system values with their
+sample counts and then take the square root. A plain mean is not the pooled RMSE.
+Systems without samples in a block receive zero by convention; this is not a
+measured zero error.
 
 Character projections
 ---------------------
 
-When ``compute_character_projections=True``, the output additionally contains
-``<name>_character_projection``. These decompose the output into the
-isotypical components of :math:`O(3)`, labeled by ``chi_lambda`` and
-``chi_sigma`` in the keys, and describe how the output is distributed across
-the irreducible sectors of the group; see the class documentation below for
-the definitions.
+Characters analyze the direct-frame response
 
-Each stored value is the squared norm :math:`\| P_{\lambda,\sigma}\, x \|^{2}`
-of the projection of the output onto the :math:`(\lambda,\sigma)` isotypical
-subspace, resolved per sample (and per component and property of the output).
-Dividing by ``<name>_norm_squared`` gives the fraction of the output's squared
-norm in that sector, as done by :py:func:`per_system_character_fractions`.
+.. math::
 
-Computing the projections requires ``max_o3_lambda_character`` to be set, on a
-quadrature grid able to integrate them exactly (``max_o3_lambda_grid`` at
-least ``2 * max_o3_lambda_character``, satisfied by the default); a
-:py:exc:`ValueError` is raised otherwise.
+    u(g) = f(gx),
+
+not the back-rotated :math:`z(g)`. An exactly equivariant polar vector can
+therefore have zero equivariance error while carrying direct-frame content in
+the :math:`(1,+1)` sector. The projector onto sector
+:math:`(\ell,\sigma)` is
+
+.. math::
+
+    (P_{\ell,\sigma}u)(g)
+    = (2\ell+1)
+      \int_{O(3)} \chi_{\ell,\sigma}(h^{-1}g)u(h)\,\mathrm{d}\mu(h).
+
+For a proper rotation :math:`R` and inversion :math:`i`, the character convention
+is
+
+.. math::
+
+    \chi_{\ell,\sigma}(R) = \operatorname{tr}D^\ell(R),
+    \qquad
+    \chi_{\ell,\sigma}(iR)
+    = \sigma(-1)^\ell\operatorname{tr}D^\ell(R).
+
+With ``compute_character_projections=True``, every decomposed output also has
+``<name>_character_projection``. Keys append ``chi_lambda`` and ``chi_sigma``;
+values are squared Fourier-coefficient norms and are non-negative by
+construction. :py:func:`per_system_character_fractions` aggregates and
+normalizes them by ``<name>_norm_squared``.
+
+Fractions sum to one only when the response is band-limited, the grid resolves
+the required products, and the character cutoff contains the full response
+bandwidth. Negative or non-finite norms and sector weights are rejected instead
+of being repaired with an absolute value. A zero norm paired with all-zero
+sector weights returns all-zero fractions; a zero norm with nonzero sector
+weight is inconsistent and raises.
+
+Performance and memory
+----------------------
+
+If the selected Lebedev rule has :math:`M` nodes and grid degree :math:`D`, each
+original System creates :math:`2M(D+1)` rotated copies and makes
+
+.. math::
+
+    2\left\lceil\frac{M(D+1)}{\mathtt{batch\_size}}\right\rceil
+
+base-model calls. ``batch_size`` changes peak batch memory and call size, not
+the total evaluated copies. Original Systems are processed one at a time, and
+geometry and neighbor vectors are transformed in batches where possible.
+
+Mean, variance, norm, and the round-off scale are streamed around the fixed
+reference, so persistent statistical state scales with output size rather than
+orbit size, while the live model-prediction payload scales with ``batch_size``.
+Setting ``storage_device`` can move back-rotation, accumulation, and results off
+the model device; the base-model evaluation and quadrature grid remain there.
+
+The grid itself grows with ``max_o3_lambda_grid`` and is not bounded by
+``batch_size`` or ``storage_device``. Spherical outputs and character
+projections additionally use a lazy Wigner-D cache. ``wigner_cache_max_bytes``
+bounds retained Wigner tensors, not total forward memory; setting it to zero
+uses a numerically equivalent batched fallback. Wigner-D construction is
+CPU-backed and completed stacks are transferred in batches for CUDA evaluation.
+
+For practical tuning, first choose the smallest grid that gives converged
+results, then increase ``batch_size`` until throughput stops improving or device
+memory becomes limiting. Reduce ``wigner_cache_max_bytes`` if persistent cache
+memory is a concern. Character projections grow rapidly with the requested
+rank and are best run on representative data. ``compute_gradients=True`` adds a
+backward pass for every rotated batch and should be enabled only when force or
+stress diagnostics are required.
 
 Reference
 ---------

--- a/metatomic-torch/CHANGELOG.md
+++ b/metatomic-torch/CHANGELOG.md
@@ -18,10 +18,16 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 
 ### Added
 
-- A `SymmetrizedModel` wrapper, that averages the outputs of an atomistic model
-  over O(3) using a Lebedev quadrature grid, and computes equivariance metrics
-  (variance over the group and character projections). Using it requires
-  scipy >= 1.15.
+- O(3) utilities for applying proper and improper transformations to Systems and
+  TensorMaps, including Cartesian and spherical components, gradients, custom
+  data, neighbor lists, and multi-system routing. These require `wigners >=0.4.0`.
+- A `SymmetrizedModel` evaluation wrapper that approximates O(3) averaging with
+  a finite Lebedev/in-plane quadrature. It reports stable orientation variance
+  and character projections, and can derive conservative forces and fully
+  periodic 3D stress. Grid evaluation is streamed, and the persistent reusable
+  full-grid Wigner-D cache is bounded by `wigner_cache_max_bytes`. Construction
+  requires SciPy >=1.15. CUDA Wigner-D construction is staged per batch on CPU
+  to avoid per-rotation synchronization in both cached and bounded fallback paths.
 
 ## [Version 0.1.15](https://github.com/metatensor/metatomic/releases/tag/metatomic-torch-v0.1.15) - 2026-06-25
 

--- a/python/metatomic_ase/CHANGELOG.md
+++ b/python/metatomic_ase/CHANGELOG.md
@@ -16,6 +16,22 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 -->
 
+### Changed
+
+- `SymmetrizedCalculator` now streams rotated prediction batches, uses stable
+  finite-grid statistics, rotates supported requested polar-vector inputs,
+  rejects axial-vector inversion that the ASE TensorMap schema cannot
+  represent, and applies the complete input-compatible space-group action to
+  per-atom energy, forces, and fully periodic stress. SciPy >=1.15 is required
+  for nontrivial rotational grids, and space-group projection uses spglib.
+
+### Fixed
+
+- Requested ASE arrays, scalar info, and standard input dependencies are
+  validated and participate in `MetatomicCalculator` cache invalidation.
+- Rotational symmetrization preserves valid unwrapped periodic coordinates
+  instead of changing their lattice images while rotating the cell.
+
 ## [Version 0.1.1](https://github.com/metatensor/metatomic/releases/tag/metatomic-ase-v0.1.1) - 2026-05-13
 
 ### Added

--- a/python/metatomic_ase/src/metatomic_ase/_calculator.py
+++ b/python/metatomic_ase/src/metatomic_ase/_calculator.py
@@ -123,13 +123,107 @@ PER_SYSTEM_QUANTITIES = {
 
 _MISSING_INFO = object()
 
-# For standard per-system quantities the model can request, the `atoms.info` keys that
-# can be read by the getter and the value returned when the key is absent. Used by
-# `check_state` to invalidate the cached results when the key changes.
+# ASE arrays read by standard per-atom inputs but omitted by ASE's cache check.
+_ARRAY_KEY_FOR_QUANTITY = {
+    "momentum": ("momenta",),
+    # ASE derives velocity from both momenta and masses.
+    "velocity": ("momenta", "masses"),
+    "mass": ("masses",),
+    "charge": ("initial_charges",),
+    "ase::initial_magmoms": ("initial_magmoms",),
+    "ase::initial_charges": ("initial_charges",),
+    "ase::tags": ("tags",),
+}
+
+# ``atoms.info`` keys and their getter defaults for standard system inputs.
 _INFO_KEY_FOR_QUANTITY = {
     "charge": (["charge"], 0.0),
     "spin_multiplicity": (["spin_multiplicity", "spin"], 1),
 }
+
+
+def _requested_ase_state_watches(model) -> Tuple[List[str], List[Tuple[str, Any]]]:
+    """Return ASE arrays/info keys that influence the model's requested inputs."""
+    array_keys = set()
+    info_keys = {}
+    for name, option in model.requested_inputs(use_new_names=True).items():
+        if option.sample_kind == "atom":
+            if name.startswith("ase::arrays::"):
+                array_keys.add(name[len("ase::arrays::") :])
+            elif name in _ARRAY_KEY_FOR_QUANTITY:
+                array_keys.update(_ARRAY_KEY_FOR_QUANTITY[name])
+        elif option.sample_kind == "system":
+            if name in _INFO_KEY_FOR_QUANTITY:
+                default = _INFO_KEY_FOR_QUANTITY[name][1]
+                for key_name in _INFO_KEY_FOR_QUANTITY[name][0]:
+                    info_keys.setdefault(key_name, default)
+            elif name.startswith("ase::info::"):
+                info_keys[name[len("ase::info::") :]] = _MISSING_INFO
+
+    return sorted(array_keys), list(info_keys.items())
+
+
+def _append_requested_state_changes(
+    changes: List[str],
+    old_atoms: Optional[ase.Atoms],
+    new_atoms: ase.Atoms,
+    array_keys: List[str],
+    info_keys: List[Tuple[str, Any]],
+    tolerance: float,
+) -> List[str]:
+    """Add changes in requested ASE inputs omitted by ASE's default state check."""
+    if old_atoms is None:
+        return changes
+
+    def different(old, new) -> bool:
+        if old is _MISSING_INFO or new is _MISSING_INFO:
+            return old is not new
+        try:
+            return not ase.calculators.calculator.equal(old, new, atol=tolerance)
+        except (TypeError, ValueError):
+            return not ase.calculators.calculator.equal(old, new)
+
+    def normalized_info(value):
+        if value is _MISSING_INFO:
+            return value
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return value
+
+    for key in array_keys:
+        if (
+            different(
+                old_atoms.arrays.get(key, _MISSING_INFO),
+                new_atoms.arrays.get(key, _MISSING_INFO),
+            )
+            and key not in changes
+        ):
+            changes.append(key)
+
+    for key, default in info_keys:
+        old = normalized_info(old_atoms.info.get(key, default))
+        new = normalized_info(new_atoms.info.get(key, default))
+        if different(old, new) and key not in changes:
+            changes.append(key)
+
+    return changes
+
+
+def _snapshot_requested_info_values(
+    atoms: ase.Atoms, info_keys: List[Tuple[str, Any]]
+) -> None:
+    """Break shallow-copy aliases for scalar ``atoms.info`` cache inputs."""
+    for key, _ in info_keys:
+        if key not in atoms.info:
+            continue
+        try:
+            atoms.info[key] = float(atoms.info[key])
+        except (TypeError, ValueError):
+            # A fallback can be present without being used, for example ``spin``
+            # when ``spin_multiplicity`` takes precedence. A required invalid value
+            # has already failed while constructing the model inputs.
+            pass
 
 
 class MetatomicCalculator(ase.calculators.calculator.Calculator):
@@ -176,6 +270,10 @@ class MetatomicCalculator(ase.calculators.calculator.Calculator):
     - **per-system**: Model can request data from :py:attr:`ase.Atoms.info` with the
       ``ase::info::`` prefix (e.g. ``ase::info::foo`` will request the ``foo`` entry
       from ``ase.Atoms.info``).
+
+    Requested ASE arrays must contain finite real-valued numerical or Boolean
+    values. Requested ``ase::info::*`` entries must be finite scalar values
+    convertible to ``float``.
     """
 
     def __init__(
@@ -407,19 +505,13 @@ class MetatomicCalculator(ase.calculators.calculator.Calculator):
 
         self._model = model.to(device=self._device)
 
-        # Pre-compute the list of `atoms.info` keys we need to watch for changes
-        # so ASE's cache gets invalidated when they change between MD steps.
+        # Pre-compute the requested arrays and `atoms.info` keys that must
+        # invalidate ASE's cache when they change between MD steps.
         # Doing this once here avoids a TorchScript dispatch on every step.
-        self._system_info_watch: List[Tuple[str, Any]] = []
-        for name, option in self._model.requested_inputs(use_new_names=True).items():
-            if option.sample_kind != "system":
-                continue
-            if name in _INFO_KEY_FOR_QUANTITY:
-                default = _INFO_KEY_FOR_QUANTITY[name][1]
-                for key_name in _INFO_KEY_FOR_QUANTITY[name][0]:
-                    self._system_info_watch.append((key_name, default))
-            elif name.startswith("ase::info::"):
-                self._system_info_watch.append((name[11:], _MISSING_INFO))
+        (
+            self._per_atom_array_watch,
+            self._system_info_watch,
+        ) = _requested_ase_state_watches(self._model)
 
         self._calculate_uncertainty = (
             self._energy_uq_key in outputs
@@ -512,15 +604,8 @@ class MetatomicCalculator(ase.calculators.calculator.Calculator):
             types, positions, cell, pbc = _ase_to_torch_data(
                 atoms=atoms, dtype=self._dtype, device=self._device
             )
-            system = System(types, positions, cell, pbc)
-            # Get the additional inputs requested by the model
-            requested_inputs = self._model.requested_inputs(use_new_names=True)
-            for name, option in requested_inputs.items():
-                input_tensormap = _get_ase_input(
-                    atoms, name, option, dtype=self._dtype, device=self._device
-                )
-                system.add_data(name, input_tensormap)
-            systems.append(system)
+            systems.append(System(types, positions, cell, pbc))
+        self._add_model_inputs(atoms_list, systems)
 
         # Compute the neighbors lists requested by the model
         input_systems = self._nl_calculators.compute(systems=systems)
@@ -541,31 +626,38 @@ class MetatomicCalculator(ase.calculators.calculator.Calculator):
             check_consistency=self.parameters["check_consistency"],
         )
 
-    def check_state(self, atoms: ase.Atoms, tol: float = 1e-15) -> List[str]:
-        """Detect system changes, including ``atoms.info`` keys used as model inputs.
+    def _add_model_inputs(
+        self, atoms_list: List[ase.Atoms], systems: List[System]
+    ) -> None:
+        """Attach every requested ASE input to the corresponding system."""
+        requested = self._model.requested_inputs(use_new_names=True)
+        for atoms, system in zip(atoms_list, systems, strict=True):
+            for name, options in requested.items():
+                system.add_data(
+                    name,
+                    _get_ase_input(
+                        atoms, name, options, dtype=self._dtype, device=self._device
+                    ),
+                )
 
-        ASE's default :py:meth:`~ase.calculators.calculator.Calculator.check_state` only
-        tracks per-atom arrays, cell and pbc, so mutations to ``atoms.info`` (e.g.
-        ``atoms.info["spin"]``) would otherwise return a stale cached result. Any
-        watched info key that differs from the last calculation is appended to the
-        change list, forcing a fresh run.
+    def check_state(self, atoms: ase.Atoms, tol: float = 1e-15) -> List[str]:
+        """Detect changes in every ASE value requested as a model input.
+
+        ASE's default :py:meth:`~ase.calculators.calculator.Calculator.check_state`
+        tracks only a fixed set of geometry/array fields. Requested values such as
+        momenta, masses used by velocity, tags, custom arrays, and ``atoms.info``
+        entries are watched here as well, preventing stale cached predictions.
         """
         changes = super().check_state(atoms, tol=tol)
 
-        if self.atoms is None:
-            return changes
-
-        for key, default in self._system_info_watch:
-            old = self.atoms.info.get(key, default)
-            new = atoms.info.get(key, default)
-            try:
-                equal = old == new
-                if not isinstance(equal, bool) or not equal:
-                    changes.append(key)
-            except Exception:
-                changes.append(key)
-
-        return changes
+        return _append_requested_state_changes(
+            changes,
+            self.atoms,
+            atoms,
+            self._per_atom_array_watch,
+            self._system_info_watch,
+            tol,
+        )
 
     def calculate(
         self,
@@ -688,12 +780,7 @@ class MetatomicCalculator(ase.calculators.calculator.Calculator):
             input_system = self._nl_calculators.compute(systems=[system])[0]
 
         with record_function("MetatomicCalculator::get_model_inputs"):
-            requested_inputs = self._model.requested_inputs(use_new_names=True)
-            for name, option in requested_inputs.items():
-                input_tensormap = _get_ase_input(
-                    atoms, name, option, dtype=self._dtype, device=self._device
-                )
-                input_system.add_data(name, input_tensormap)
+            self._add_model_inputs([atoms], [input_system])
 
         # no `record_function` here, this will be handled by AtomisticModel
         outputs = self._model(
@@ -791,6 +878,12 @@ class MetatomicCalculator(ase.calculators.calculator.Calculator):
             for name in self._additional_output_requests:
                 self.additional_outputs[name] = outputs[name]
 
+        # ASE copies ``atoms.info`` shallowly in ``super().calculate``. Replace
+        # watched mutable scalar values in the calculator-owned snapshot so a later
+        # in-place mutation of the caller's value invalidates the cached result.
+        assert self.atoms is not None
+        _snapshot_requested_info_values(self.atoms, self._system_info_watch)
+
     def compute_energy(
         self,
         atoms: Union[ase.Atoms, List[ase.Atoms]],
@@ -812,10 +905,11 @@ class MetatomicCalculator(ase.calculators.calculator.Calculator):
         :param per_atom: if ``True``, the per-atom energies will also be
             computed.
         :return: A dictionary with the computed properties. The dictionary will contain
-            the ``energy`` as a float. If ``compute_forces_and_stresses`` is True,
-            the ``forces`` and ``stress`` will also be included as numpy arrays.
-            If ``per_atom`` is True, the ``energies`` key will also be present,
-            containing the per-atom energies as a numpy array.
+            the ``energy`` as a float. If ``compute_forces_and_stresses`` is ``True``,
+            ``forces`` will also be included as a numpy array; ``stress`` is included
+            only when all provided systems are fully periodic. If ``per_atom`` is
+            ``True``, the ``energies`` key will also be present, containing the
+            per-atom energies as a numpy array.
             In case of a list of :py:class:`ase.Atoms`, the dictionary values will
             instead be lists of the corresponding properties, in the same format.
         """
@@ -869,6 +963,8 @@ class MetatomicCalculator(ase.calculators.calculator.Calculator):
 
         # Compute the neighbors lists requested by the model
         input_systems = self._nl_calculators.compute(systems=systems)
+
+        self._add_model_inputs(atoms_list, input_systems)
 
         predictions = self._model(
             systems=input_systems,
@@ -1049,15 +1145,13 @@ def _get_ase_input(
                     f"The model requested '{name}' as input, but no array with name "
                     f"'{array_name}' was found in the ASE Atoms object."
                 )
-
-        if name not in PER_ATOM_QUANTITIES:
+        elif name in PER_ATOM_QUANTITIES:
+            infos = PER_ATOM_QUANTITIES[name]
+            values = infos["getter"](atoms)
+        else:
             raise ValueError(
                 f"The model requested '{name}', which is not available in `ase`."
             )
-
-        infos = PER_ATOM_QUANTITIES[name]
-
-        values = infos["getter"](atoms)
         if values.shape[0] != len(atoms):
             raise NotImplementedError(
                 f"The model requested the '{name}' input, "
@@ -1075,7 +1169,20 @@ def _get_ase_input(
         if name.startswith("ase::info::"):
             info_name = name[len("ase::info::") :]
             if info_name in atoms.info:
-                values = np.array([float(atoms.info[info_name])])
+                raw_value = atoms.info[info_name]
+                if np.iscomplexobj(raw_value):
+                    raise ValueError(
+                        f"The model requested '{name}', but ASE inputs must be "
+                        "real-valued."
+                    )
+                try:
+                    scalar_value = float(raw_value)
+                except (TypeError, ValueError) as error:
+                    raise ValueError(
+                        f"The model requested '{name}', but ASE system-info inputs "
+                        "must be real-valued scalars."
+                    ) from error
+                values = np.array([scalar_value])
                 infos = {
                     "unit": "",
                     "properties_name": "_",
@@ -1085,14 +1192,13 @@ def _get_ase_input(
                     f"The model requested '{name}' as input, but no info with name "
                     f"'{info_name}' was found in the ASE Atoms object."
                 )
-
-        if name not in PER_SYSTEM_QUANTITIES:
+        elif name in PER_SYSTEM_QUANTITIES:
+            infos = PER_SYSTEM_QUANTITIES[name]
+            values = infos["getter"](atoms)
+        else:
             raise ValueError(
                 f"The model requested '{name}', which is not available in `ase`."
             )
-        infos = PER_SYSTEM_QUANTITIES[name]
-
-        values = infos["getter"](atoms)
         if values.shape[0] != 1:
             raise NotImplementedError(
                 f"The model requested the '{name}' input, "
@@ -1105,6 +1211,23 @@ def _get_ase_input(
     else:
         raise ValueError(
             f"unexpected sample kind for input '{name}': {options.sample_kind}"
+        )
+
+    if np.iscomplexobj(values):
+        raise ValueError(
+            f"The model requested '{name}', but ASE inputs must be real-valued."
+        )
+    try:
+        finite_values = np.isfinite(values)
+    except TypeError as error:
+        raise ValueError(
+            f"The model requested '{name}', but ASE inputs must contain real "
+            "numeric values."
+        ) from error
+    if not np.all(finite_values):
+        raise ValueError(
+            f"The model requested '{name}', but the ASE input contains non-finite "
+            "values."
         )
 
     values = torch.tensor(values, dtype=dtype)

--- a/python/metatomic_ase/src/metatomic_ase/_symmetry.py
+++ b/python/metatomic_ase/src/metatomic_ase/_symmetry.py
@@ -36,9 +36,17 @@ class _RotationalMomentState:
 class _RotationalAverageAccumulator:
     """Stream prediction batches into reference-centered weighted moments.
 
-    The fixed reference supports signed rules and stable large-offset means;
-    absolute-weight moments distinguish round-off from a negative variance.
-    Retained prediction storage is independent of the quadrature size.
+    For a fixed reference ``c = x[0]``, this accumulates
+    ``m = sum_i w[i] * (x[i] - c)`` and
+    ``q = sum_i w[i] * (x[i] - c)**2``. The final mean and variance are
+    ``c + m`` and ``q - m**2``. Absolute-weight moments provide the scale used
+    to distinguish round-off from a materially negative variance when the
+    quadrature contains signed weights.
+
+    Calls to :meth:`update` must contain consecutive rotations in quadrature
+    order because weights are selected from the number of predictions already
+    consumed. Retained prediction state is one array per property and is
+    independent of the number of quadrature rotations.
     """
 
     _SUPPORTED_PROPERTIES = ("energy", "energies", "forces", "stress")
@@ -218,7 +226,13 @@ def _requested_per_atom_features(
     atoms: ase.Atoms,
     allow_axial: bool = False,
 ) -> Tuple[List[_PerAtomFeature], List[str]]:
-    """Collect requested features and names of arrays that rotate as vectors."""
+    """Classify requested per-atom inputs for rotations and group filtering.
+
+    Real numerical or Boolean ``(N, 3)`` arrays are interpreted as polar
+    vectors, except for ``initial_magmoms``, which are axial. All other
+    per-atom inputs are scalars. The returned array names identify caller-owned
+    ASE arrays that must be rotated together with the geometry.
+    """
     if not hasattr(calculator, "_model"):
         return [], []
 
@@ -305,10 +319,10 @@ class SymmetrizedCalculator(ase.calculators.calculator.Calculator):
         rotations are evaluated at once. Predictions are reduced immediately, so a
         finite value bounds the live model-prediction payload; ``None`` evaluates the
         full grid in one batch.
-    :param include_inversion: if ``True``, the inversion operation will be included in
-        the averaging. This is required to average over the full orthogonal group O(3).
-        Vector ``initial_magmoms`` are accepted only when this is ``False``, because
-        their axial parity is not represented by the ASE input TensorMap.
+    :param include_inversion: if ``True``, every proper grid rotation is paired with
+        its inverted partner, adding the full improper coset required to average over
+        O(3). Vector ``initial_magmoms`` are accepted only when this is ``False``,
+        because their axial parity is not represented by the ASE input TensorMap.
     :param apply_space_group_symmetry: if ``True``, fully periodic structures are
         averaged over the discrete space group after O(3) averaging, using
         `spglib <https://github.com/spglib/spglib>`_. This step is skipped for other
@@ -508,7 +522,12 @@ def _rotate_atoms(
     rotations: List[np.ndarray],
     vector_arrays: Optional[List[str]] = None,
 ) -> List[ase.Atoms]:
-    """Rotate geometry and the requested vector-valued ASE arrays."""
+    """Apply active rotations to geometry and requested polar/axial arrays.
+
+    ASE stores Cartesian vectors and cell vectors by row, so an operation
+    ``R`` maps each of them to ``x @ R.T``. Coordinates are not wrapped; in
+    particular, the identity preserves the caller's selected lattice images.
+    """
     if vector_arrays is None:
         vector_arrays = []
     rotated_atoms_list = []
@@ -777,7 +796,19 @@ def _get_group_operations(
     angle_tolerance: float = -1.0,
     per_atom_features: Optional[List[_PerAtomFeature]] = None,
 ) -> Tuple[List[np.ndarray], List[np.ndarray]]:
-    """Return Cartesian rotations and site permutations for retained actions."""
+    """Return Cartesian rotations and site permutations for retained actions.
+
+    For each fractional action ``(Rf, tf)``, ``permutation[i]`` is the original
+    site matched by the image of site ``i``. Matching is restricted to the same
+    species and uses minimum-image Cartesian distance with an effective
+    ``symprec`` threshold including round-off. A periodic index can reduce the
+    candidate set, but the bounded pairwise path remains the authoritative
+    fallback. Every accepted permutation is within tolerance and bijective.
+
+    Input-incompatible actions are discarded. Actions with the same rotation
+    but translation-distinct permutations remain separate, and a filtered set
+    is accepted only if it is closed under action composition.
+    """
     if not atoms.pbc.all():
         return [], []
     if per_atom_features is None:
@@ -928,7 +959,12 @@ def _get_group_operations(
 def _average_over_group(
     results: dict, Q_list: List[np.ndarray], permutations: List[np.ndarray]
 ) -> dict:
-    """Apply the space-group projector to supported output properties."""
+    """Apply the space-group projector to supported output properties.
+
+    With ``p = permutation`` and Cartesian row-vector convention, one action
+    contributes ``energies[p]``, ``forces[p] @ Q``, and ``Q.T @ stress @ Q``.
+    Total energy is already invariant under the discrete site action.
+    """
     m = len(Q_list)
     if len(permutations) != m:
         raise ValueError(

--- a/python/metatomic_ase/src/metatomic_ase/_symmetry.py
+++ b/python/metatomic_ase/src/metatomic_ase/_symmetry.py
@@ -1,47 +1,325 @@
+import operator
+import warnings
+from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 import torch
 
-from ._calculator import MetatomicCalculator
+from ._calculator import (
+    PER_ATOM_QUANTITIES,
+    MetatomicCalculator,
+    _append_requested_state_changes,
+    _snapshot_requested_info_values,
+)
 
 
 import ase  # isort: skip
 import ase.calculators.calculator  # isort: skip
+from ase.geometry import find_mic  # isort: skip
+
+
+_PerAtomFeature = Tuple[str, np.ndarray, str]
+
+
+@dataclass
+class _RotationalMomentState:
+    """Reference-centered sufficient statistics for one predicted property."""
+
+    reference: np.ndarray
+    centered_sum: np.ndarray
+    centered_second: Optional[np.ndarray]
+    absolute_centered_sum: Optional[np.ndarray]
+    absolute_centered_second: Optional[np.ndarray]
+
+
+class _RotationalAverageAccumulator:
+    """Stream prediction batches into reference-centered weighted moments.
+
+    The fixed reference supports signed rules and stable large-offset means;
+    absolute-weight moments distinguish round-off from a negative variance.
+    Retained prediction storage is independent of the quadrature size.
+    """
+
+    _SUPPORTED_PROPERTIES = ("energy", "energies", "forces", "stress")
+
+    def __init__(
+        self,
+        normalized_weights: np.ndarray,
+        *,
+        store_std: bool,
+    ) -> None:
+        weights = np.asarray(normalized_weights, dtype=float).copy()
+        if weights.ndim != 1 or len(weights) == 0:
+            raise ValueError("rotational weights must be a non-empty 1D array")
+        if not np.all(np.isfinite(weights)):
+            raise ValueError("rotational weights must be finite")
+        weight_sum = np.sum(weights, dtype=np.float64)
+        if not np.isfinite(weight_sum) or weight_sum == 0:
+            raise ValueError("rotational weights must have a finite nonzero sum")
+        weights /= weight_sum
+        # Make normalization exact so the reference does not leak into the sum.
+        weights[-1] += 1.0 - np.sum(weights, dtype=np.float64)
+
+        self._weights = weights
+        self._store_std = store_std
+        self._states: Dict[str, _RotationalMomentState] = {}
+        self._property_names: Optional[Tuple[str, ...]] = None
+        self._property_shapes: Dict[str, Tuple[int, ...]] = {}
+        self._seen = 0
+        self._absolute_weight_sum = 0.0
+
+    @staticmethod
+    def _as_batch(name: str, value, batch_size: int) -> np.ndarray:
+        values = np.asarray(value, dtype=float)
+        if values.ndim == 0:
+            if batch_size != 1:
+                raise ValueError(
+                    f"property '{name}' returned a scalar for a batch of "
+                    f"{batch_size} systems"
+                )
+            values = values.reshape(1)
+        if values.shape[0] != batch_size:
+            raise ValueError(
+                f"property '{name}' returned {values.shape[0]} systems for a "
+                f"batch of {batch_size}"
+            )
+        return values
+
+    @staticmethod
+    def _back_rotate(
+        name: str, values: np.ndarray, rotations: np.ndarray
+    ) -> np.ndarray:
+        if name == "forces":
+            return values @ rotations
+        if name == "stress":
+            return np.swapaxes(rotations, 1, 2) @ values @ rotations
+        return values
+
+    def update(
+        self,
+        batch_results: Dict[str, object],
+        batch_rotations: np.ndarray,
+    ) -> None:
+        """Consume one consecutive batch from the configured quadrature."""
+        rotations = np.asarray(batch_rotations, dtype=float)
+        if rotations.ndim != 3 or rotations.shape[1:] != (3, 3):
+            raise ValueError("batch rotations must have shape (batch, 3, 3)")
+        batch_size = len(rotations)
+        batch_stop = self._seen + batch_size
+        if batch_stop > len(self._weights):
+            raise ValueError("received more predictions than quadrature rotations")
+
+        property_names = tuple(
+            name for name in self._SUPPORTED_PROPERTIES if name in batch_results
+        )
+        if self._property_names is None:
+            self._property_names = property_names
+        elif property_names != self._property_names:
+            raise ValueError(
+                "base calculator returned inconsistent properties across "
+                "rotation batches"
+            )
+
+        weights = self._weights[self._seen : batch_stop]
+        absolute_weights = np.abs(weights)
+        self._absolute_weight_sum += float(np.sum(absolute_weights))
+        for name in property_names:
+            values = self._as_batch(name, batch_results[name], batch_size)
+            property_shape = tuple(values.shape[1:])
+            expected_shape = self._property_shapes.setdefault(name, property_shape)
+            if property_shape != expected_shape:
+                raise ValueError(
+                    f"property '{name}' changed shape across rotation batches: "
+                    f"expected {expected_shape}, got {property_shape}"
+                )
+
+            values = self._back_rotate(name, values, rotations)
+
+            state = self._states.get(name)
+            if state is None:
+                reference = np.array(values[0], dtype=float, copy=True)
+                zeros = np.zeros_like(reference, dtype=float)
+                state = _RotationalMomentState(
+                    reference=reference,
+                    centered_sum=zeros.copy(),
+                    centered_second=zeros.copy() if self._store_std else None,
+                    absolute_centered_sum=(zeros.copy() if self._store_std else None),
+                    absolute_centered_second=(
+                        zeros.copy() if self._store_std else None
+                    ),
+                )
+                self._states[name] = state
+
+            centered = values - state.reference
+            weight_shape = (len(weights),) + (1,) * (values.ndim - 1)
+            signed_weight = weights.reshape(weight_shape)
+            state.centered_sum += np.sum(signed_weight * centered, axis=0)
+
+            if self._store_std:
+                assert state.centered_second is not None
+                assert state.absolute_centered_sum is not None
+                assert state.absolute_centered_second is not None
+                absolute_weight = absolute_weights.reshape(weight_shape)
+                state.centered_second += np.sum(signed_weight * centered**2, axis=0)
+                state.absolute_centered_sum += np.sum(
+                    absolute_weight * centered, axis=0
+                )
+                state.absolute_centered_second += np.sum(
+                    absolute_weight * centered**2, axis=0
+                )
+
+        self._seen = batch_stop
+
+    def finalize(self) -> Dict[str, np.ndarray]:
+        """Return the same property dictionary as a full-grid reduction."""
+        if self._seen != len(self._weights):
+            raise ValueError(
+                f"received {self._seen} predictions for "
+                f"{len(self._weights)} quadrature rotations"
+            )
+
+        output: Dict[str, np.ndarray] = {}
+        for name, state in self._states.items():
+            mean = state.reference + state.centered_sum
+            output[name] = mean
+            if not self._store_std:
+                continue
+
+            assert state.centered_second is not None
+            assert state.absolute_centered_sum is not None
+            assert state.absolute_centered_second is not None
+            variance = state.centered_second - state.centered_sum**2
+
+            # Reconstruct sum |w_i| (x_i - mean)^2 around the fixed reference.
+            scale = (
+                state.absolute_centered_second
+                - 2.0 * state.centered_sum * state.absolute_centered_sum
+                + state.centered_sum**2 * self._absolute_weight_sum
+            )
+            scale = np.maximum(scale, 0.0)
+            finfo = np.finfo(np.result_type(variance.dtype, np.float64))
+            tolerance = (
+                64.0 * len(self._weights) * finfo.eps * np.maximum(scale, finfo.tiny)
+            )
+            if np.any(variance < -tolerance):
+                minimum = float(np.min(variance))
+                raise ValueError(
+                    "rotational variance is materially negative "
+                    f"({minimum}); increase l_max and check quadrature convergence"
+                )
+            output[name + "_rot_std"] = np.sqrt(np.maximum(variance, 0.0))
+
+        return output
+
+
+def _requested_per_atom_features(
+    calculator: MetatomicCalculator,
+    atoms: ase.Atoms,
+    allow_axial: bool = False,
+) -> Tuple[List[_PerAtomFeature], List[str]]:
+    """Collect requested features and names of arrays that rotate as vectors."""
+    if not hasattr(calculator, "_model"):
+        return [], []
+
+    requested = calculator._model.requested_inputs(use_new_names=True)
+    features: List[_PerAtomFeature] = []
+    vector_array_names: List[str] = []
+    for name, options in requested.items():
+        if options.sample_kind != "atom":
+            continue
+
+        array_name: Optional[str]
+        if name.startswith("ase::arrays::"):
+            array_name = name[len("ase::arrays::") :]
+            if array_name not in atoms.arrays:
+                continue
+            values = atoms.arrays[array_name]
+        elif name in PER_ATOM_QUANTITIES:
+            values = PER_ATOM_QUANTITIES[name]["getter"](atoms)
+            array_name = {
+                "momentum": "momenta",
+                "velocity": "momenta",
+                "mass": "masses",
+                "charge": "initial_charges",
+                "ase::initial_magmoms": "initial_magmoms",
+                "ase::initial_charges": "initial_charges",
+                "ase::tags": "tags",
+            }.get(name)
+        else:
+            continue
+
+        values = np.asarray(values)
+        if values.ndim == 0 or values.shape[0] != len(atoms):
+            continue
+        if name == "ase::arrays::positions":
+            raise ValueError(
+                "SymmetrizedCalculator does not support the reserved custom input "
+                "'ase::arrays::positions'; models must use System.positions so "
+                "forces and stress retain the correct derivatives"
+            )
+        if np.iscomplexobj(values):
+            raise ValueError(f"requested per-atom input '{name}' must be real-valued")
+        is_numeric = np.issubdtype(values.dtype, np.number) or np.issubdtype(
+            values.dtype, np.bool_
+        )
+        if is_numeric and not np.all(np.isfinite(values)):
+            raise ValueError(
+                f"requested per-atom input '{name}' contains non-finite values"
+            )
+        if values.shape == (len(atoms), 3) and is_numeric:
+            is_axial = array_name == "initial_magmoms"
+            if is_axial and not allow_axial:
+                raise ValueError(
+                    "SymmetrizedCalculator can not transform vector "
+                    "initial_magmoms consistently: the ASE input converter does "
+                    "not expose their axial O(3) parity"
+                )
+            kind = "axial" if is_axial else "polar"
+            if array_name is not None and array_name in atoms.arrays:
+                vector_array_names.append(array_name)
+        else:
+            kind = "scalar"
+        features.append((name, values, kind))
+
+    return features, sorted(set(vector_array_names))
 
 
 class SymmetrizedCalculator(ase.calculators.calculator.Calculator):
     r"""
     Take a MetatomicCalculator and average its predictions to make it (approximately)
-    equivariant. Only predictions for energy, forces and stress are supported.
+    equivariant. Only predictions for total/per-atom energy, forces, and stress are
+    supported.
 
-    The default is to average over a quadrature of the orthogonal group O(3) composed
-    this way:
-
-    - Lebedev quadrature of the unit sphere (S^2)
-    - Equispaced sampling of the unit circle (S^1)
-    - Both proper and improper rotations are taken into account by including the
-        inversion operation (if ``include_inversion=True``)
+    The finite O(3) grid combines a Lebedev sphere rule, equispaced in-plane
+    rotations, and (when requested) the improper coset.
 
     :param base_calculator: the MetatomicCalculator to be symmetrized
-    :param l_max: the maximum spherical harmonic degree that the model is expected to
-        be able to represent. This is used to choose the quadrature order. If ``0``,
-        no rotational averaging will be performed (it can be useful to average only over
-        the space group, see ``apply_group_symmetry``).
+    :param l_max: effective angular bandwidth used to choose the finite product
+        quadrature. It must cover both the model response and the target
+        representation (at least 1 for forces and 2 for stress); check convergence by
+        increasing it. Componentwise ``*_rot_std`` must cover the complete
+        back-rotated response. The largest supported value is 65. At ``0``, only
+        identity and, when requested, inversion are used.
     :param batch_size: number of rotated systems to evaluate at once. If ``None``, all
-        systems will be evaluated at once (this can lead to high memory usage).
+        rotations are evaluated at once. Predictions are reduced immediately, so a
+        finite value bounds the live model-prediction payload; ``None`` evaluates the
+        full grid in one batch.
     :param include_inversion: if ``True``, the inversion operation will be included in
         the averaging. This is required to average over the full orthogonal group O(3).
-    :param apply_space_group_symmetry: if ``True``, the results will be averaged over
-        discrete space group of rotations for the input system. The group operations are
-        computed with `spglib <https://github.com/spglib/spglib>`_, and the average is
-        performed after the O(3) averaging (if any). This has no effect for non-periodic
-        systems.
+        Vector ``initial_magmoms`` are accepted only when this is ``False``, because
+        their axial parity is not represented by the ASE input TensorMap.
+    :param apply_space_group_symmetry: if ``True``, fully periodic structures are
+        averaged over the discrete space group after O(3) averaging, using
+        `spglib <https://github.com/spglib/spglib>`_. This step is skipped for other
+        structures. Operations that do not preserve requested per-atom inputs are
+        discarded.
     :param store_rotational_std: if ``True``, the results will contain the standard
-        deviation over the different rotations for each property (e.g., ``energy_std``).
+        deviation over the different rotations for each property (e.g.,
+        ``energy_rot_std``, ``forces_rot_std``, and ``stress_rot_std``).
     """
 
-    implemented_properties = ["energy", "energies", "forces", "stress", "stresses"]
+    implemented_properties = ["energy", "energies", "forces", "stress"]
 
     def __init__(
         self,
@@ -53,34 +331,33 @@ class SymmetrizedCalculator(ase.calculators.calculator.Calculator):
         apply_space_group_symmetry: bool = False,
         store_rotational_std: bool = False,
     ) -> None:
-        try:
-            from scipy.integrate import lebedev_rule  # noqa: F401
-        except ImportError as e:
-            raise ImportError(
-                "scipy is required to use the `SymmetrizedCalculator`, please install "
-                "it with `pip install scipy` or `conda install scipy`"
-            ) from e
-
         super().__init__()
 
+        l_max = _validated_integer("l_max", l_max, 0)
+        if batch_size is not None:
+            batch_size = _validated_integer("batch_size", batch_size, 1)
+
         self.base_calculator = base_calculator
-        if l_max > 131:
-            raise ValueError(
-                f"l_max={l_max} is too large, the maximum supported value is 131"
-            )
         self.l_max = l_max
         self.include_inversion = include_inversion
 
         if l_max > 0:
+            try:
+                from scipy.integrate import lebedev_rule  # noqa: F401
+            except ImportError as e:
+                raise ImportError(
+                    "scipy is required to use the `SymmetrizedCalculator`, please "
+                    "install it with `pip install scipy` or `conda install scipy`"
+                ) from e
             lebedev_order, n_inplane_rotations = _choose_quadrature(l_max)
             self.quadrature_rotations, self.quadrature_weights = _get_quadrature(
                 lebedev_order, n_inplane_rotations, include_inversion
             )
-        else:  # no quadrature
-            if include_inversion:  # identity and inversion
+        else:
+            if include_inversion:
                 self.quadrature_rotations = np.array([np.eye(3), -np.eye(3)])
                 self.quadrature_weights = np.array([0.5, 0.5])
-            else:  # only the identity
+            else:
                 self.quadrature_rotations = np.array([np.eye(3)])
                 self.quadrature_weights = np.array([1.0])
 
@@ -91,77 +368,123 @@ class SymmetrizedCalculator(ase.calculators.calculator.Calculator):
         self.store_rotational_std = store_rotational_std
         self.apply_space_group_symmetry = apply_space_group_symmetry
 
+        self._per_atom_array_watch = getattr(
+            base_calculator, "_per_atom_array_watch", []
+        )
+        self._system_info_watch = getattr(base_calculator, "_system_info_watch", [])
+
+    def check_state(self, atoms: ase.Atoms, tol: float = 1e-15) -> List[str]:
+        """Detect changes in every ASE value requested by the wrapped model."""
+        changes = super().check_state(atoms, tol=tol)
+        return _append_requested_state_changes(
+            changes,
+            self.atoms,
+            atoms,
+            self._per_atom_array_watch,
+            self._system_info_watch,
+            tol,
+        )
+
     def calculate(
         self, atoms: ase.Atoms, properties: List[str], system_changes: List[str]
     ) -> None:
-        """
-        Perform the calculation for the given atoms and properties.
-
-        :param atoms: the :py:class:`ase.Atoms` on which to perform the calculation
-        :param properties: list of properties to compute, among ``energy``, ``forces``,
-            and ``stress``
-        :param system_changes: list of changes to the system since the last call to
-            ``calculate``
-        """
+        """Average the requested properties over the configured operations."""
         super().calculate(atoms, properties, system_changes)
-        self.base_calculator.calculate(atoms, properties, system_changes)
+        # A later failure must not leave old results attached to the new atoms.
+        self.results = {}
 
         compute_forces_and_stresses = "forces" in properties or "stress" in properties
-        per_atom = "energies" in properties
-
-        if len(self.quadrature_rotations) > 0:
-            rotated_atoms_list = _rotate_atoms(atoms, self.quadrature_rotations)
-            batches = [
-                rotated_atoms_list[i : i + self.batch_size]
-                for i in range(0, len(rotated_atoms_list), self.batch_size)
-            ]
-            results: Dict[str, np.ndarray] = {}
-            for batch in batches:
-                try:
-                    batch_results = self.base_calculator.compute_energy(
-                        batch,
-                        compute_forces_and_stresses,
-                        per_atom=per_atom,
-                    )
-                    for key, value in batch_results.items():
-                        results.setdefault(key, [])
-                        results[key].extend(
-                            [value] if isinstance(value, float) else value
-                        )
-                except torch.cuda.OutOfMemoryError as e:
-                    raise RuntimeError(
-                        "Out of memory error encountered during rotational averaging. "
-                        "Please reduce the batch size or use lower rotational "
-                        "averaging parameters. This can be done by setting the "
-                        "`batch_size` and `l_max` parameters while initializing the "
-                        "calculator."
-                    ) from e
-
-            self.results.update(
-                _compute_rotational_average(
-                    results,
-                    self.quadrature_rotations,
-                    self.quadrature_weights,
-                    self.store_rotational_std,
+        if "stress" in properties:
+            if not atoms.pbc.all():
+                raise ase.calculators.calculator.PropertyNotImplementedError(
+                    "SymmetrizedCalculator only defines 3D stress for systems "
+                    "periodic in all three directions"
                 )
-            )
+        # The base computes stress with forces for fully periodic systems.
+        if compute_forces_and_stresses and atoms.pbc.all():
+            cell = atoms.cell.array
+            invalid_cell = not np.all(np.isfinite(cell))
+            volume = 0.0 if invalid_cell else abs(np.linalg.det(cell))
+            if invalid_cell or not np.isfinite(volume) or volume == 0:
+                raise ValueError(
+                    "SymmetrizedCalculator can not compute 3D stress for a "
+                    "singular or non-finite periodic cell"
+                )
 
-        if self.apply_space_group_symmetry:
-            # Apply the discrete space group of the system a posteriori
-            Q_list, P_list = _get_group_operations(atoms)
-            self.results.update(_average_over_group(self.results, Q_list, P_list))
+        per_atom = "energies" in properties
+        per_atom_features, vector_arrays = _requested_per_atom_features(
+            self.base_calculator,
+            atoms,
+            allow_axial=not self.include_inversion,
+        )
+
+        accumulator = _RotationalAverageAccumulator(
+            self.quadrature_weights,
+            store_std=self.store_rotational_std,
+        )
+        for batch_start in range(0, len(self.quadrature_rotations), self.batch_size):
+            batch_rotations = self.quadrature_rotations[
+                batch_start : batch_start + self.batch_size
+            ]
+            batch = _rotate_atoms(atoms, batch_rotations, vector_arrays)
+            try:
+                batch_results = self.base_calculator.compute_energy(
+                    batch,
+                    compute_forces_and_stresses,
+                    per_atom=per_atom,
+                )
+                del batch
+                accumulator.update(batch_results, batch_rotations)
+                del batch_results
+            except torch.cuda.OutOfMemoryError as e:
+                raise RuntimeError(
+                    "Out of memory error encountered during rotational averaging. "
+                    "Please reduce the batch size or use lower rotational "
+                    "averaging parameters. This can be done by setting the "
+                    "`batch_size` and `l_max` parameters while initializing the "
+                    "calculator."
+                ) from e
+
+        final_results = accumulator.finalize()
+        # Release moment state before allocating projection temporaries.
+        del accumulator
+
+        if self.apply_space_group_symmetry and any(
+            name in final_results for name in ("energies", "forces", "stress")
+        ):
+            Q_list, permutations = _get_group_operations(
+                atoms, per_atom_features=per_atom_features
+            )
+            projected_results = _average_over_group(final_results, Q_list, permutations)
+            # Rotational deviations describe the preceding O(3) orbit.
+            final_results.update(projected_results)
+
+        # Break shallow-copy aliases in ASE's calculator-owned cache snapshot.
+        assert self.atoms is not None
+        _snapshot_requested_info_values(self.atoms, self._system_info_watch)
+        self.results = final_results
+
+
+def _validated_integer(name: str, value, minimum: int) -> int:
+    if isinstance(value, (bool, np.bool_)):
+        raise TypeError(f"{name} must be an integer, not a boolean")
+    try:
+        normalized = int(operator.index(value))
+    except TypeError as error:
+        raise TypeError(
+            f"{name} must be an integer, got {type(value).__name__}"
+        ) from error
+    if normalized < minimum:
+        qualifier = "positive" if minimum == 1 else "non-negative"
+        raise ValueError(f"{name} must be {qualifier}, got {normalized}")
+    return normalized
 
 
 def _choose_quadrature(L_max: int) -> Tuple[int, int]:
-    """
-    Choose a Lebedev quadrature order and number of in-plane rotations to integrate
-    spherical harmonics up to degree ``L_max``.
+    """Choose the product grid for Wigner-D products through ``L_max``."""
+    L_max = _validated_integer("L_max", L_max, 0)
 
-    :param L_max: maximum spherical harmonic degree
-    :return: (lebedev_order, n_inplane_rotations)
-    """
-    # the same table lives in metatomic.torch.symmetrized_model._quadrature;
-    # keep the two in sync
+    # Keep in sync with metatomic.torch.symmetrized_model._quadrature.
     # fmt: off
     available = [
         3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31, 35, 41,
@@ -169,26 +492,25 @@ def _choose_quadrature(L_max: int) -> Tuple[int, int]:
     ]
     # fmt: on
 
-    if L_max > available[-1]:
+    required_lebedev_degree = 2 * L_max
+    if required_lebedev_degree > available[-1]:
         raise ValueError(
-            f"the requested quadrature degree L_max={L_max} exceeds the largest "
-            f"available Lebedev order ({available[-1]})"
+            f"l_max={L_max} requires Lebedev degree {required_lebedev_degree}, "
+            f"which exceeds the largest available order ({available[-1]}); "
+            f"the largest supported l_max is {available[-1] // 2}"
         )
-    # pick smallest order >= L_max
-    n = min(o for o in available if o >= L_max)
-    # minimal gamma count
-    K = 2 * L_max + 1
-    return n, K
+    n = min(o for o in available if o >= required_lebedev_degree)
+    return n, 2 * L_max + 1
 
 
-def _rotate_atoms(atoms: ase.Atoms, rotations: List[np.ndarray]) -> List[ase.Atoms]:
-    """
-    Create a list of copies of ``atoms``, rotated by each of the given ``rotations``.
-
-    :param atoms: the :py:class:`ase.Atoms` to be rotated
-    :param rotations: (N, 3, 3) array of orthogonal matrices
-    :return: list of N :py:class:`ase.Atoms`, each rotated by the corresponding matrix
-    """
+def _rotate_atoms(
+    atoms: ase.Atoms,
+    rotations: List[np.ndarray],
+    vector_arrays: Optional[List[str]] = None,
+) -> List[ase.Atoms]:
+    """Rotate geometry and the requested vector-valued ASE arrays."""
+    if vector_arrays is None:
+        vector_arrays = []
     rotated_atoms_list = []
     has_cell = atoms.cell is not None and atoms.cell.rank > 0
     for rot in rotations:
@@ -198,234 +520,452 @@ def _rotate_atoms(atoms: ase.Atoms, rotations: List[np.ndarray]) -> List[ase.Ato
             new_atoms.set_cell(
                 new_atoms.cell.array @ rot.T, scale_atoms=False, apply_constraint=False
             )
-            new_atoms.wrap()
+        for name in vector_arrays:
+            values = new_atoms.arrays[name]
+            new_atoms.arrays[name] = values @ rot.T
         rotated_atoms_list.append(new_atoms)
     return rotated_atoms_list
 
 
+def _arrays_respect_operation(
+    features: List[_PerAtomFeature],
+    rotation: np.ndarray,
+    permutation: np.ndarray,
+    determinant: int,
+) -> bool:
+    """Whether all requested per-atom inputs respect a space-group action."""
+    for _, values, kind in features:
+        transformed = values
+        if kind in ("polar", "axial"):
+            transformed = transformed @ rotation.T
+            if kind == "axial":
+                parity = determinant
+                transformed = parity * transformed
+
+        mapped = values[permutation]
+        if kind in ("polar", "axial"):
+            # Bound matrix-arithmetic error component by component. Values are
+            # compared as represented; adding the source dtype's epsilon would
+            # turn nearby but distinct float32 features into false symmetries.
+            # A global/unit-sized absolute floor would likewise erase a
+            # physically meaningful tiny vector or a small component next to a
+            # much larger one.
+            operation_scale = np.abs(values) @ np.abs(rotation).T
+            if kind == "axial":
+                operation_scale *= abs(parity)
+            arithmetic_dtype = np.result_type(values.dtype, rotation.dtype)
+            arithmetic_eps = np.finfo(arithmetic_dtype).eps
+            tolerance = 64.0 * arithmetic_eps * operation_scale
+            if not np.all(np.abs(mapped - transformed) <= tolerance):
+                return False
+        elif not np.array_equal(mapped, transformed):
+            return False
+    return True
+
+
+def _group_actions_are_closed(
+    fractional_rotations: List[np.ndarray],
+    permutations: List[np.ndarray],
+) -> bool:
+    """Check closure by finding generators rather than all action pairs."""
+    if len(fractional_rotations) != len(permutations) or len(permutations) == 0:
+        return False
+
+    def action_key(rotation, permutation):
+        return (tuple(rotation.flatten().tolist()), tuple(permutation.tolist()))
+
+    actions = {
+        action_key(rotation, permutation): (rotation, permutation)
+        for rotation, permutation in zip(
+            fractional_rotations, permutations, strict=True
+        )
+    }
+
+    def resolve(rotation, permutation):
+        key = action_key(rotation, permutation)
+        return key if key in actions else None
+
+    identity_key = resolve(np.eye(3, dtype=np.int64), np.arange(len(permutations[0])))
+
+    if identity_key is None:
+        return False
+
+    generators = []
+    generated = {identity_key}
+    for candidate_key, candidate in actions.items():
+        if candidate_key in generated:
+            continue
+        generators.append(candidate)
+
+        # Re-enumerate canonically after adding each generator.
+        generated = {identity_key}
+        frontier = [identity_key]
+        while frontier:
+            current_key = frontier.pop()
+            current_rotation, current_permutation = actions[current_key]
+            for generator_rotation, generator_permutation in generators:
+                composed_key = resolve(
+                    generator_rotation @ current_rotation,
+                    generator_permutation[current_permutation],
+                )
+                if composed_key is None:
+                    return False
+                if composed_key not in generated:
+                    generated.add(composed_key)
+                    frontier.append(composed_key)
+
+    return len(generated) == len(actions)
+
+
 def _get_quadrature(lebedev_order: int, n_rotations: int, include_inversion: bool):
-    """
-    Lebedev(S^2) x uniform angle quadrature on SO(3).
-    If include_inversion=True, extend to O(3) by adding inversion * R.
-
-    The construction is shared with ``metatomic.torch.symmetrized_model``, so
-    both tools build their grids from the same primitives; note that the two
-    tools size their grids independently (this module picks ``2*l_max + 1``
-    in-plane rotations for its averages, the torch module sizes the whole grid
-    for its doubled band limit), so equal ``l_max`` does not mean equal grids.
-
-    :param lebedev_order: order of the Lebedev quadrature on the unit sphere
-    :param n_rotations: number of in-plane rotations per Lebedev node
-    :param include_inversion: if ``True``, include the inversion operation in the
-        quadrature
-    :return: (N, 3, 3) array of orthogonal matrices, and (N,) array of weights
-        associated to each matrix
-    """
+    """Return the shared Lebedev-by-angle SO(3)/O(3) quadrature."""
     from metatomic.torch.symmetrized_model import get_rotation_quadrature
 
     return get_rotation_quadrature(lebedev_order, n_rotations, include_inversion)
 
 
-def _compute_rotational_average(results, rotations, weights, store_std):
-    R = rotations
-    B = R.shape[0]
-    w = weights
-    w = w / w.sum()
+def _build_periodic_site_indices(
+    frac: np.ndarray,
+    species_indices: List[np.ndarray],
+    cell: np.ndarray,
+    match_tolerance: float,
+):
+    """Build a conservative periodic candidate index, or request fallback.
 
-    def _wreshape(x):
-        return w.reshape((B,) + (1,) * (x.ndim - 1))
+    ``||d_frac|| <= ||d_cart|| / sigma_min(cell)`` makes the query complete;
+    :func:`find_mic` remains authoritative in Cartesian space.
+    """
+    if len(species_indices) == 0 or not any(
+        len(indices) >= 8 for indices in species_indices
+    ):
+        return None, 0.0
 
-    def _wmean(x):
-        return np.sum(_wreshape(x) * x, axis=0)
+    try:
+        from scipy.spatial import cKDTree
+    except ImportError:
+        return None, 0.0
 
-    def _wstd(x):
-        mu = _wmean(x)
-        return np.sqrt(np.sum(_wreshape(x) * (x - mu) ** 2, axis=0))
+    try:
+        singular_values = np.linalg.svd(cell, compute_uv=False)
+    except np.linalg.LinAlgError:
+        return None, 0.0
+    smallest_singular_value = float(singular_values[-1])
+    if not np.isfinite(smallest_singular_value) or smallest_singular_value <= 0.0:
+        return None, 0.0
 
-    out = {}
+    # Cover boundary round-off between tree and Cartesian calculations.
+    eps = np.finfo(float).eps
+    fractional_query_radius = (
+        match_tolerance / smallest_singular_value * (1.0 + 64.0 * eps) + 64.0 * eps
+    )
+    fractional_query_radius = float(np.nextafter(fractional_query_radius, np.inf))
+    # Dense candidate sets are handled by the bounded vectorized fallback.
+    if (
+        not np.isfinite(fractional_query_radius)
+        or fractional_query_radius <= 0.0
+        or fractional_query_radius >= 0.25
+    ):
+        return None, 0.0
 
-    # Energy (B,)
-    if "energy" in results:
-        E = np.asarray(results["energy"], dtype=float)  # (B,)
-        out["energy"] = _wmean(E)  # ()
-        if store_std:
-            out["energy_rot_std"] = _wstd(E)  # ()
+    wrapped_frac = frac % 1.0
+    try:
+        site_indices = [
+            cKDTree(wrapped_frac[indices], boxsize=1.0) if len(indices) >= 8 else None
+            for indices in species_indices
+        ]
+    except ValueError:
+        return None, 0.0
+    return site_indices, fractional_query_radius
 
-    if "energies" in results:
-        E = np.asarray(results["energies"], dtype=float)  # (B,N)
-        out["energies"] = _wmean(E)  # (N,)
-        if store_std:
-            out["energies_rot_std"] = _wstd(E)  # (N,)
 
-    # Forces (B,N,3) from rotated structures: back-rotate with F' R
-    if "forces" in results:
-        F = np.asarray(results["forces"], dtype=float)  # (B,N,3)
-        F_back = F @ R  # F' R
-        out["forces"] = _wmean(F_back)  # (N,3)
-        if store_std:
-            out["forces_rot_std"] = _wstd(F_back)  # (N,3)
+def _match_species_pairwise(
+    new_frac: np.ndarray,
+    frac: np.ndarray,
+    indices: np.ndarray,
+    cell,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Return nearest same-species sites using bounded dense chunks."""
+    nearest = np.empty(len(indices), dtype=np.int64)
+    nearest_distances = np.empty(len(indices), dtype=float)
+    max_pairs_per_chunk = 65_536
+    chunk_size = max(1, max_pairs_per_chunk // len(indices))
+    for start in range(0, len(indices), chunk_size):
+        stop = min(start + chunk_size, len(indices))
+        source = indices[start:stop]
+        fractional_delta = new_frac[source, None, :] - frac[None, indices, :]
+        cartesian_delta = fractional_delta @ cell.array
+        _, distances = find_mic(cartesian_delta.reshape(-1, 3), cell, pbc=True)
+        distances = distances.reshape(len(source), len(indices))
+        local_nearest = np.argmin(distances, axis=1)
+        nearest[start:stop] = local_nearest
+        nearest_distances[start:stop] = distances[np.arange(len(source)), local_nearest]
+    return nearest, nearest_distances
 
-    # Stress (B,3,3) from rotated structures: back-rotate with R^T S' R
-    if "stress" in results:
-        S = np.asarray(results["stress"], dtype=float)  # (B,3,3)
-        RT = np.swapaxes(R, 1, 2)
-        S_back = RT @ S @ R  # R^T S' R
-        out["stress"] = _wmean(S_back)  # (3,3)
-        if store_std:
-            out["stress_rot_std"] = _wstd(S_back)  # (3,3)
 
-    if "stresses" in results:
-        S = np.asarray(results["stresses"], dtype=float)  # (B,N,3,3)
-        RT = np.swapaxes(R, 1, 2)
-        S_back = RT[:, None, :, :] @ S @ R[:, None, :, :]  # R^T S' R
-        out["stresses"] = _wmean(S_back)  # (N,3,3)
-        if store_std:
-            out["stresses_rot_std"] = _wstd(S_back)  # (N,3,3)
+def _match_species_with_periodic_index(
+    new_frac: np.ndarray,
+    frac: np.ndarray,
+    indices: np.ndarray,
+    cell,
+    match_tolerance: float,
+    site_index,
+    fractional_query_radius: float,
+) -> Optional[Tuple[np.ndarray, np.ndarray]]:
+    """Match indexed candidates, returning ``None`` for exact fallback."""
+    query_points = new_frac[indices] % 1.0
+    counts = np.asarray(
+        site_index.query_ball_point(
+            query_points,
+            r=fractional_query_radius,
+            return_length=True,
+        ),
+        dtype=np.int64,
+    )
+    candidate_count = int(np.sum(counts))
+    # Keep verification linear for large species and bounded for small ones.
+    candidate_limit = max(65_536, 4 * len(indices))
+    if (
+        np.any(counts == 0)
+        or candidate_count * 4 >= len(indices) * len(indices)
+        or candidate_count > candidate_limit
+    ):
+        return None
 
-    return out
+    # Materialize ragged lists only after the count-only sparse preflight.
+    candidates = site_index.query_ball_point(
+        query_points,
+        r=fractional_query_radius,
+        return_sorted=True,
+    )
+
+    candidate_indices = np.concatenate(candidates).astype(np.int64, copy=False)
+    source_indices = np.repeat(np.arange(len(indices)), counts)
+    fractional_delta = (
+        new_frac[indices[source_indices]] - frac[indices[candidate_indices]]
+    )
+    cartesian_delta = fractional_delta @ cell.array
+    _, candidate_distances = find_mic(cartesian_delta, cell, pbc=True)
+
+    offsets = np.cumsum(counts) - counts
+    accepted_counts = np.add.reduceat(
+        (candidate_distances <= match_tolerance).astype(np.int64), offsets
+    )
+    # Exact fallback owns ambiguity and tie-breaking.
+    if np.any(accepted_counts != 1):
+        return None
+
+    nearest_distances = np.minimum.reduceat(candidate_distances, offsets)
+
+    # Match ``np.argmin``: lowest local index wins an exact tie.
+    is_nearest = candidate_distances == np.repeat(nearest_distances, counts)
+    sentinel = len(indices)
+    nearest = np.minimum.reduceat(
+        np.where(is_nearest, candidate_indices, sentinel), offsets
+    )
+    return nearest, nearest_distances
+
+
+def _cartesian_site_match_tolerance(cell: np.ndarray, symprec: float) -> float:
+    """Return the Cartesian site threshold including round-off allowance."""
+    cell_scale = max(1.0, float(np.linalg.norm(cell, ord=2)))
+    return symprec + 64.0 * np.finfo(float).eps * cell_scale
 
 
 def _get_group_operations(
-    atoms: ase.Atoms, symprec: float = 1e-6, angle_tolerance: float = -1.0
+    atoms: ase.Atoms,
+    symprec: float = 1e-6,
+    angle_tolerance: float = -1.0,
+    per_atom_features: Optional[List[_PerAtomFeature]] = None,
 ) -> Tuple[List[np.ndarray], List[np.ndarray]]:
-    """
-    Extract point-group rotations Q_g (Cartesian, 3x3) and the corresponding
-    atom-index permutations P_g (N x N) induced by the space-group operations.
-    Returns Q_list, Cartesian rotation matrices of the point group,
-    and P_list, permutation matrices mapping original indexing -> indexing after (R,t),
+    """Return Cartesian rotations and site permutations for retained actions."""
+    if not atoms.pbc.all():
+        return [], []
+    if per_atom_features is None:
+        per_atom_features = []
 
-    :param atoms: input structure
-    :param symprec: tolerance for symmetry finding
-    :param angle_tolerance: tolerance for symmetry finding (in degrees). If less than 0,
-        a value depending on ``symprec`` will be chosen automatically by spglib.
-    :return: List of rotation matrices and permutation matrices.
-
-    """
     try:
         import spglib
     except ImportError as e:
         raise ImportError(
             "spglib is required to use the SymmetrizedCalculator with "
-            "`apply_group_symmetry=True`. Please install it with "
+            "`apply_space_group_symmetry=True`. Please install it with "
             "`pip install spglib` or `conda install -c conda-forge spglib`"
         ) from e
 
-    if not (atoms.pbc.all()):
-        # No periodic boundary conditions: no symmetry
-        return [], []
-
-    # Lattice with column vectors a1,a2,a3 (spglib expects (cell, frac, Z))
-    A = atoms.cell.array.T  # (3,3)
-    frac = atoms.get_scaled_positions()  # (N,3) in [0,1)
+    A = atoms.cell.array.T
+    frac = atoms.get_scaled_positions()
     numbers = atoms.numbers
     N = len(atoms)
 
-    data = spglib.get_symmetry_dataset(
-        (atoms.cell.array, frac, numbers),
-        symprec=symprec,
-        angle_tolerance=angle_tolerance,
-        _throw=True,
-    )
+    dataset_arguments = (atoms.cell.array, frac, numbers)
+    with warnings.catch_warnings():
+        # spglib 2.7 warns while its legacy global error mode is enabled. The
+        # supported non-throwing API is intentional here: ``None`` is handled below.
+        warnings.filterwarnings(
+            "ignore",
+            message="Set OLD_ERROR_HANDLING to false.*",
+            category=DeprecationWarning,
+        )
+        data = spglib.get_symmetry_dataset(
+            dataset_arguments,
+            symprec=symprec,
+            angle_tolerance=angle_tolerance,
+        )
 
     if data is None:
-        # No symmetry found
         return [], []
-    R_frac = data.rotations  # (n_ops, 3,3), integer
-    t_frac = data.translations  # (n_ops, 3)
-    Z = numbers
+    if hasattr(data, "rotations"):
+        R_frac = data.rotations
+        t_frac = data.translations
+    else:
+        # spglib releases before the dataclass result used mapping access.
+        R_frac = data["rotations"]
+        t_frac = data["translations"]
+    species_indices = [np.flatnonzero(numbers == z) for z in np.unique(numbers)]
+    match_tolerance = _cartesian_site_match_tolerance(atoms.cell.array, symprec)
+    site_indices, fractional_query_radius = _build_periodic_site_indices(
+        frac,
+        species_indices,
+        atoms.cell.array,
+        match_tolerance,
+    )
 
-    # Match fractional coords modulo 1 within a tolerance, respecting chemical species
-    def _match_index(x_new, frac_ref, Z_ref, Z_i, tol=1e-6):
-        d = np.abs(frac_ref - x_new)  # (N,3)
-        d = np.minimum(d, 1.0 - d)  # periodic distance
-        # Mask by identical species
-        mask = Z_ref == Z_i
-        if not np.any(mask):
-            raise RuntimeError("No matching species found while building permutation.")
-        # Choose argmin over max-norm within species
-        idx = np.where(mask)[0]
-        j = idx[np.argmin(np.max(d[idx], axis=1))]
-
-        # Sanity check
-        if np.max(d[j]) > tol:
-            raise RuntimeError(
-                (
-                    f"Sanity check failed in _match_index: max distance {np.max(d[j])} "
-                    f"exceeds tolerance {tol}."
-                )
-            )
-        return j
-
-    Q_list, P_list = [], []
+    Q_list, permutations, fractional_rotations = [], [], []
     seen = set()
     Ainv = np.linalg.inv(A)
 
     for Rf, tf in zip(R_frac, t_frac, strict=True):
-        # Cartesian rotation: Q = A Rf A^{-1}
-        Q = A @ Rf @ Ainv
-        # Deduplicate rotations (point group) by rounding
-        key = tuple(np.round(Q.flatten(), 12))
+        if np.array_equal(Rf, np.eye(3, dtype=Rf.dtype)):
+            Q = np.eye(3)
+        else:
+            # Solve Q A = A Rf rather than explicitly multiplying by A^{-1}.
+            Q = np.linalg.solve(A.T, (A @ Rf).T).T
+            # Recover entries that are indistinguishable from exact zero at the
+            # construction-error scale. This prevents a huge unrelated vector
+            # component from hiding a small physical mismatch.
+            construction_scale = np.abs(A) @ np.abs(Rf) @ np.abs(Ainv)
+            zero_tolerance = 64.0 * np.finfo(Q.dtype).eps * construction_scale
+            if not np.all(np.isfinite(Q)) or not np.all(np.isfinite(zero_tolerance)):
+                raise ValueError(
+                    "space-group Cartesian rotation is numerically undefined for "
+                    "this cell"
+                )
+            Q[np.abs(Q) <= zero_tolerance] = 0.0
+        # ``Rf`` is an integer unimodular matrix. Compute its determinant with
+        # Python integers so axial-vector parity does not depend on a rounded
+        # floating-point determinant.
+        (a, b, c), (d, e, f), (g, h, i) = Rf.tolist()
+        fractional_determinant = (
+            a * (e * i - f * h) - b * (d * i - f * g) + c * (d * h - e * g)
+        )
+        permutation = np.empty(N, dtype=np.int64)
+        new_frac = (frac @ Rf.T + tf) % 1.0
+        for species, indices in enumerate(species_indices):
+            matched = None
+            if site_indices is not None and site_indices[species] is not None:
+                matched = _match_species_with_periodic_index(
+                    new_frac,
+                    frac,
+                    indices,
+                    atoms.cell,
+                    match_tolerance,
+                    site_indices[species],
+                    fractional_query_radius,
+                )
+            if matched is None:
+                matched = _match_species_pairwise(
+                    new_frac,
+                    frac,
+                    indices,
+                    atoms.cell,
+                )
+
+            nearest, nearest_distances = matched
+            if np.any(nearest_distances > match_tolerance):
+                maximum = float(np.max(nearest_distances))
+                raise RuntimeError(
+                    "space-group operation can not be matched to atom sites: "
+                    f"maximum Cartesian distance {maximum} exceeds effective "
+                    f"matching threshold {match_tolerance} "
+                    f"(symprec={symprec})"
+                )
+            permutation[indices] = indices[nearest]
+        if len(np.unique(permutation)) != N:
+            raise RuntimeError(
+                "space-group operation did not produce a bijective atom permutation"
+            )
+
+        if not _arrays_respect_operation(
+            per_atom_features,
+            Q,
+            permutation,
+            determinant=fractional_determinant,
+        ):
+            continue
+
+        # Translation-distinct permutations remain distinct actions.
+        key = (tuple(Rf.flatten().tolist()), tuple(permutation.tolist()))
         if key in seen:
             continue
         seen.add(key)
 
-        # Build the permutation P from i to j
-        P = np.zeros((N, N), dtype=int)
-        new_frac = (frac @ Rf.T + tf) % 1.0  # images after (Rf,tf)
-        for i in range(N):
-            j = _match_index(new_frac[i], frac, Z, Z[i])
-            P[j, i] = 1  # column i maps to row j
-
         Q_list.append(Q.astype(float))
-        P_list.append(P)
+        permutations.append(permutation)
+        fractional_rotations.append(Rf.astype(np.int64))
 
-    return Q_list, P_list
+    if len(per_atom_features) != 0 and not _group_actions_are_closed(
+        fractional_rotations, permutations
+    ):
+        raise ValueError(
+            "model-input-compatible space-group operations are not closed; "
+            "the per-atom inputs are numerically ambiguous under the requested "
+            "symmetry tolerance"
+        )
+
+    return Q_list, permutations
 
 
 def _average_over_group(
-    results: dict, Q_list: List[np.ndarray], P_list: List[np.ndarray]
+    results: dict, Q_list: List[np.ndarray], permutations: List[np.ndarray]
 ) -> dict:
-    """
-    Apply the point-group projector in output space.
-
-    :param results: Must contain 'energy' (scalar), and/or 'forces' (N,3), and/or
-        'stress' (3,3). These are predictions for the current structure in the reference
-        frame.
-    :param Q_list: Rotation matrices of the point group, from
-        :py:func:`_get_group_operations`
-    :param P_list: Permutation matrices of the point group, from
-        :py:func:`_get_group_operations`
-    :return out: Projected quantities.
-    """
+    """Apply the space-group projector to supported output properties."""
     m = len(Q_list)
+    if len(permutations) != m:
+        raise ValueError(
+            "Q_list and permutations must contain the same number of operations"
+        )
     if m == 0:
-        return results  # nothing to do
+        return results
 
     out = {}
-    # Energy: unchanged by the projector (scalar)
     if "energy" in results:
         out["energy"] = float(results["energy"])
 
-    # Forces: (N,3) row-vectors; projector: (1/|G|) \sum_g P_g^T F Q_g
+    if "energies" in results:
+        energies = np.asarray(results["energies"], float)
+        if energies.ndim != 1:
+            raise ValueError(f"'energies' must be (N,), got {energies.shape}")
+        acc = np.zeros_like(energies)
+        for permutation in permutations:
+            acc += energies[permutation]
+        out["energies"] = acc / m
+
     if "forces" in results:
         F = np.asarray(results["forces"], float)
         if F.ndim != 2 or F.shape[1] != 3:
             raise ValueError(f"'forces' must be (N,3), got {F.shape}")
         acc = np.zeros_like(F)
-        for Q, P in zip(Q_list, P_list, strict=True):
-            acc += P.T @ (F @ Q)
+        for Q, permutation in zip(Q_list, permutations, strict=True):
+            acc += F[permutation] @ Q
         out["forces"] = acc / m
 
-    # Stress: (3,3); projector: (1/|G|) \sum_g Q_g^T S Q_g
     if "stress" in results:
         S = np.asarray(results["stress"], float)
         if S.shape != (3, 3):
             raise ValueError(f"'stress' must be (3,3), got {S.shape}")
-        # S = 0.5 * (S + S.T)  # symmetrize just in case
         acc = np.zeros_like(S)
         for Q in Q_list:
             acc += Q.T @ S @ Q
-        S_pg = acc / m
-        out["stress"] = S_pg
+        out["stress"] = acc / m
 
     return out

--- a/python/metatomic_ase/tests/symmetrized.py
+++ b/python/metatomic_ase/tests/symmetrized.py
@@ -1,10 +1,14 @@
+import sys
+import weakref
 from typing import Dict, List, Optional, Tuple, Union
 
+import ase.calculators.calculator
 import numpy as np
 import pytest
 import torch
 from ase import Atoms
 from ase.build import bulk, molecule
+from ase.cell import Cell
 from metatensor.torch import Labels, TensorBlock, TensorMap
 
 from metatomic.torch import (
@@ -16,32 +20,24 @@ from metatomic.torch import (
     System,
 )
 from metatomic_ase import MetatomicCalculator, SymmetrizedCalculator
+from metatomic_ase import _symmetry as symmetry_module
 from metatomic_ase._symmetry import (
     _average_over_group,
     _choose_quadrature,
-    _compute_rotational_average,
     _get_group_operations,
     _get_quadrature,
     _rotate_atoms,
+    _RotationalAverageAccumulator,
 )
 
 
 def _body_axis_from_system(system: System) -> torch.Tensor:
-    """
-    Return the normalized vector connecting the two farthest atoms.
-
-    :param system: System.
-    :return: Normalized 3D vector defining the body axis.
-    """
     pos = system.positions
     if len(pos) < 2:
         return torch.tensor([0.0, 0.0, 1.0], dtype=pos.dtype, device=pos.device)
     d2 = torch.sum((pos[:, None, :] - pos[None, :, :]) ** 2, axis=-1)
-    # i, j = torch.unravel_index(torch.argmax(d2), d2.shape) # for newer PyTorch
     idx = torch.argmax(d2)
-    i = idx // d2.shape[1]
-    j = idx % d2.shape[1]
-    b = pos[j] - pos[i]
+    b = pos[idx % d2.shape[1]] - pos[idx // d2.shape[1]]
     nrm = torch.linalg.norm(b)
     return (
         b / nrm
@@ -51,38 +47,60 @@ def _body_axis_from_system(system: System) -> torch.Tensor:
 
 
 def _legendre_0_1_2_3(c: float) -> tuple[float, float, float, float]:
-    """
-    Compute Legendre polynomials P0..P3(c).
+    return 1.0, c, 0.5 * (3 * c**2 - 1.0), 0.5 * (5 * c**3 - 3 * c)
 
-    :param c: Cosine between the body axis and the lab z-axis.
-    :return: Tuple (P0, P1, P2, P3).
-    """
-    P0 = 1.0
-    P1 = c
-    P2 = 0.5 * (3 * c**2 - 1.0)
-    P3 = 0.5 * (5 * c**3 - 3 * c)
-    return P0, P1, P2, P3
+
+def _compute_rotational_average(results, rotations, weights, store_std):
+    batch_size = len(rotations)
+    w = weights / weights.sum()
+
+    def _wreshape(x):
+        return w.reshape((batch_size,) + (1,) * (x.ndim - 1))
+
+    def _wmean(x):
+        return np.sum(_wreshape(x) * x, axis=0)
+
+    def _wstd(x):
+        mu = _wmean(x)
+        weighted_terms = _wreshape(x) * (x - mu) ** 2
+        variance = np.sum(weighted_terms, axis=0)
+        scale = np.sum(np.abs(weighted_terms), axis=0)
+        dtype = np.result_type(x.dtype, w.dtype, np.float64)
+        finfo = np.finfo(dtype)
+        tolerance = 64.0 * batch_size * finfo.eps * np.maximum(scale, finfo.tiny)
+        if np.any(variance < -tolerance):
+            minimum = float(np.min(variance))
+            raise ValueError(
+                "rotational variance is materially negative "
+                f"({minimum}); increase l_max and check quadrature convergence"
+            )
+        return np.sqrt(np.maximum(variance, 0.0))
+
+    output = {}
+    for name, result in results.items():
+        values = np.asarray(result, dtype=float)
+        if name == "forces":
+            values = values @ rotations
+        elif name == "stress":
+            values = np.swapaxes(rotations, 1, 2) @ values @ rotations
+        output[name] = _wmean(values)
+        if store_std:
+            output[name + "_rot_std"] = _wstd(values)
+    return output
+
+
+def _streaming_average(results, rotations, weights, batch_size, store_std=True):
+    accumulator = _RotationalAverageAccumulator(weights, store_std=store_std)
+    for start in range(0, len(rotations), batch_size):
+        stop = min(start + batch_size, len(rotations))
+        accumulator.update(
+            {name: values[start:stop] for name, values in results.items()},
+            rotations[start:stop],
+        )
+    return accumulator.finalize()
 
 
 class MockAnisoModel(torch.nn.Module):
-    """
-    Deterministic, rotation-dependent mock for testing SymmetrizedCalculator.
-
-    Components:
-      - Energy:  E_true + a1*P1 + a2*P2 + a3*P3
-      - Forces:  F_true + (b1*P1 + b2*P2 + b3*P3)*zhat + optional tensor L=2 term
-      - Stress:  p_iso*I + (c2*P2 + c3*P3)*D
-
-    :param a: Coefficients for Legendre P0..P3 in the energy.
-    :param b: Coefficients for P1..P3 in the forces (spurious vector parts).
-    :param c: Coefficients for P2,P3 in the stress (spurious deviators).
-    :param p_iso: Isotropic (true) part of the stress tensor.
-    :param tensor_forces: If True, add L=2 tensor-coupled force term.
-    :param tensor_amp: Amplitude of the tensor-coupled force component.
-    :param dtype: Data type for internal tensors.
-    :param device: Device for internal tensors.
-    """
-
     def __init__(
         self,
         a: Tuple[float, float, float, float] = (0.0, 0.0, 0.0, 0.0),
@@ -103,8 +121,6 @@ class MockAnisoModel(torch.nn.Module):
         self.tensor_amp = tensor_amp
         self._dtype = dtype
         self._device = torch.device(device)
-
-        # Fixed bases
         self._zhat = torch.tensor([0.0, 0.0, 1.0], dtype=dtype, device=device)
         self._D = torch.diag(torch.tensor([1.0, -1.0, 0.0], dtype=dtype, device=device))
 
@@ -115,29 +131,28 @@ class MockAnisoModel(torch.nn.Module):
         selected_atoms: Optional[Labels] = None,
     ) -> Dict[str, TensorMap]:
         n_sys = len(systems)
-
-        # Pre-allocate storages
         energies: List[torch.Tensor] = []
         stresses: List[torch.Tensor] = []
         forces: List[torch.Tensor] = []
 
-        for sys in systems:
-            pos = sys.positions
-
-            # Determine body axis and related scalars
-            b = _body_axis_from_system(sys).to(dtype=self._dtype, device=self._device)
+        for system in systems:
+            pos = system.positions
+            b = _body_axis_from_system(system).to(
+                dtype=self._dtype, device=self._device
+            )
             cval = float(torch.dot(b, self._zhat))
             P0, P1, P2, P3 = _legendre_0_1_2_3(cval)
 
-            # Energy
-            E_true = torch.sum(pos**2)
-            E = E_true + self.a0 * P0 + self.a1 * P1 + self.a2 * P2 + self.a3 * P3
-            energies.append(E)
+            energies.append(
+                torch.sum(pos**2)
+                + self.a0 * P0
+                + self.a1 * P1
+                + self.a2 * P2
+                + self.a3 * P3
+            )
 
-            # Forces
-            F_true = pos.clone()
             F_spur = (self.b1 * P1 + self.b2 * P2 + self.b3 * P3) * self._zhat[None, :]
-            F = F_true + F_spur
+            F = pos.clone() + F_spur
             if self.tensor_forces:
                 v = torch.cross(self._zhat, b, dim=0)
                 s = torch.norm(v)
@@ -163,109 +178,67 @@ class MockAnisoModel(torch.nn.Module):
                         + vx
                         + vx @ vx * ((1.0 - cth) / (s**2))
                     )
-                T = R @ self._D @ R.T
-                F_tensor = self.tensor_amp * (T @ self._zhat)
-                F = F + F_tensor[None, :]
+                F = F + (self.tensor_amp * (R @ self._D @ R.T @ self._zhat))[None, :]
             forces.append(F)
 
-            # Stress
-            S = (
+            stresses.append(
                 self.p_iso * torch.eye(3, dtype=self._dtype, device=self._device)
                 + (self.c2 * P2 + self.c3 * P3) * self._D
             )
-            stresses.append(S)
 
         result: Dict[str, TensorMap] = {}
-        key = Labels(
-            names=["_"],
-            values=torch.tensor([[0]], dtype=torch.int64, device=self._device),
+        zero = torch.tensor([[0]], dtype=torch.int64, device=self._device)
+        key = Labels("_", zero)
+        system_samples = Labels(
+            "system",
+            torch.arange(n_sys, dtype=torch.int64, device=self._device).unsqueeze(1),
         )
-
-        # Energy
-        energy_block = TensorBlock(
-            values=torch.stack(energies, dim=0)
-            .to(dtype=self._dtype, device=self._device)
-            .unsqueeze(-1),
-            samples=Labels(
-                names=["system"],
-                values=torch.arange(
-                    n_sys, dtype=torch.int64, device=self._device
-                ).unsqueeze(1),
-            ),
-            components=[],
-            properties=Labels(
-                names=["energy"],
-                values=torch.tensor([[0]], dtype=torch.int64, device=self._device),
-            ),
-        )
-
-        # Forces
-        force_block = TensorBlock(
-            values=torch.cat(forces, dim=0)
-            .to(dtype=self._dtype, device=self._device)
-            .unsqueeze(-1),
-            samples=Labels(
-                names=["system", "atom"],
-                values=torch.cat(
-                    [
-                        torch.cartesian_prod(torch.tensor([i]), torch.arange(len(sys)))
-                        for i, sys in enumerate(systems)
-                    ]
-                ).to(dtype=torch.int64, device=self._device),
-            ),
-            components=[
-                Labels(
-                    "xyz",
-                    torch.arange(3)
-                    .reshape(-1, 1)
-                    .to(dtype=torch.int64, device=self._device),
-                )
-            ],
-            properties=Labels(
-                names=["non_conservative_force"],
-                values=torch.tensor([[0]], dtype=torch.int64, device=self._device),
-            ),
-        )
-
-        # Stress
-        stress_block = TensorBlock(
-            values=torch.stack(stresses, dim=0)
-            .to(dtype=self._dtype, device=self._device)
-            .unsqueeze(-1),
-            samples=Labels(
-                names=["system"],
-                values=torch.arange(
-                    n_sys, dtype=torch.int64, device=self._device
-                ).unsqueeze(1),
-            ),
-            components=[
-                Labels(
-                    "xyz_1",
-                    torch.arange(3)
-                    .reshape(-1, 1)
-                    .to(dtype=torch.int64, device=self._device),
-                ),
-                Labels(
-                    "xyz_2",
-                    torch.arange(3)
-                    .reshape(-1, 1)
-                    .to(dtype=torch.int64, device=self._device),
-                ),
-            ],
-            properties=Labels(
-                names=["non_conservative_stress"],
-                values=torch.tensor([[0]], dtype=torch.int64, device=self._device),
-            ),
-        )
+        xyz = torch.arange(3, dtype=torch.int64, device=self._device).reshape(-1, 1)
 
         if "energy" in outputs:
-            result["energy"] = TensorMap(key, [energy_block])
+            result["energy"] = TensorMap(
+                key,
+                [
+                    TensorBlock(
+                        torch.stack(energies).unsqueeze(-1),
+                        system_samples,
+                        [],
+                        Labels("energy", zero),
+                    )
+                ],
+            )
 
         if "non_conservative_force" in outputs:
-            result["non_conservative_force"] = TensorMap(key, [force_block])
+            force_samples = torch.cat(
+                [
+                    torch.cartesian_prod(torch.tensor([i]), torch.arange(len(system)))
+                    for i, system in enumerate(systems)
+                ]
+            ).to(dtype=torch.int64, device=self._device)
+            result["non_conservative_force"] = TensorMap(
+                key,
+                [
+                    TensorBlock(
+                        torch.cat(forces).unsqueeze(-1),
+                        Labels(["system", "atom"], force_samples),
+                        [Labels("xyz", xyz)],
+                        Labels("non_conservative_force", zero),
+                    )
+                ],
+            )
 
         if "non_conservative_stress" in outputs:
-            result["non_conservative_stress"] = TensorMap(key, [stress_block])
+            result["non_conservative_stress"] = TensorMap(
+                key,
+                [
+                    TensorBlock(
+                        torch.stack(stresses).unsqueeze(-1),
+                        system_samples,
+                        [Labels("xyz_1", xyz), Labels("xyz_2", xyz)],
+                        Labels("non_conservative_stress", zero),
+                    )
+                ],
+            )
 
         return result
 
@@ -273,26 +246,9 @@ class MockAnisoModel(torch.nn.Module):
         return []
 
 
-def mock_atomistic_model(
-    a: tuple[float, float, float, float] = (0.0, 0.0, 0.0, 0.0),
-    b: tuple[float, float, float] = (0.0, 0.0, 0.0),
-    c: tuple[float, float] = (0.0, 0.0),
-    p_iso: float = 1.0,
-    tensor_forces: bool = False,
-    tensor_amp: float = 0.5,
-) -> AtomisticModel:
-    model = MockAnisoModel(
-        a=a,
-        b=b,
-        c=c,
-        p_iso=p_iso,
-        tensor_forces=tensor_forces,
-        tensor_amp=tensor_amp,
-    )
-    model.eval()
-
+def mock_atomistic_model(**options) -> AtomisticModel:
     return AtomisticModel(
-        model,
+        MockAnisoModel(**options).eval(),
         ModelMetadata("mock_aniso", "Mock anisotropic model for testing"),
         ModelCapabilities(
             {
@@ -311,23 +267,9 @@ def mock_atomistic_model(
     )
 
 
-def mock_calculator(
-    a: tuple[float, float, float, float] = (0.0, 0.0, 0.0, 0.0),
-    b: tuple[float, float, float] = (0.0, 0.0, 0.0),
-    c: tuple[float, float] = (0.0, 0.0),
-    p_iso: float = 1.0,
-    tensor_forces: bool = False,
-    tensor_amp: float = 0.5,
-) -> MetatomicCalculator:
+def mock_calculator(**options) -> MetatomicCalculator:
     return MetatomicCalculator(
-        mock_atomistic_model(
-            a=a,
-            b=b,
-            c=c,
-            p_iso=p_iso,
-            tensor_forces=tensor_forces,
-            tensor_amp=tensor_amp,
-        ),
+        mock_atomistic_model(**options),
         non_conservative=True,
         do_gradients_with_energy=False,
         additional_outputs={
@@ -338,42 +280,138 @@ def mock_calculator(
     )
 
 
+class RequestedInputEnergyModel(torch.nn.Module):
+    _requested_inputs: Dict[str, ModelOutput]
+
+    def __init__(self, name: str, unit: str, sample_kind: str):
+        super().__init__()
+        self.input_name = name
+        self._requested_inputs = {name: ModelOutput(unit=unit, sample_kind=sample_kind)}
+
+    def requested_inputs(self) -> Dict[str, ModelOutput]:
+        return self._requested_inputs
+
+    def forward(
+        self,
+        systems: List[System],
+        outputs: Dict[str, ModelOutput],
+        selected_atoms: Optional[Labels] = None,
+    ) -> Dict[str, TensorMap]:
+        energies: List[torch.Tensor] = []
+        for system in systems:
+            energies.append(system.get_data(self.input_name).block().values.sum())
+
+        device = systems[0].positions.device
+        return {
+            "energy": TensorMap(
+                Labels("_", torch.tensor([[0]], device=device)),
+                [
+                    TensorBlock(
+                        values=torch.stack(energies).reshape(-1, 1),
+                        samples=Labels(
+                            "system",
+                            torch.arange(len(systems), device=device).reshape(-1, 1),
+                        ),
+                        components=torch.jit.annotate(List[Labels], []),
+                        properties=Labels("energy", torch.tensor([[0]], device=device)),
+                    )
+                ],
+            )
+        }
+
+
+def requested_input_calculator(
+    name: str,
+    unit: str,
+    sample_kind: str = "atom",
+    requested_inputs: Optional[Dict[str, ModelOutput]] = None,
+) -> MetatomicCalculator:
+    model = RequestedInputEnergyModel(name, unit, sample_kind).eval()
+    if requested_inputs is not None:
+        model._requested_inputs = requested_inputs
+    atomistic = AtomisticModel(
+        model,
+        ModelMetadata(),
+        ModelCapabilities(
+            {"energy": ModelOutput(sample_kind="system", unit="eV")},
+            [1],
+            0.0,
+            "Angstrom",
+            ["cpu"],
+            "float64",
+        ),
+    )
+    return MetatomicCalculator(atomistic, check_consistency=True)
+
+
+def _set_input_dependency(atoms, dependency, value):
+    if dependency == "momenta":
+        atoms.set_momenta([[value, 0.0, 0.0]])
+    elif dependency == "masses":
+        atoms.set_masses([value])
+    elif dependency == "signal":
+        atoms.set_array("signal", np.asarray([value]))
+    elif dependency == "bias":
+        atoms.info["bias"] = value
+    else:  # pragma: no cover - test-table programming error
+        raise AssertionError(f"unknown dependency: {dependency}")
+
+
+@pytest.mark.parametrize(
+    ("standard_name", "standard_unit", "custom_name", "info_name", "value"),
+    [
+        ("charge", "e", "ase::info::charge", "charge", 0.0),
+        ("spin_multiplicity", "", "ase::info::spin", "spin", 1),
+    ],
+)
+@pytest.mark.parametrize("custom_first", [False, True])
+def test_required_info_cache_watch_dominates_standard_default(
+    standard_name,
+    standard_unit,
+    custom_name,
+    info_name,
+    value,
+    custom_first,
+):
+    names = (
+        [custom_name, standard_name] if custom_first else [standard_name, custom_name]
+    )
+    units = {standard_name: standard_unit, custom_name: ""}
+    requested_inputs = {
+        name: ModelOutput(unit=units[name], sample_kind="system") for name in names
+    }
+    base = requested_input_calculator(
+        custom_name,
+        "",
+        sample_kind="system",
+        requested_inputs=requested_inputs,
+    )
+    calculator = SymmetrizedCalculator(base, l_max=0, include_inversion=False)
+    atoms = Atoms("H")
+    atoms.info[info_name] = value
+    atoms.calc = calculator
+
+    assert atoms.get_potential_energy() == pytest.approx(value)
+    del atoms.info[info_name]
+    assert info_name in calculator.check_state(atoms)
+    with pytest.raises(ValueError, match=f"no info with name '{info_name}'"):
+        atoms.get_potential_energy()
+
+
 @pytest.fixture
 def dimer() -> Atoms:
-    """
-    Create a small asymmetric geometry with a well-defined body axis.
-
-    :return: ASE Atoms object with the H2 molecule.
-    """
     return Atoms("H2", positions=[[0, 0, 0], [0.3, 0.2, 1.0]])
 
 
 @pytest.fixture
 def fcc_bulk() -> Atoms:
-    """
-    Create a small FCC bulk structure.
-
-    :return: ASE Atoms object with FCC Cu.
-    """
     return bulk("Cu", "fcc", cubic=True)
-
-
-def test_quadrature_normalization():
-    """Verify normalization and determinant signs of the quadrature."""
-    R, w = _get_quadrature(lebedev_order=11, n_rotations=5, include_inversion=True)
-    assert np.isclose(np.sum(w), 1.0)
-    dets = np.linalg.det(R)
-    assert np.all(np.isin(np.round(dets).astype(int), [-1, 1]))
 
 
 @pytest.mark.parametrize("Lmax, expect_removed", [(0, False), (3, True)])
 def test_energy_L_components_removed(
     dimer: Atoms, Lmax: int, expect_removed: bool
 ) -> None:
-    """
-    Verify that spurious energy components vanish once rotational averaging is applied.
-    For Lmax>0, all use the same minimal Lebedev rule (order=3).
-    """
     a = (1.0, 1.0, 1.0, 1.0)
     base = mock_calculator(a=a)
     calc = SymmetrizedCalculator(base, l_max=Lmax)
@@ -387,28 +425,7 @@ def test_energy_L_components_removed(
         assert not np.isclose(e, E_true + a[0], atol=1e-10)
 
 
-def test_force_backrotation_exact(dimer: Atoms) -> None:
-    """
-    Check that forces are back-rotated exactly when no spurious terms are present.
-
-    :param dimer: Test atomic structure.
-    """
-    base = mock_calculator(b=(0, 0, 0))
-    calc = SymmetrizedCalculator(base, l_max=3)
-    dimer.calc = calc
-    F = dimer.get_forces()
-    expected_F = dimer.get_positions()
-    expected_F -= np.mean(expected_F, axis=0)
-    assert np.allclose(F, expected_F, atol=1e-12)
-
-
 def test_tensorial_L2_force_cancellation(dimer: Atoms) -> None:
-    """
-    Tensor-coupled (L=2) force components must vanish under O(3) averaging.
-
-    Since the minimal Lebedev order used internally is 3, all quadratures
-    integrate L=2 components exactly; we only check for correct cancellation.
-    """
     base = mock_calculator(tensor_forces=True, tensor_amp=1.0)
 
     for Lmax in [1, 2, 3]:
@@ -420,56 +437,42 @@ def test_tensorial_L2_force_cancellation(dimer: Atoms) -> None:
         assert np.allclose(F, expected_F, atol=1e-10)
 
 
-def test_stress_isotropization(fcc_bulk: Atoms) -> None:
-    """
-    Check that stress deviatoric parts (L=2,3) vanish under full O(3) averaging.
+def test_product_quadrature_cancels_rank_three_vector_integrand() -> None:
+    """Exercise the D^3 response times D^1 vector-backrotation product directly."""
+    lebedev_order, n_rotations = _choose_quadrature(3)
+    rotations, weights = _get_quadrature(
+        lebedev_order, n_rotations, include_inversion=False
+    )
 
-    :param fcc_bulk: Test atomic structure.
+    body = np.array([0.3, 0.2, 1.0])
+    body /= np.linalg.norm(body)
+    rotated_body = np.einsum("bij,j->bi", rotations, body)
+    cosine = rotated_body[:, 2]
+    p3 = 0.5 * (5.0 * cosine**3 - 3.0 * cosine)
+    forces = p3[:, None, None] * np.array([0.0, 0.0, 1.0])[None, None, :]
+
+    averaged = _compute_rotational_average(
+        {"forces": forces}, rotations, weights, False
+    )["forces"]
+    assert np.allclose(averaged, np.zeros((1, 3)), atol=1e-12)
+
+
+def test_stress_trace_is_preserved(fcc_bulk: Atoms) -> None:
+    """Averaging preserves the isotropic stress component.
+
+    The traceless part need not vanish: symmetrization makes a rank-2 output
+    equivariant, not invariant, so an input-dependent deviatoric stress is valid.
     """
     base = mock_calculator(c=(2.0, 1.0), p_iso=5.0)
-    calc = SymmetrizedCalculator(base, l_max=9, include_inversion=True)
+    calc = SymmetrizedCalculator(base, l_max=3, include_inversion=True)
     fcc_bulk.calc = calc
     fcc_bulk.get_forces()
     S = fcc_bulk.get_stress(voigt=False)
 
-    fcc_bulk.calc = base
-    fcc_bulk.get_forces()
-
-    iso = np.trace(S) / 3.0
-    assert np.isclose(iso, 5.0, atol=1e-10)
-
-
-def test_cancellation_vs_Lmax(dimer: Atoms) -> None:
-    """
-    Residual anisotropy must vanish once rotational averaging is applied.
-    All quadratures with Lmax>0 are equivalent (Lebedev order=3).
-    """
-    a = (0.0, 0.0, 1.0, 1.0)
-    base = mock_calculator(a=a)
-    E_true = float(np.sum(dimer.positions**2))
-
-    # No averaging
-    calc0 = SymmetrizedCalculator(base, l_max=0)
-    dimer.calc = calc0
-    dimer.get_forces()
-    e0 = dimer.get_potential_energy()
-
-    # Averaged
-    calc3 = SymmetrizedCalculator(base, l_max=3)
-    dimer.calc = calc3
-    dimer.get_forces()
-    e3 = dimer.get_potential_energy()
-
-    assert not np.isclose(e0, E_true, atol=1e-10)
-    assert np.isclose(e3, E_true, atol=1e-10)
+    assert np.isclose(np.trace(S) / 3.0, 5.0, atol=1e-10)
 
 
 def test_joint_energy_force_consistency(dimer: Atoms) -> None:
-    """
-    Combined test: both energy and forces are consistent and invariant.
-
-    :param dimer: Test atomic structure.
-    """
     base = mock_calculator(a=(1, 1, 1, 1), b=(0, 0, 0))
     calc = SymmetrizedCalculator(base, l_max=3)
     dimer.calc = calc
@@ -481,37 +484,501 @@ def test_joint_energy_force_consistency(dimer: Atoms) -> None:
     assert np.allclose(f, expected_F, atol=1e-12)
 
 
-def test_rotate_atoms_preserves_geometry(tmp_path):
-    """Check that _rotate_atoms applies rotations correctly and preserves distances."""
+def _requested_features(atoms, *names):
+    class _Model:
+        def requested_inputs(self, use_new_names=True):
+            assert use_new_names
+            return {name: ModelOutput(sample_kind="atom") for name in names}
+
+    class _Base:
+        _model = _Model()
+
+    return symmetry_module._requested_per_atom_features(_Base(), atoms)
+
+
+_MAGMOM_INPUTS = [
+    ("ase::initial_magmoms", "e * hbar / (2 * m_e)"),
+    ("ase::arrays::initial_magmoms", ""),
+]
+
+
+def test_rotate_atoms_preserves_geometry():
     from scipy.spatial.transform import Rotation
 
-    # Build simple cubic cell with 2 atoms along x
-    atoms = Atoms("H2", positions=[[0, 0, 0], [1, 0, 0]], cell=np.eye(3))
+    atoms = Atoms("H2", positions=[[0, 0, 0], [1.2, 0, 0]], cell=np.eye(3), pbc=True)
+    atoms.set_momenta([[1, 0, 0], [0, 1, 0]])
+    atoms.new_array("custom_vector", np.array([[1, 2, 3], [4, 5, 6]]))
+    atoms.new_array("labels3", np.array([["a", "b", "c"], ["d", "e", "f"]]))
+    atoms.set_tags([3, 4])
     R = Rotation.from_euler("z", 90, degrees=True).as_matrix()[None, ...]  # 90° about z
 
-    rotated = _rotate_atoms(atoms, R)[0]
-    # Positions should now align along y
+    rotated = _rotate_atoms(atoms, R, ["momenta", "custom_vector"])[0]
     assert np.allclose(
-        rotated.positions[1] - rotated.positions[0], [0, 1, 0], atol=1e-12
+        rotated.positions[1] - rotated.positions[0], [0, 1.2, 0], atol=1e-12
     )
-    # Cell rotated
     assert np.allclose(rotated.cell[0], [0, 1, 0], atol=1e-12)
-    # Distances preserved
+    assert np.allclose(
+        rotated.get_scaled_positions(wrap=False),
+        atoms.get_scaled_positions(wrap=False),
+        atol=1e-12,
+    )
     d0 = atoms.get_distance(0, 1)
     d1 = rotated.get_distance(0, 1)
     assert np.isclose(d0, d1, atol=1e-12)
+    assert np.allclose(rotated.get_momenta(), atoms.get_momenta() @ R[0].T)
+    assert np.allclose(
+        rotated.arrays["custom_vector"], atoms.arrays["custom_vector"] @ R[0].T
+    )
+    assert np.array_equal(rotated.get_tags(), atoms.get_tags())
+    assert np.array_equal(rotated.arrays["labels3"], atoms.arrays["labels3"])
+
+    inverted = _rotate_atoms(atoms, -np.eye(3)[None, ...], ["momenta"])[0]
+    assert np.allclose(inverted.get_momenta(), -atoms.get_momenta())
+
+
+def test_identity_grid_preserves_unwrapped_periodic_coordinates():
+    atoms = Atoms("H", positions=[[1.2, -0.3, 0.5]], cell=np.eye(3), pbc=True)
+    atoms.calc = SymmetrizedCalculator(
+        mock_calculator(), l_max=0, include_inversion=False
+    )
+
+    assert atoms.get_potential_energy() == pytest.approx(
+        np.sum(atoms.positions**2), abs=1e-12
+    )
+
+
+def test_space_group_operations_respect_per_atom_arrays():
+    atoms = Atoms(
+        "H2",
+        scaled_positions=[[0.0, 0.0, 0.0], [0.5, 0.5, 0.5]],
+        cell=np.eye(3),
+        pbc=True,
+    )
+    atoms.set_tags([1, 2])
+    features, _ = _requested_features(atoms, "ase::tags")
+
+    rotations, permutations = _get_group_operations(atoms, per_atom_features=features)
+
+    assert len(permutations) > 0
+    assert all(
+        np.array_equal(atoms.get_tags()[p], atoms.get_tags()) for p in permutations
+    )
+
+
+def test_unrequested_arrays_do_not_reduce_space_group():
+    atoms = Atoms("Cu", scaled_positions=[[0.0, 0.0, 0.0]], cell=np.eye(3), pbc=True)
+    atoms.set_momenta([[1.234, 2.345, 3.456]])
+    atoms.new_array("labels3", np.array([["a", "b", "c"]]))
+    features, vectors = _requested_features(atoms)
+
+    rotations, permutations = _get_group_operations(atoms, per_atom_features=features)
+
+    assert vectors == []
+    assert len(rotations) == 48
+
+
+@pytest.mark.parametrize(("name", "unit"), _MAGMOM_INPUTS)
+def test_vector_initial_magmoms_are_rejected_for_improper_quadrature(name, unit):
+    atoms = Atoms("H", positions=[[0.0, 0.0, 0.0]])
+    atoms.set_initial_magnetic_moments([[1.0, 2.0, 3.0]])
+    base = requested_input_calculator(name, unit)
+    calculator = SymmetrizedCalculator(base, l_max=0, include_inversion=True)
+
+    with pytest.raises(ValueError, match=r"axial O\(3\) parity"):
+        calculator.calculate(atoms, ["energy"], [])
+
+
+@pytest.mark.parametrize(("name", "unit"), _MAGMOM_INPUTS)
+def test_vector_initial_magmoms_are_rotated_for_proper_quadrature(name, unit):
+    atoms = Atoms("H", positions=[[0.0, 0.0, 0.0]])
+    magnetic_moment = np.array([[1.0, 2.0, 3.0]])
+    atoms.set_initial_magnetic_moments(magnetic_moment)
+    base = requested_input_calculator(name, unit)
+    calculator = SymmetrizedCalculator(base, l_max=1, include_inversion=False)
+
+    calculator.calculate(atoms, ["energy"], [])
+
+    rotated = magnetic_moment @ np.swapaxes(calculator.quadrature_rotations, 1, 2)
+    expected = np.sum(calculator.quadrature_weights * rotated.sum(axis=(1, 2)))
+    assert calculator.results["energy"] == pytest.approx(expected, abs=1e-14)
+
+
+def test_feature_filtered_space_group_remains_a_projector(fcc_bulk):
+    atoms = fcc_bulk.copy()
+    atoms.set_initial_charges(np.array([0.0, 0.6, 1.2, 1.8]) * 1.0e-6)
+    features, _ = _requested_features(atoms, "ase::initial_charges")
+    rotations, permutations = _get_group_operations(atoms, per_atom_features=features)
+
+    rng = np.random.default_rng(123)
+    results = {
+        "energies": rng.normal(size=len(atoms)),
+        "forces": rng.normal(size=(len(atoms), 3)),
+        "stress": rng.normal(size=(3, 3)),
+    }
+    once = _average_over_group(results, rotations, permutations)
+    twice = _average_over_group(once, rotations, permutations)
+    for name in results:
+        assert np.allclose(twice[name], once[name], atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    ("direction", "dtype", "expected_operations"),
+    [
+        ([1.0e-15, 0.0, 0.0], float, 8),
+        ([1.0e20, 1.0, 0.0], float, 2),
+        ([1.0, 1.0 + 1.0e-6, 1.0], np.float32, 2),
+    ],
+    ids=["tiny", "large-component-range", "float32-resolution"],
+)
+def test_vector_feature_filter_has_componentwise_scale(
+    direction, dtype, expected_operations
+):
+    atoms = Atoms("Cu", scaled_positions=[[0.0, 0.0, 0.0]], cell=np.eye(3), pbc=True)
+    atoms.new_array("direction", np.array([direction], dtype=dtype))
+    features, _ = _requested_features(atoms, "ase::arrays::direction")
+
+    rotations, permutations = _get_group_operations(atoms, per_atom_features=features)
+
+    assert len(rotations) == expected_operations
+
+
+def test_space_group_filter_applies_axial_parity_to_improper_actions():
+    atoms = Atoms("Cu", scaled_positions=[[0.0, 0.0, 0.0]], cell=np.eye(3), pbc=True)
+    direction = np.array([[0.0, 0.0, 1.0]])
+
+    polar, _ = _get_group_operations(
+        atoms, per_atom_features=[("direction", direction, "polar")]
+    )
+    axial, _ = _get_group_operations(
+        atoms, per_atom_features=[("direction", direction, "axial")]
+    )
+
+    polar_improper = [Q for Q in polar if np.linalg.det(Q) < 0]
+    axial_improper = [Q for Q in axial if np.linalg.det(Q) < 0]
+    assert len(polar) == len(axial) == 8
+    assert len(polar_improper) == len(axial_improper) == 4
+    assert all(np.isclose(Q[2, 2], 1.0) for Q in polar_improper)
+    assert all(np.isclose(Q[2, 2], -1.0) for Q in axial_improper)
+
+
+def test_group_closure_check_rejects_nonclosed_actions():
+    quarter_turn = np.array([[0, -1, 0], [1, 0, 0], [0, 0, 1]])
+    assert not symmetry_module._group_actions_are_closed(
+        [np.eye(3, dtype=int), quarter_turn], [np.array([0]), np.array([0])]
+    )
+
+
+@pytest.mark.parametrize(
+    ("direction", "expected_actions"),
+    [([1.0, 0.0, 0.0], 6), ([1e20, 0.0, 1.0], 2)],
+)
+def test_vector_filter_rotated_crystal_little_group(direction, expected_actions):
+    axis = np.array([1.0, 1.0, 1.0]) / np.sqrt(3.0)
+    transverse = np.array([1.0, -1.0, 0.0]) / np.sqrt(2.0)
+    cell = np.stack([axis, transverse, np.cross(axis, transverse)]).T
+    atoms = Atoms("Cu", scaled_positions=[[0.0, 0.0, 0.0]], cell=cell, pbc=True)
+    atoms.new_array("direction", np.array([direction]))
+    features, _ = _requested_features(atoms, "ase::arrays::direction")
+
+    rotations, permutations = _get_group_operations(atoms, per_atom_features=features)
+
+    assert len(rotations) == expected_actions
+
+
+def test_vector_filter_handles_anisotropic_rotated_cell_roundoff():
+    from scipy.spatial.transform import Rotation
+
+    orientation = Rotation.random(random_state=972).as_matrix()
+    cell = np.diag([1.0, 100.0, 10_000.0]) @ orientation.T
+    atoms = Atoms("Cu", scaled_positions=[[0.0, 0.0, 0.0]], cell=cell, pbc=True)
+    feature = [("direction", orientation[:, 2][None, :], "polar")]
+
+    rotations, permutations = _get_group_operations(atoms, per_atom_features=feature)
+
+    assert len(rotations) == 4
+
+
+def test_vector_filter_retains_identity_in_triclinic_cell():
+    atoms = Atoms(
+        "Cu",
+        scaled_positions=[[0.0, 0.0, 0.0]],
+        cell=[[2.1, 0.2, 0.1], [0.3, 1.7, 0.2], [0.1, 0.4, 1.9]],
+        pbc=True,
+    )
+    atoms.new_array("direction", np.array([[1.0, 0.0, 0.0]]))
+    features, _ = _requested_features(atoms, "ase::arrays::direction")
+
+    rotations, _ = _get_group_operations(atoms, per_atom_features=features)
+
+    assert len(rotations) == 1
+    assert np.array_equal(rotations[0], np.eye(3))
 
 
 def test_choose_quadrature_rules():
-    """Check that _choose_quadrature selects appropriate rules."""
     for L in [0, 5, 17, 50]:
         lebedev_order, n_gamma = _choose_quadrature(L)
-        assert lebedev_order >= L
+        assert lebedev_order >= 2 * L
         assert n_gamma == 2 * L + 1
+
+    assert _choose_quadrature(65) == (131, 131)
+
+
+def test_choose_quadrature_rejects_unsupported_bandwidth():
+    with pytest.raises(ValueError, match="largest supported l_max is 65"):
+        _choose_quadrature(66)
+
+
+@pytest.mark.parametrize(
+    ("name", "value", "error"),
+    [
+        ("l_max", -1, ValueError),
+        ("l_max", 1.0, TypeError),
+        ("l_max", True, TypeError),
+        ("batch_size", 0, ValueError),
+        ("batch_size", -1, ValueError),
+        ("batch_size", 1.0, TypeError),
+        ("batch_size", True, TypeError),
+    ],
+)
+def test_constructor_rejects_invalid_discrete_settings(name, value, error):
+    arguments = {"l_max": 0, name: value}
+    with pytest.raises(error, match=name):
+        SymmetrizedCalculator(mock_calculator(), **arguments)
+
+
+def test_constructor_accepts_numpy_integer_settings():
+    calculator = SymmetrizedCalculator(
+        mock_calculator(), l_max=np.int64(0), batch_size=np.int64(1)
+    )
+    assert calculator.l_max == 0
+    assert calculator.batch_size == 1
+
+
+def test_supported_properties_match_base_calculator_contract():
+    assert "stresses" not in SymmetrizedCalculator.implemented_properties
+
+
+def test_calculate_streams_rotations_in_bounded_batches(dimer, monkeypatch):
+    class _CountingBase:
+        def __init__(self):
+            self.calculate_calls = 0
+            self.batch_sizes = []
+            self.previous_atoms = None
+            self.previous_forces = None
+
+        def calculate(self, atoms, properties, system_changes):
+            self.calculate_calls += 1
+
+        def compute_energy(
+            self, atoms_list, compute_forces_and_stresses=False, per_atom=False
+        ):
+            if self.previous_atoms is not None:
+                assert self.previous_atoms() is None
+                assert self.previous_forces() is None
+            self.batch_sizes.append(len(atoms_list))
+            forces = np.ones((len(atoms_list[0]), 3))
+            self.previous_atoms = weakref.ref(atoms_list[0])
+            self.previous_forces = weakref.ref(forces)
+            return {
+                "energy": [float(np.sum(atoms.positions**2)) for atoms in atoms_list],
+                "forces": [forces],
+            }
+
+    rotation_batch_sizes = []
+    original_rotate_atoms = symmetry_module._rotate_atoms
+
+    def counted_rotate_atoms(atoms, rotations, vector_arrays=None):
+        rotation_batch_sizes.append(len(rotations))
+        return original_rotate_atoms(atoms, rotations, vector_arrays)
+
+    monkeypatch.setattr(symmetry_module, "_rotate_atoms", counted_rotate_atoms)
+    base = _CountingBase()
+    calculator = SymmetrizedCalculator(
+        base,
+        l_max=0,
+        batch_size=1,
+        include_inversion=True,
+    )
+    calculator.calculate(dimer, ["forces"], [])
+
+    assert base.calculate_calls == 0
+    assert base.batch_sizes == [1, 1]
+    assert rotation_batch_sizes == [1, 1]
+    assert base.previous_atoms() is None
+    assert base.previous_forces() is None
+    assert np.all(np.isfinite(calculator.results["forces"]))
+
+
+def test_calculate_rotates_requested_momentum_input():
+    atoms = Atoms("H", positions=[[0.0, 0.0, 0.0]])
+    atoms.set_momenta([[2.0, 0.0, 0.0]])
+    base = requested_input_calculator("momentum", "(eV*u)^(1/2)")
+    calculator = SymmetrizedCalculator(base, l_max=0, include_inversion=True)
+
+    calculator.calculate(atoms, ["energy"], [])
+
+    assert calculator.results["energy"] == pytest.approx(0.0, abs=1e-15)
+
+
+@pytest.mark.parametrize(
+    (
+        "name",
+        "unit",
+        "sample_kind",
+        "dependency",
+        "initial",
+        "changed",
+        "expected",
+    ),
+    [
+        ("momentum", "(eV*u)^(1/2)", "atom", "momenta", 1.0, 2.0, (1.0, 2.0)),
+        ("velocity", "(eV/u)^(1/2)", "atom", "masses", 1.0, 2.0, (2.0, 1.0)),
+        ("ase::arrays::signal", "", "atom", "signal", 1.0, 2.0, (1.0, 2.0)),
+        ("ase::info::bias", "", "system", "bias", 3.0, 9.0, (3.0, 9.0)),
+    ],
+    ids=["momentum", "velocity-mass", "custom-array", "custom-info"],
+)
+def test_cache_tracks_every_requested_input_dependency(
+    name, unit, sample_kind, dependency, initial, changed, expected
+):
+    atoms = Atoms("H", positions=[[0.0, 0.0, 0.0]])
+    if name == "velocity":
+        atoms.set_momenta([[2.0, 0.0, 0.0]])
+    _set_input_dependency(atoms, dependency, initial)
+    atoms.calc = SymmetrizedCalculator(
+        requested_input_calculator(name, unit, sample_kind),
+        l_max=0,
+        include_inversion=False,
+    )
+
+    assert atoms.get_potential_energy() == pytest.approx(expected[0])
+    _set_input_dependency(atoms, dependency, changed)
+    assert dependency in atoms.calc.check_state(atoms)
+    assert atoms.get_potential_energy() == pytest.approx(expected[1])
+
+
+def test_cache_tracks_in_place_info_mutation():
+    atoms = Atoms("H")
+    atoms.info["bias"] = np.array(3.0)
+    base = requested_input_calculator("ase::info::bias", "", "system")
+    atoms.calc = SymmetrizedCalculator(base, l_max=0, include_inversion=False)
+
+    assert atoms.get_potential_energy() == pytest.approx(3.0)
+    atoms.info["bias"][...] = 9.0
+    assert "bias" in atoms.calc.check_state(atoms)
+    assert atoms.get_potential_energy() == pytest.approx(9.0)
+
+
+def test_calculate_rejects_reserved_custom_positions_input():
+    atoms = Atoms("H", positions=[[2.0, 0.0, 0.0]])
+    base = requested_input_calculator("ase::arrays::positions", "")
+    calculator = SymmetrizedCalculator(base, l_max=0, include_inversion=True)
+
+    with pytest.raises(ValueError, match="must use System.positions"):
+        calculator.calculate(atoms, ["energy"], [])
+
+
+def test_calculate_rotates_boolean_xyz_input_as_converter_labels_it():
+    atoms = Atoms("H", positions=[[0.0, 0.0, 0.0]])
+    atoms.new_array("flags", np.array([[True, False, False]]))
+    base = requested_input_calculator("ase::arrays::flags", "")
+    calculator = SymmetrizedCalculator(base, l_max=0, include_inversion=True)
+
+    calculator.calculate(atoms, ["energy"], [])
+
+    assert calculator.results["energy"] == pytest.approx(0.0, abs=1e-15)
+
+
+@pytest.mark.parametrize(
+    ("name", "sample_kind", "dependency"),
+    [
+        ("ase::arrays::signal", "atom", "signal"),
+        ("ase::info::bias", "system", "bias"),
+    ],
+    ids=["custom-array", "custom-info"],
+)
+@pytest.mark.parametrize(
+    ("value", "error"),
+    [
+        (np.nan, "non-finite"),
+        (np.inf, "non-finite"),
+        (-np.inf, "non-finite"),
+        (1.0 + 2.0j, "real-valued"),
+    ],
+    ids=["nan", "positive-inf", "negative-inf", "complex"],
+)
+def test_calculate_rejects_invalid_requested_input(
+    name, sample_kind, dependency, value, error
+):
+    atoms = Atoms("H", positions=[[0.0, 0.0, 0.0]])
+    _set_input_dependency(atoms, dependency, value)
+    calculator = SymmetrizedCalculator(
+        requested_input_calculator(name, "", sample_kind), l_max=0
+    )
+
+    with pytest.raises(ValueError, match=f"{dependency}.*{error}"):
+        calculator.calculate(atoms, ["energy"], [])
+
+
+def test_failed_projection_does_not_leave_partial_cached_results(monkeypatch):
+    class _EnergyBase:
+        def compute_energy(
+            self, atoms_list, compute_forces_and_stresses=False, per_atom=False
+        ):
+            return {
+                "energy": [1.0 for _ in atoms_list],
+                "forces": [np.ones((len(atoms), 3)) for atoms in atoms_list],
+            }
+
+    projection_calls = 0
+
+    def fail_once(atoms, **kwargs):
+        nonlocal projection_calls
+        projection_calls += 1
+        if projection_calls == 1:
+            raise RuntimeError("synthetic projection failure")
+        return [], []
+
+    monkeypatch.setattr(symmetry_module, "_get_group_operations", fail_once)
+    atoms = Atoms("H", positions=[[0.0, 0.0, 0.0]])
+    calculator = SymmetrizedCalculator(
+        _EnergyBase(),
+        l_max=0,
+        include_inversion=False,
+        apply_space_group_symmetry=True,
+    )
+    atoms.calc = calculator
+
+    with pytest.raises(RuntimeError, match="synthetic projection failure"):
+        atoms.get_forces()
+    assert calculator.results == {}
+
+    assert np.allclose(atoms.get_forces(), 1.0)
+    assert projection_calls == 2
+
+
+def test_scalar_energy_skips_space_group_discovery(fcc_bulk, monkeypatch):
+    def unexpected_group_discovery(*args, **kwargs):
+        raise AssertionError("scalar total energy needs no space-group projection")
+
+    monkeypatch.setattr(
+        symmetry_module, "_get_group_operations", unexpected_group_discovery
+    )
+    calculator = SymmetrizedCalculator(
+        mock_calculator(a=(0.0, 1.0, 0.0, 0.0)),
+        l_max=0,
+        include_inversion=True,
+        apply_space_group_symmetry=True,
+        store_rotational_std=True,
+    )
+
+    calculator.calculate(fcc_bulk, ["energy"], [])
+
+    assert np.isfinite(calculator.results["energy"])
+    assert np.isfinite(calculator.results["energy_rot_std"])
 
 
 def test_get_quadrature_properties():
-    """Check properties of the quadrature returned by _get_quadrature."""
     R, w = _get_quadrature(lebedev_order=11, n_rotations=5, include_inversion=False)
     assert np.isclose(np.sum(w), 1.0)
     assert np.allclose([np.dot(r.T, r) for r in R], np.eye(3), atol=1e-12)
@@ -526,96 +993,401 @@ def test_get_quadrature_properties():
     assert np.isclose(np.sum(w_inv), 1.0)
 
 
-def test_compute_rotational_average_identity():
-    """Check that _compute_rotational_average produces correct averages."""
-
-    R = np.repeat(np.eye(3)[None, :, :], 3, axis=0)
-    w = np.ones(3) / 3
+@pytest.mark.parametrize("batch_size", [1, 2, 7, 1000])
+def test_streaming_rotational_average_matches_full_grid(batch_size):
+    rotations, weights = _get_quadrature(
+        lebedev_order=7,
+        n_rotations=5,
+        include_inversion=True,
+    )
+    generator = np.random.default_rng(20260711)
+    n_rotations = len(rotations)
+    n_atoms = 4
     results = {
-        "energy": np.array([1.0, 2.0, 3.0]),
-        "forces": np.array([[[1, 0, 0]], [[0, 1, 0]], [[0, 0, 1]]]),
-        "stress": np.array([np.eye(3), 2 * np.eye(3), 3 * np.eye(3)]),
+        "energy": generator.normal(size=n_rotations),
+        "energies": generator.normal(size=(n_rotations, n_atoms)),
+        "forces": generator.normal(size=(n_rotations, n_atoms, 3)),
+        "stress": generator.normal(size=(n_rotations, 3, 3)),
     }
-    out = _compute_rotational_average(results, R, w, False)
-    assert np.isclose(out["energy"], np.mean(results["energy"]))
-    assert np.allclose(out["forces"], np.mean(results["forces"], axis=0))
-    assert np.allclose(out["stress"], np.mean(results["stress"], axis=0))
+    expected = _compute_rotational_average(results, rotations, weights, True)
 
-    out = _compute_rotational_average(results, R, w, True)
-    assert "energy_rot_std" in out
-    assert "forces_rot_std" in out
-    assert "stress_rot_std" in out
+    actual = _streaming_average(results, rotations, weights, batch_size)
+
+    assert actual.keys() == expected.keys()
+    for name in expected:
+        assert np.allclose(actual[name], expected[name], rtol=2e-13, atol=2e-13)
+
+
+@pytest.mark.parametrize(
+    ("excess", "raises"),
+    [(1e-15, False), (1e-12, True)],
+)
+@pytest.mark.parametrize("batch_size", [1, 2, 3])
+def test_streaming_rotational_std_preserves_signed_weight_guard(
+    excess, raises, batch_size
+):
+    rotations = np.repeat(np.eye(3)[None, :, :], 3, axis=0)
+    weights = np.array([1.0, 1.0, -1.0 - excess])
+    energy = np.array([0.0, 1.0, 0.0])
+    if raises:
+        with pytest.raises(ValueError, match="rotational variance.*negative"):
+            _streaming_average({"energy": energy}, rotations, weights, batch_size)
+    else:
+        output = _streaming_average({"energy": energy}, rotations, weights, batch_size)
+        assert output["energy_rot_std"] == 0.0
+
+
+@pytest.mark.parametrize("batch_size", [1, 2, 5])
+def test_streaming_rotational_average_is_stable_around_large_offset(batch_size):
+    rotations = np.repeat(np.eye(3)[None, :, :], 5, axis=0)
+    weights = np.array([0.1, 0.2, 0.25, 0.15, 0.3])
+    energy = 1.0e12 + np.array([0.0, 1.0, -2.0, 3.0, -1.0])
+    output = _streaming_average({"energy": energy}, rotations, weights, batch_size)
+
+    normalized = weights / np.sum(weights)
+    centered = energy - energy[0]
+    expected_mean = energy[0] + np.sum(normalized * centered)
+    expected_variance = np.sum(
+        normalized * (centered - np.sum(normalized * centered)) ** 2
+    )
+    assert output["energy"] == expected_mean
+    assert output["energy_rot_std"] == pytest.approx(
+        np.sqrt(expected_variance), abs=1e-14
+    )
+
+
+def test_streaming_rotational_average_rejects_shape_changes():
+    rotations = np.repeat(np.eye(3)[None, :, :], 2, axis=0)
+    accumulator = _RotationalAverageAccumulator(np.array([0.5, 0.5]), store_std=False)
+    accumulator.update({"forces": np.zeros((1, 2, 3))}, rotations[:1])
+
+    with pytest.raises(ValueError, match="property 'forces' changed shape"):
+        accumulator.update({"forces": np.zeros((1, 1, 3))}, rotations[1:])
+
+
+def test_componentwise_std_uses_complete_backrotated_bandwidth():
+    """A bandwidth-3 response times vector back-rotation needs l_max=4 when
+    individual squared components, rather than the invariant norm, are requested."""
+
+    def component_variance(l_max):
+        order, n_gamma = _choose_quadrature(l_max)
+        rotations, weights = _get_quadrature(order, n_gamma, False)
+        body_axis = np.array([0.0, 0.0, 1.0])
+        lab_z = np.array([0.0, 0.0, 1.0])
+        cosine = (rotations @ body_axis)[:, 2]
+        response = 0.5 * (5.0 * cosine**3 - 3.0 * cosine)
+        forces = response[:, None, None] * lab_z[None, None, :]
+        output = _compute_rotational_average(
+            {"forces": forces}, rotations, weights, True
+        )
+        return output["forces_rot_std"][0] ** 2
+
+    under_resolved = component_variance(3)
+    resolved = component_variance(4)
+    expected = np.array([11.0, 11.0, 23.0]) / 315.0
+
+    # The invariant norm is already exact on both grids, but the components are not.
+    assert np.isclose(np.sum(under_resolved), 1.0 / 7.0, atol=1e-12)
+    assert np.isclose(np.sum(resolved), 1.0 / 7.0, atol=1e-12)
+    assert not np.allclose(under_resolved, expected, atol=1e-3)
+    assert np.allclose(resolved, expected, atol=1e-12)
 
 
 def test_average_over_fcc_group(fcc_bulk: Atoms):
-    """
-    Check that averaging over the space group of an FCC crystal
-    produces an isotropic (scalar) stress tensor.
-    """
-
-    # FCC conventional cubic cell (4 atoms)
-    atoms = fcc_bulk
-
     energy = 0.0
-    forces = np.random.normal(0, 1, (4, 3))
-    forces -= np.mean(forces, axis=0)  # Ensure zero net force
-
-    # Create an intentionally anisotropic stress
+    forces = np.random.default_rng(0).normal(size=(4, 3))
+    forces -= np.mean(forces, axis=0)
     stress = np.array([[10.0, 1.0, 0.0], [1.0, 5.0, 0.0], [0.0, 0.0, 1.0]])
-    results = {"energy": energy, "forces": forces, "stress": stress}
+    rotations, permutations = _get_group_operations(fcc_bulk)
+    out = _average_over_group(
+        {"energy": energy, "forces": forces, "stress": stress},
+        rotations,
+        permutations,
+    )
 
-    Q_list, P_list = _get_group_operations(atoms)
-    out = _average_over_group(results, Q_list, P_list)
-
-    # Energy must be unchanged
     assert np.isclose(out["energy"], energy)
-
-    # Forces must average to zero by symmetry
-    F_pg = out["forces"]
-    assert np.allclose(F_pg, np.zeros_like(F_pg))
-
-    S_pg = out["stress"]
-
-    # The averaged stress must be isotropic: S_pg = (trace/3)*I
-    iso = np.trace(S_pg) / 3.0
-    assert np.allclose(S_pg, np.eye(3) * iso, atol=1e-8)
+    assert np.allclose(out["forces"], np.zeros_like(forces))
+    assert np.allclose(
+        out["stress"], np.eye(3) * np.trace(out["stress"]) / 3.0, atol=1e-8
+    )
 
 
-def test_space_group_average_non_periodic():
-    """
-    Check that averaging over the space group of a non-periodic system leaves the
-    results unchanged.
-    """
-
-    # Methane molecule (Td symmetry)
+def test_space_group_average_non_periodic_does_not_import_spglib(monkeypatch):
     atoms = molecule("CH4")
-
     energy = 0.0
-    forces = np.random.normal(0, 1, (5, 3))
-    forces -= np.mean(forces, axis=0)  # Ensure zero net force
+    forces = np.random.default_rng(0).normal(size=(5, 3))
+    forces -= np.mean(forces, axis=0)
+    monkeypatch.setitem(sys.modules, "spglib", None)
 
-    results = {"energy": energy, "forces": forces}
+    rotations, permutations = _get_group_operations(atoms)
+    assert rotations == []
+    assert permutations == []
 
-    Q_list, P_list = _get_group_operations(atoms)
-
-    # Check that the operation lists are empty
-    assert len(Q_list) == 0
-    assert len(P_list) == 0
-
-    out = _average_over_group(results, Q_list, P_list)
-
-    # Energy must be unchanged
+    out = _average_over_group(
+        {"energy": energy, "forces": forces}, rotations, permutations
+    )
     assert np.isclose(out["energy"], energy)
+    assert np.allclose(out["forces"], forces)
 
-    # Forces must be unchanged
-    F_pg = out["forces"]
-    assert np.allclose(F_pg, forces)
+
+def test_space_group_keeps_translation_distinct_permutations():
+    primitive = Atoms(
+        numbers=[1, 2, 3],
+        scaled_positions=[
+            [0.113, 0.227, 0.319],
+            [0.367, 0.419, 0.173],
+            [0.271, 0.083, 0.449],
+        ],
+        cell=[[2.1, 0.2, 0.1], [0.3, 1.7, 0.2], [0.1, 0.4, 1.9]],
+        pbc=True,
+    )
+    atoms = primitive.repeat((2, 1, 1))
+
+    Q_list, permutations = _get_group_operations(atoms)
+    identity = np.arange(len(atoms))
+    identity_rotations = [
+        permutation
+        for Q, permutation in zip(Q_list, permutations, strict=True)
+        if np.allclose(Q, np.eye(3), atol=1e-12)
+    ]
+    assert len(identity_rotations) >= 2
+    assert any(
+        not np.array_equal(permutation, identity) for permutation in permutations
+    )
+    assert all(permutation.shape == (len(atoms),) for permutation in permutations)
+
+    energies = np.arange(len(atoms), dtype=float)
+    forces = np.arange(3 * len(atoms), dtype=float).reshape(len(atoms), 3)
+    once = _average_over_group(
+        {"energies": energies, "forces": forces}, Q_list, permutations
+    )
+    twice = _average_over_group(once, Q_list, permutations)
+
+    expected_energies = 0.5 * (energies + energies[[3, 4, 5, 0, 1, 2]])
+    expected_forces = 0.5 * (forces + forces[[3, 4, 5, 0, 1, 2]])
+    assert np.allclose(once["energies"], expected_energies)
+    assert np.allclose(once["forces"], expected_forces)
+    assert np.allclose(twice["energies"], once["energies"])
+    assert np.allclose(twice["forces"], once["forces"])
+
+
+def test_space_group_matching_uses_cartesian_symprec():
+    atoms = bulk("Cu", "fcc", a=3.6, cubic=True)
+    atoms.positions[0] += [1.0e-4, -2.0e-4, 1.5e-4]
+
+    rotations, permutations = _get_group_operations(atoms, symprec=1.0e-3)
+
+    assert len(rotations) > 1
+    assert all(
+        len(np.unique(permutation)) == len(atoms) for permutation in permutations
+    )
+
+
+def _skew_site_matching_case(second_site_x):
+    frac = np.array(
+        [
+            [0.9, 0.1, 0.0],
+            [second_site_x, 0.0, 0.0],
+            [0.25, 0.25, 0.25],
+            [0.25, 0.75, 0.75],
+            [0.75, 0.25, 0.75],
+            [0.75, 0.75, 0.25],
+            [0.5, 0.5, 0.0],
+            [0.5, 0.0, 0.5],
+        ]
+    )
+    new_frac = frac.copy()
+    new_frac[0] = 0.0
+    indices = np.arange(len(frac))
+    cell = Cell([[1.0, 0.0, 0.0], [0.99, 0.1, 0.0], [0.0, 0.0, 1.0]])
+    tolerance = 1.5e-2
+    site_indices, radius = symmetry_module._build_periodic_site_indices(
+        frac, [indices], cell.array, tolerance
+    )
+    assert site_indices is not None
+    return new_frac, frac, indices, cell, tolerance, site_indices[0], radius
+
+
+def _assert_group_actions_equal(actual, expected):
+    for actual_items, expected_items in zip(actual, expected, strict=True):
+        assert len(actual_items) == len(expected_items)
+        assert all(
+            np.array_equal(left, right)
+            for left, right in zip(actual_items, expected_items, strict=True)
+        )
+
+
+@pytest.mark.parametrize(
+    "cell,symprec",
+    [
+        (
+            [[3.1, 0.0, 0.0], [2.7, 0.8, 0.0], [2.4, 0.3, 1.1]],
+            1.0e-6,
+        ),
+        (
+            [[10.0, 0.0, 0.0], [9.9999, 2.0e-3, 0.0], [0.3, 0.4, 8.0]],
+            1.0e-8,
+        ),
+    ],
+    ids=["skew", "ill-conditioned"],
+)
+def test_periodic_site_index_matches_pairwise_for_adversarial_cells(
+    monkeypatch, cell, symprec
+):
+    atoms = Atoms("Cu", scaled_positions=[[0.0, 0.0, 0.0]], cell=cell, pbc=True).repeat(
+        (3, 3, 3)
+    )
+
+    indexed_rotations, indexed_permutations = _get_group_operations(
+        atoms, symprec=symprec
+    )
+    monkeypatch.setattr(
+        symmetry_module,
+        "_build_periodic_site_indices",
+        lambda *args, **kwargs: (None, 0.0),
+    )
+    pairwise_rotations, pairwise_permutations = _get_group_operations(
+        atoms, symprec=symprec
+    )
+
+    _assert_group_actions_equal(
+        (indexed_rotations, indexed_permutations),
+        (pairwise_rotations, pairwise_permutations),
+    )
+
+
+@pytest.mark.parametrize(
+    ("second_site_x", "expected_index"),
+    [(0.98, 0), (0.986, None)],
+    ids=["verify-cartesian-nearest", "ambiguous-fallback"],
+)
+def test_periodic_site_index_verifies_or_falls_back(second_site_x, expected_index):
+    # In this skew cell, target 1 is closest in fractional Euclidean distance,
+    # while target 0 is closest in Cartesian MIC distance. The index must only
+    # generate candidates and leave the final choice to ``find_mic``.
+    new_frac, frac, indices, cell, tolerance, site_index, radius = (
+        _skew_site_matching_case(second_site_x)
+    )
+
+    indexed = symmetry_module._match_species_with_periodic_index(
+        new_frac,
+        frac,
+        indices,
+        cell,
+        tolerance,
+        site_index,
+        radius,
+    )
+    if expected_index is None:
+        assert indexed is None
+    else:
+        pairwise = symmetry_module._match_species_pairwise(
+            new_frac, frac, indices, cell
+        )
+        assert indexed is not None
+        assert indexed[0][0] == expected_index
+        assert np.array_equal(indexed[0], pairwise[0])
+        assert np.allclose(indexed[1], pairwise[1], rtol=0.0, atol=1.0e-15)
+
+
+@pytest.mark.parametrize(
+    ("n_sites", "candidates_per_site"),
+    [(8, 8), (1_000, 100)],
+    ids=["dense-fraction", "linear-memory-cap"],
+)
+def test_periodic_site_index_preflights_dense_candidates(n_sites, candidates_per_site):
+    class DenseSiteIndex:
+        calls = 0
+
+        def query_ball_point(self, points, *, r, return_length=False, **kwargs):
+            self.calls += 1
+            assert return_length
+            return np.full(len(points), candidates_per_site, dtype=np.int64)
+
+    site_index = DenseSiteIndex()
+    frac = np.zeros((n_sites, 3))
+    matched = symmetry_module._match_species_with_periodic_index(
+        frac,
+        frac,
+        np.arange(len(frac)),
+        Cell(np.eye(3)),
+        1.0e-6,
+        site_index,
+        1.0e-6,
+    )
+
+    assert matched is None
+    assert site_index.calls == 1
+
+
+def test_space_group_site_matching_falls_back_without_scipy(monkeypatch):
+    atoms = Atoms(
+        "Cu",
+        scaled_positions=[[0.0, 0.0, 0.0]],
+        cell=[[3.1, 0.0, 0.0], [2.7, 0.8, 0.0], [2.4, 0.3, 1.1]],
+        pbc=True,
+    ).repeat((2, 2, 2))
+    expected_rotations, expected_permutations = _get_group_operations(atoms)
+
+    monkeypatch.setitem(sys.modules, "scipy.spatial", None)
+    actual_rotations, actual_permutations = _get_group_operations(atoms)
+
+    _assert_group_actions_equal(
+        (actual_rotations, actual_permutations),
+        (expected_rotations, expected_permutations),
+    )
+
+
+def test_space_group_discovery_supports_legacy_spglib_result(monkeypatch):
+    import spglib
+
+    def legacy_get_symmetry_dataset(cell, symprec, angle_tolerance):
+        return {
+            "rotations": np.eye(3, dtype=np.int64)[None, :, :],
+            "translations": np.zeros((1, 3)),
+        }
+
+    monkeypatch.setattr(spglib, "get_symmetry_dataset", legacy_get_symmetry_dataset)
+    atoms = Atoms("Cu", scaled_positions=[[0.0, 0.0, 0.0]], cell=np.eye(3), pbc=True)
+
+    rotations, permutations = _get_group_operations(atoms)
+
+    assert len(rotations) == 1
+    assert np.array_equal(rotations[0], np.eye(3))
+    assert np.array_equal(permutations[0], np.array([0]))
+
+
+def test_symmetrized_calculator_rejects_nonperiodic_3d_stress(dimer):
+    calculator = SymmetrizedCalculator(mock_calculator(), l_max=0)
+    with pytest.raises(
+        ase.calculators.calculator.PropertyNotImplementedError,
+        match="3D stress.*periodic",
+    ):
+        calculator.calculate(dimer, ["stress"], [])
+
+
+@pytest.mark.parametrize(
+    "cell",
+    [
+        np.zeros((3, 3)),
+        np.diag([1.0, 1.0, np.nan]),
+        np.diag([1.0, 1.0, np.inf]),
+    ],
+    ids=["singular", "nan", "inf"],
+)
+@pytest.mark.parametrize("properties", [["stress"], ["forces"]])
+def test_symmetrized_calculator_rejects_invalid_3d_stress_volume(cell, properties):
+    atoms = Atoms("H", positions=[[0.0, 0.0, 0.0]], cell=cell, pbc=True)
+    calculator = SymmetrizedCalculator(mock_calculator(), l_max=0)
+
+    with pytest.raises(ValueError, match="singular or non-finite periodic cell"):
+        calculator.calculate(atoms, properties, [])
 
 
 def test_symmetrized_calculator_matches_symmetrized_model(fcc_bulk: Atoms) -> None:
     """SymmetrizedModel and SymmetrizedCalculator implement the same O(3)
     average: evaluated on the same quadrature grid, energy, forces, and stress
-    must agree exactly."""
+    must agree within floating-point tolerance."""
     from metatomic.torch import systems_to_torch
     from metatomic.torch.symmetrized_model import SymmetrizedModel
 
@@ -680,17 +1452,14 @@ def test_symmetrized_calculator_matches_symmetrized_model(fcc_bulk: Atoms) -> No
 
     l0 = low_level["non_conservative_stress_l0_mean"].block().values.squeeze().item()
     l2 = low_level["non_conservative_stress_l2_mean"].block().values.squeeze().numpy()
-    low_stress = np.zeros((3, 3), dtype=np.float64)
-    low_stress[0, 1] = l2[0]
-    low_stress[1, 0] = l2[0]
-    low_stress[1, 2] = l2[1]
-    low_stress[2, 1] = l2[1]
-    low_stress[0, 2] = l2[3]
-    low_stress[2, 0] = l2[3]
-    low_stress[0, 0] = l2[4] - l2[2] * np.sqrt(3.0) / 3.0
-    low_stress[1, 1] = -l2[4] - l2[2] * np.sqrt(3.0) / 3.0
-    low_stress[2, 2] = l2[2] * 2.0 * np.sqrt(3.0) / 3.0
-    low_stress += np.eye(3) * (l0 / 3.0)
+    l2_diag = l2[2] / np.sqrt(3.0)
+    low_stress = np.array(
+        [
+            [l2[4] - l2_diag, l2[0], l2[3]],
+            [l2[0], -l2[4] - l2_diag, l2[1]],
+            [l2[3], l2[1], 2.0 * l2_diag],
+        ]
+    ) + np.eye(3) * (l0 / 3.0)
 
     assert np.isclose(ase_energy, low_energy, atol=1e-12)
     assert np.allclose(ase_forces, low_forces, atol=1e-12)

--- a/python/metatomic_torch/metatomic/torch/o3/_tranformations.py
+++ b/python/metatomic_torch/metatomic/torch/o3/_tranformations.py
@@ -31,7 +31,7 @@ def _validate_nonnegative_integer(name: str, value: int) -> int:
 
 
 def _spherical_parity(ell: int, sigma: int, is_inverted: bool) -> int:
-    """Return the discrete O(3) factor outside the proper-rotation Wigner-D."""
+    """Return ``1`` for a proper operation and ``sigma*(-1)**ell`` otherwise."""
     if isinstance(sigma, bool) or not isinstance(sigma, Integral):
         raise TypeError("sigma must be either -1 or +1")
     sigma = int(sigma)
@@ -119,9 +119,17 @@ def _validate_transformation_dtype_device(
 
 
 class O3Transformation:
-    """
-    A single O(3) transformation, represented by a (3, 3) rotation or improper-rotation
-    matrix.
+    r"""An immutable proper or improper O(3) transformation.
+
+    The matrix acts actively on Cartesian column vectors; row-vector tensors
+    therefore use ``values @ matrix.T``. Spherical values use the real
+    Wigner-D matrix of the proper part. For an improper operation they also
+    acquire ``sigma * (-1)**ell``, following the metatensor
+    ``o3_lambda``/``o3_sigma`` convention.
+
+    The public constructor validates and snapshots the matrix because its
+    determinant parity and lazily constructed Wigner-D matrices must remain
+    consistent for the lifetime of the object.
     """
 
     def __init__(self, matrix: torch.Tensor, max_angular_momentum: int):
@@ -182,6 +190,7 @@ class O3Transformation:
         return transformation
 
     def _ensure_wigner_D_cache(self) -> dict[int, torch.Tensor]:
+        """Build the proper-part Wigner-D matrices on first spherical use."""
         if self._wigner_D_cache is None:
             self._wigner_D_cache = build_wigner_D_cache(
                 self._max_angular_momentum,
@@ -405,8 +414,12 @@ def _gradient_row_indices_by_system(
 def transform_system(system: System, transformation: O3Transformation) -> System:
     """Apply an O(3) transformation to a single System.
 
-    This function will transform positions, cell vectors, neighbor-list displacement
-    vectors, and any custom data.
+    Positions, cell vectors, neighbor-list displacements, and custom TensorMap
+    data are transformed in the same Cartesian frame. No centering, wrapping,
+    or periodic-image reduction is performed, so the identity operation
+    preserves supplied unwrapped coordinates. Atomic types and PBC flags are
+    retained; custom data follows the component metadata documented in
+    :ref:`o3-conventions`.
 
     :param system: input system
     :param transformation: O(3) transformation to apply

--- a/python/metatomic_torch/metatomic/torch/o3/_tranformations.py
+++ b/python/metatomic_torch/metatomic/torch/o3/_tranformations.py
@@ -3,6 +3,8 @@ Rotate systems and tensor maps under O(3) transformations, routing rows of
 multi-system tensors by their ``"system"`` sample label.
 """
 
+from numbers import Integral
+
 import torch
 from metatensor.torch import Labels, LabelsEntry, TensorBlock, TensorMap
 
@@ -15,6 +17,105 @@ _SUFFIXES = [""] + [f"_{i}" for i in range(1, 10)]
 _CARTESIAN_AXES = frozenset({f"xyz{s}" for s in _SUFFIXES})
 _SPHERICAL_AXIS_TO_LAMBDA = {f"o3_mu{s}": f"o3_lambda{s}" for s in _SUFFIXES}
 _SPHERICAL_AXIS_TO_SIGMA = {f"o3_mu{s}": f"o3_sigma{s}" for s in _SUFFIXES}
+_INTEGER_DTYPES = (torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64)
+
+
+def _validate_nonnegative_integer(name: str, value: int) -> int:
+    """Normalize a public integer argument without accepting booleans."""
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise TypeError(f"{name} must be a non-negative integer.")
+    normalized = int(value)
+    if normalized < 0:
+        raise ValueError(f"{name} must be a non-negative integer, got {normalized}.")
+    return normalized
+
+
+def _spherical_parity(ell: int, sigma: int, is_inverted: bool) -> int:
+    """Return the discrete O(3) factor outside the proper-rotation Wigner-D."""
+    if isinstance(sigma, bool) or not isinstance(sigma, Integral):
+        raise TypeError("sigma must be either -1 or +1")
+    sigma = int(sigma)
+    if sigma not in (-1, 1):
+        raise ValueError(f"sigma must be either -1 or +1, got {sigma}")
+    if is_inverted:
+        return ((-1) ** ell) * sigma
+    return 1
+
+
+def _validate_system_routing(
+    systems: list[System],
+    transformations: list["O3Transformation"],
+    system_ids: list[int] | torch.Tensor | None,
+    *,
+    device: torch.device,
+) -> torch.Tensor:
+    """Validate and normalize the mapping from sample labels to systems."""
+    n_systems = len(systems)
+    n_transformations = len(transformations)
+    if n_systems != n_transformations:
+        raise ValueError(
+            "Expected one transformation per system, but got "
+            f"len(systems)={n_systems} and "
+            f"len(transformations)={n_transformations}."
+        )
+
+    if system_ids is None:
+        # This is the hot path used by SymmetrizedModel. The generated mapping
+        # has the required length and is unique by construction.
+        return torch.arange(n_systems, dtype=torch.long, device=device)
+
+    if isinstance(system_ids, torch.Tensor):
+        if system_ids.ndim != 1:
+            raise ValueError(
+                "system_ids must be one-dimensional, but got a tensor with shape "
+                f"{tuple(system_ids.shape)}."
+            )
+        if system_ids.dtype not in _INTEGER_DTYPES:
+            raise ValueError(
+                "system_ids must contain integers, but got a tensor with dtype "
+                f"{system_ids.dtype}."
+            )
+        if system_ids.device != device:
+            raise ValueError(
+                f"system_ids are on device {system_ids.device}, but the values to "
+                f"transform are on device {device}."
+            )
+        normalized_ids = system_ids.to(dtype=torch.long)
+    else:
+        python_ids: list[int] = []
+        for system_id in system_ids:
+            if isinstance(system_id, bool) or not isinstance(system_id, Integral):
+                raise ValueError("system_ids must contain integers.")
+            python_ids.append(int(system_id))
+        normalized_ids = torch.tensor(python_ids, dtype=torch.long, device=device)
+
+    if len(normalized_ids) != n_systems:
+        raise ValueError(
+            "system_ids must contain exactly one entry per system, but got "
+            f"len(system_ids)={len(normalized_ids)} and len(systems)={n_systems}."
+        )
+    if torch.unique(normalized_ids).numel() != n_systems:
+        raise ValueError(
+            "system_ids must contain one distinct entry per system, but got "
+            f"{normalized_ids.tolist()}."
+        )
+    return normalized_ids
+
+
+def _validate_transformation_dtype_device(
+    transformations: list["O3Transformation"],
+    *,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> None:
+    """Require every transformation to match the values it will transform."""
+    for index, transformation in enumerate(transformations):
+        if transformation.dtype != dtype or transformation.device != device:
+            raise ValueError(
+                f"Transformation at index {index} has dtype/device "
+                f"({transformation.dtype}, {transformation.device}), differing from "
+                f"the values to transform ({dtype}, {device})."
+            )
 
 
 class O3Transformation:
@@ -28,8 +129,12 @@ class O3Transformation:
         :param matrix: (3, 3) rotation or improper-rotation matrix
         :param max_angular_momentum: maximum angular momentum of any spherical
             representation to be transformed by this transformation; Wigner-D matrices
-            will be precomputed for all ``ell <= max_angular_momentum``
+            are computed on first use for all ``ell <= max_angular_momentum``
         """
+        max_angular_momentum = _validate_nonnegative_integer(
+            "max_angular_momentum", max_angular_momentum
+        )
+
         if matrix.shape != (3, 3):
             raise ValueError(
                 f"Transformation has shape {tuple(matrix.shape)}; expected (3, 3)."
@@ -41,21 +146,55 @@ class O3Transformation:
                 "Transformation is not orthogonal (R @ R.T deviates from I)."
             )
 
-        self._matrix = matrix
+        # Keep the validated transformation immutable. The determinant parity and
+        # Wigner-D matrices are cached, so retaining caller-owned storage would let a
+        # later in-place mutation make the Cartesian and spherical paths disagree.
+        self._matrix = matrix.clone()
         self._max_angular_momentum = max_angular_momentum
         self._is_inverted = bool(torch.det(matrix) < 0)
 
-        self._wigner_D_cache = build_wigner_D_cache(
-            max_angular_momentum,
-            matrix,
-            device=matrix.device,
-            dtype=matrix.dtype,
-        )
+        # Cartesian transformations only need ``matrix``. Building Wigner-D
+        # matrices eagerly is particularly expensive for quadrature workloads,
+        # where most transformations never touch a spherical component.
+        self._wigner_D_cache: dict[int, torch.Tensor] | None = None
+
+    @classmethod
+    def _from_validated_matrix(
+        cls,
+        matrix: torch.Tensor,
+        max_angular_momentum: int,
+        *,
+        is_inverted: bool,
+    ) -> "O3Transformation":
+        """Build a transformation whose orthogonality/parity is already known.
+
+        This private constructor is for internally generated quadrature
+        matrices only. It avoids the device synchronizations required by the
+        public constructor's orthogonality and determinant checks; callers are
+        responsible for providing a valid matrix and the correct component of
+        O(3).
+        """
+        transformation = cls.__new__(cls)
+        transformation._matrix = matrix
+        transformation._max_angular_momentum = max_angular_momentum
+        transformation._is_inverted = is_inverted
+        transformation._wigner_D_cache = None
+        return transformation
+
+    def _ensure_wigner_D_cache(self) -> dict[int, torch.Tensor]:
+        if self._wigner_D_cache is None:
+            self._wigner_D_cache = build_wigner_D_cache(
+                self._max_angular_momentum,
+                self._matrix,
+                device=self._matrix.device,
+                dtype=self._matrix.dtype,
+            )
+        return self._wigner_D_cache
 
     @property
     def matrix(self) -> torch.Tensor:
-        """The (3, 3) rotation or improper-rotation matrix."""
-        return self._matrix
+        """A copy of the (3, 3) rotation or improper-rotation matrix."""
+        return self._matrix.clone()
 
     @property
     def dtype(self) -> torch.dtype:
@@ -87,27 +226,45 @@ class O3Transformation:
 
         :param values: (..., 2*ell+1) tensor of spherical values
         :param ell: angular momentum of the spherical representation
-        :param sigma: inversion parity of the spherical representation
+        :param sigma: metatensor O(3) parity label (+1 for a proper tensor and
+            -1 for a pseudotensor). Under inversion the representation acquires
+            the factor ``sigma * (-1)**ell``.
         :return: (..., 2*ell+1) tensor of transformed spherical values
         """
-        D = self._wigner_D_cache.get(ell)
-        if D is None:
-            raise ValueError(f"Wigner-D matrix for ell={ell} not found in cache.")
-        transformed = values @ D.T
-        if sigma == -1:
-            transformed = transformed * ((-1) ** ell)
+        ell = self._validate_angular_momentum(ell)
+        parity = _spherical_parity(ell, sigma, self.is_inverted)
+        transformed = values @ self._wigner_D_matrix(ell).T
+        if parity != 1:
+            transformed = transformed * parity
         return transformed
 
-    def wigner_D_matrix(self, ell: int):
-        """Return the Wigner-D matrix for this transformation and angular momentum ell.
+    def _wigner_D_matrix(self, ell: int) -> torch.Tensor:
+        """Return the cached Wigner-D matrix without copying it."""
+        ell = self._validate_angular_momentum(ell)
+        D = self._ensure_wigner_D_cache().get(ell)
+        assert D is not None
+        return D
+
+    def _validate_angular_momentum(self, ell: int) -> int:
+        """Normalize an angular momentum and enforce this instance's bound."""
+        ell = _validate_nonnegative_integer("ell", ell)
+        if ell > self._max_angular_momentum:
+            raise ValueError(
+                f"ell={ell} exceeds max_angular_momentum={self._max_angular_momentum}."
+            )
+        return ell
+
+    def wigner_D_matrix(self, ell: int) -> torch.Tensor:
+        """Return a copy of the proper-part Wigner-D matrix for angular momentum
+        ``ell``.
+
+        For an improper transformation, :meth:`transform_spherical` applies
+        the discrete inversion-parity factor separately.
 
         :param ell: angular momentum of the spherical representation
         :return: (2*ell+1, 2*ell+1) Wigner-D matrix
         """
-        D = self._wigner_D_cache.get(ell)
-        if D is None:
-            raise ValueError(f"Wigner-D matrix for ell={ell} not found in cache.")
-        return D
+        return self._wigner_D_matrix(ell).clone()
 
 
 def random_transformations(
@@ -132,8 +289,18 @@ def random_transformations(
     :param include_inversions: if ``True``, sample from O(3) instead of SO(3)
     :param generator: optional :class:`torch.Generator` for reproducible sampling; when
         ``None`` the global RNG is used
-    :return: list of ``n`` orthogonal (3, 3) tensors
+    :return: list of ``n`` :class:`O3Transformation` objects
     """
+    n = _validate_nonnegative_integer("n", n)
+    max_angular_momentum = _validate_nonnegative_integer(
+        "max_angular_momentum", max_angular_momentum
+    )
+
+    if not dtype.is_floating_point:
+        raise TypeError(
+            f"random O(3) transformations require a real dtype, got {dtype}"
+        )
+
     q = torch.randn(n, 4, device=device, dtype=dtype, generator=generator)
     q = q / q.norm(dim=1, keepdim=True)
     w, x, y, z = q.unbind(1)
@@ -153,30 +320,37 @@ def random_transformations(
         dim=1,
     ).reshape(n, 3, 3)
 
+    inverted = [False] * n
     if include_inversions:
         signs = torch.randint(0, 2, (n,), device=device, generator=generator) * 2 - 1
         R = R * signs.to(dtype=dtype).reshape(n, 1, 1)
+        # One bulk transfer avoids a determinant synchronization per matrix.
+        inverted = (signs < 0).tolist()
 
-    return [O3Transformation(r, max_angular_momentum) for r in R.unbind(0)]
+    # Preserve the public constructor's orthogonality check, but validate the
+    # internally generated batch at once instead of synchronizing once per matrix.
+    identity = torch.eye(3, device=R.device, dtype=R.dtype).expand(n, 3, 3)
+    if not torch.allclose(R @ R.transpose(-1, -2), identity, atol=1e-5):
+        raise ValueError("Generated transformations are not orthogonal.")
+
+    return [
+        O3Transformation._from_validated_matrix(
+            matrix,
+            max_angular_momentum,
+            is_inverted=is_inverted,
+        )
+        for matrix, is_inverted in zip(R.unbind(0), inverted, strict=True)
+    ]
 
 
 def _block_row_indices_by_system(
     block: TensorBlock,
     system_ids: torch.Tensor,
 ) -> list[torch.Tensor]:
-    """Return row-index tensors into ``block.values``, one per system.
+    """Route value rows using the ``system`` sample label.
 
-    With a single system every row belongs to it (any ``"system"`` label is ignored).
-
-    With several systems the ``"system"`` column is required and each row is routed by
-    matching its ``"system"`` label against ``system_ids``.
-
-    :param block: block whose ``samples`` may contain a ``"system"`` column
-    :param system_ids: one value per system; ``system_ids[i]`` is the value of the
-        ``"system"`` column identifying the rows belonging to the i-th entry in the
-        ``systems`` list passed to ``transform_tensor`` or ``transform_block``
-    :return: list of length ``len(system_ids)``; entry ``i`` selects the rows of system
-        ``i``
+    For one system all rows belong to it; otherwise ``system_ids[i]`` identifies
+    the rows transformed by operation ``i``.
     """
     n_systems = len(system_ids)
     if n_systems == 1:
@@ -208,20 +382,7 @@ def _gradient_row_indices_by_system(
     parent_block: TensorBlock,
     system_ids: torch.Tensor,
 ) -> list[torch.Tensor]:
-    """Return row-index tensors into a gradient block, one per system.
-
-    Gradient samples carry a ``"sample"`` column indexing into the parent block rather
-    than their own ``"system"`` column, so the system of each gradient row is read from
-    the parent block's ``"system"`` column.
-
-    :param grad_block: gradient block to route
-    :param parent_block: the value block this gradient is attached to
-    :param system_ids: one value per system; ``system_ids[i]`` is the value of the
-        ``"system"`` column identifying the rows belonging to the i-th entry in the
-        ``systems`` list passed to ``transform_tensor`` or ``transform_block``
-    :return: list of length ``len(system_ids)``; entry ``i`` selects the gradient
-        rows of system ``i``
-    """
+    """Route gradient rows through their parent ``sample`` indices."""
     n_systems = len(system_ids)
     if n_systems == 1:
         return [
@@ -278,7 +439,9 @@ def transform_system(system: System, transformation: O3Transformation) -> System
     for options in system.known_neighbor_lists():
         neighbors = system.get_neighbor_list(options)
         # neighbor vectors are stored as (N, 3, 1); squeeze/unsqueeze around the matmul
-        neighbors_values = neighbors.values.squeeze(-1)
+        # A neighbor list can already be registered with the input geometry. Start
+        # from detached values and register a fresh graph against ``new_system``.
+        neighbors_values = neighbors.values.detach().squeeze(-1)
         new_values = transformation.transform_cartesian(neighbors_values)
         rotated_neighbors = TensorBlock(
             values=new_values.unsqueeze(-1),
@@ -306,14 +469,16 @@ def _contract_component_axes(
     :param matrices: one rotation matrix per component axis (empty for scalars)
     :return: rotated values, same shape as the input
     """
-    # einsum index letters for the per-axis component contraction (input lower, output
-    # upper). Six axes is far more than any realistic block (value + gradient) needs.
-    _EINSUM_IN = "abcdef"
-    _EINSUM_OUT = "ABCDEF"
+    # einsum index letters for the per-axis component contraction (input lower,
+    # output upper). Keep these in sync with the ten recognized component suffixes.
+    _EINSUM_IN = "abcdefghjk"
+    _EINSUM_OUT = "ABCDEFGHIJ"
 
     if len(matrices) == 0:
         return values
     n_axes = len(matrices)
+    if n_axes > len(_EINSUM_IN):
+        raise ValueError(f"can not transform a tensor with {n_axes} component axes")
     in_subscript = "i" + _EINSUM_IN[:n_axes] + "p"
     out_subscript = "i" + _EINSUM_OUT[:n_axes] + "p"
     matrix_subscripts = [_EINSUM_OUT[j] + _EINSUM_IN[j] for j in range(n_axes)]
@@ -321,43 +486,83 @@ def _contract_component_axes(
     return torch.einsum(equation, *matrices, values)
 
 
-def _axis_matrices_and_parity(
+def _component_axis_metadata(
     components: list[Labels],
     key: LabelsEntry,
-    transformation: O3Transformation,
-) -> tuple[list[torch.Tensor], int]:
-    """Pick the rotation matrix for each component axis and the O(3) inversion parity.
-
-    Cartesian axes (``xyz``/``xyz_1``/``xyz_2``/...) use the rotation directly, so
-    improper rotations flip vectors automatically. Spherical axes
-    (``o3_mu``/``o3_mu_1``/ ``o3_mu_2``) use the proper-rotation Wigner-D matrix of the
-    matching ``o3_lambda`` plus a ``(-1)^ell * sigma`` parity factor accumulated
-    whenever ``transformation`` is improper.
-
-    :param name: TensorMap name, used only in error messages
-    :param components: component :class:`Labels` of the block (or gradient block)
-    :param key: the parent block's key, supplying ``o3_lambda``/``o3_sigma`` values
-    :param transformation: this system's O3 transformation
-    :return: ``(matrices, parity)`` with one matrix per component axis
-    """
-    matrices: list[torch.Tensor] = []
-    parity = 1
+) -> list[tuple[str, int, int]]:
+    """Validate component axes independently of the number of value rows."""
+    if len(components) > len(_SUFFIXES):
+        raise ValueError(
+            f"can not transform a tensor with {len(components)} component axes; "
+            f"at most {len(_SUFFIXES)} are supported"
+        )
+    metadata: list[tuple[str, int, int]] = []
     for component in components:
         axis_name = component.names[0]
         if axis_name in _CARTESIAN_AXES:
-            matrices.append(transformation.matrix)
+            if len(component) != 3:
+                raise ValueError(
+                    f"Cartesian component axis '{axis_name}' must contain 3 "
+                    f"entries, got {len(component)}."
+                )
+            expected = torch.arange(
+                3,
+                device=component.values.device,
+                dtype=component.values.dtype,
+            )
+            if not torch.equal(component.values[:, 0], expected):
+                raise ValueError(
+                    f"Cartesian component axis '{axis_name}' must use labels "
+                    "[0, 1, 2] in x, y, z order."
+                )
+            metadata.append((axis_name, 0, 1))
         elif axis_name in _SPHERICAL_AXIS_TO_LAMBDA:
             ell = int(key[_SPHERICAL_AXIS_TO_LAMBDA[axis_name]])
-            matrices.append(transformation.wigner_D_matrix(ell))
-            if transformation.is_inverted:
-                sigma = int(key[_SPHERICAL_AXIS_TO_SIGMA[axis_name]])
-                parity *= ((-1) ** ell) * sigma
+            sigma = int(key[_SPHERICAL_AXIS_TO_SIGMA[axis_name]])
+            if ell < 0:
+                raise ValueError(f"ell must be non-negative, got {ell}")
+            expected_size = 2 * ell + 1
+            if len(component) != expected_size:
+                raise ValueError(
+                    f"Spherical component axis '{axis_name}' for ell={ell} must "
+                    f"contain {expected_size} entries, got {len(component)}."
+                )
+            expected = torch.arange(
+                -ell,
+                ell + 1,
+                device=component.values.device,
+                dtype=component.values.dtype,
+            )
+            if not torch.equal(component.values[:, 0], expected):
+                raise ValueError(
+                    f"Spherical component axis '{axis_name}' for ell={ell} must "
+                    f"use labels from {-ell} through {ell} in ascending order."
+                )
+            # Validate sigma even when a selected-atom block has no rows.
+            _spherical_parity(ell, sigma, False)
+            metadata.append((axis_name, ell, sigma))
         else:
             raise ValueError(
                 f"Found a component axis '{axis_name}', which is neither a Cartesian "
                 "('xyz'/'xyz_1'/'xyz_2'/...) nor spherical ('o3_mu'/'o3_mu_1'/...) "
                 "axis; it can not be transformed."
             )
+    return metadata
+
+
+def _axis_matrices_and_parity(
+    metadata: list[tuple[str, int, int]],
+    transformation: O3Transformation,
+) -> tuple[list[torch.Tensor], int]:
+    """Return each axis matrix and the combined spherical inversion parity."""
+    matrices: list[torch.Tensor] = []
+    parity = 1
+    for axis_name, ell, sigma in metadata:
+        if axis_name in _CARTESIAN_AXES:
+            matrices.append(transformation._matrix)
+        else:
+            parity *= _spherical_parity(ell, sigma, transformation.is_inverted)
+            matrices.append(transformation._wigner_D_matrix(ell))
     return matrices, parity
 
 
@@ -368,23 +573,14 @@ def _transform_component_values(
     row_indices: list[torch.Tensor],
     transformations: list[O3Transformation],
 ) -> torch.Tensor:
-    """Rotate the values of a single value or gradient block, per system.
-
-    :param name: TensorMap name, used only in error messages
-    :param values: the block's values tensor
-    :param components: the block's component :class:`Labels`
-    :param key: the parent block's key (for spherical ``o3_lambda``/``o3_sigma``)
-    :param row_indices: per-system row indices into ``values``
-    :param transformations: per-system (3, 3) transformation matrices
-    :param wigner_D_matrices: ``{ell: [D_0, ..., D_{N-1}]}`` real Wigner-D matrices
-    :return: new values tensor with each system's rows rotated
-    """
+    """Rotate value or gradient rows with their assigned transformation."""
+    metadata = _component_axis_metadata(components, key)
     new_values = values.clone()
     for system_index, rows in enumerate(row_indices):
         if len(rows) == 0:
             continue
         matrices, parity = _axis_matrices_and_parity(
-            components, key, transformations[system_index]
+            metadata, transformations[system_index]
         )
         rotated = _contract_component_axes(values[rows], matrices)
         if parity != 1:
@@ -406,41 +602,36 @@ def transform_block(
         spherical blocks
     :param block: the block to rotate
     :param systems: list of systems, one per transformation
-    :param transformations: per-system O(3) transformation matrices
-    :param system_ids: index of the ``systems`` used in the samples of ``block``;
-        defaults to ``list(range(len(systems)))``
+    :param transformations: per-system O(3) transformation matrices, all with the same
+        dtype and device as ``block.values``
+    :param system_ids: Python list or one-dimensional integer tensor containing
+        one distinct ``"system"`` sample label per entry in ``systems``. Entry
+        ``i`` identifies the samples transformed with ``transformations[i]``.
+        Labels need not be sorted or consecutive. A tensor-valued ``system_ids``
+        must be on the same device as ``block.values``. Defaults to
+        ``list(range(len(systems)))``
     :return: new block with rotated values and gradients
     """
-    assert len(systems) == len(transformations)
+    system_ids = _validate_system_routing(
+        systems,
+        transformations,
+        system_ids,
+        device=block.values.device,
+    )
+    _validate_transformation_dtype_device(
+        transformations,
+        dtype=block.values.dtype,
+        device=block.values.device,
+    )
     if len(systems) == 0:
         return block
 
-    if system_ids is None:
-        system_ids = list(range(len(systems)))
-
-    if not isinstance(system_ids, torch.Tensor):
-        system_ids = torch.tensor(
-            system_ids, dtype=torch.int32, device=block.values.device
-        )
-
-    if (
-        block.values.dtype != transformations[0].dtype
-        or block.values.device != transformations[0].device
-    ):
-        raise ValueError(
-            f"TensorMap has values with dtype/device "
-            f"({block.values.dtype}, {block.values.device}) differing "
-            f"from the transformations ({transformations[0].dtype}, "
-            f"{transformations[0].device})."
-        )
-
-    return _transform_block_impl(key, block, systems, transformations, system_ids)
+    return _transform_block_impl(key, block, transformations, system_ids)
 
 
 def _transform_block_impl(
     key: LabelsEntry,
     block: TensorBlock,
-    systems: list[System],
     transformations: list[O3Transformation],
     system_ids: torch.Tensor,
 ) -> TensorBlock:
@@ -491,43 +682,49 @@ def transform_tensor(
     :py:class:`TensorMap` may freely mix scalar, Cartesian and spherical blocks, and
     blocks may carry gradients.
 
-    One of the samples dimensions must be ``"system"``, which is used to route each row
-    to the correct system and transformation.
+    With multiple systems, one sample dimension must be ``"system"`` and is
+    used to route each row to the correct system and transformation. With one
+    system this column is optional and, when present, ignored.
 
     :param tensor: TensorMap to rotate
     :param systems: input systems
-    :param transformations: per-system O(3) transformation matrices
-    :param system_ids: index of the ``systems`` used in the samples of ``tensor``;
-        defaults to ``list(range(len(systems)))``
+    :param transformations: per-system O(3) transformation matrices, all with the same
+        dtype and device as the tensor values
+    :param system_ids: Python list or one-dimensional integer tensor containing
+        one distinct ``"system"`` sample label per entry in ``systems``. Entry
+        ``i`` identifies the samples transformed with ``transformations[i]``.
+        Labels need not be sorted or consecutive. A tensor-valued ``system_ids``
+        must be on the same device as the tensor values. Defaults to
+        ``list(range(len(systems)))``
     :return: new TensorMap with rotated values and gradients
     """
-    assert len(systems) == len(transformations)
+    reference_values = (
+        tensor.block(0).values
+        if len(tensor) != 0
+        else transformations[0]._matrix
+        if len(transformations) != 0
+        else torch.empty(0)
+    )
+    system_ids = _validate_system_routing(
+        systems,
+        transformations,
+        system_ids,
+        device=reference_values.device,
+    )
     if len(systems) == 0:
         return tensor
 
-    if system_ids is None:
-        system_ids = list(range(len(systems)))
-
-    if not isinstance(system_ids, torch.Tensor):
-        system_ids = torch.tensor(
-            system_ids, dtype=torch.int32, device=transformations[0].device
-        )
-
-    if len(tensor) != 0:
-        block = tensor.block(0)
-        if (
-            block.values.dtype != transformations[0].dtype
-            or block.values.device != transformations[0].device
-        ):
-            raise ValueError(
-                f"TensorMap has values with dtype/device "
-                f"({block.values.dtype}, {block.values.device}) differing "
-                f"from the transformations ({transformations[0].dtype}, "
-                f"{transformations[0].device})."
-            )
+    _validate_transformation_dtype_device(
+        transformations,
+        dtype=reference_values.dtype,
+        device=reference_values.device,
+    )
 
     new_blocks = [
-        _transform_block_impl(key, block, systems, transformations, system_ids)
+        _transform_block_impl(key, block, transformations, system_ids)
         for key, block in tensor.items()
     ]
-    return TensorMap(keys=tensor.keys, blocks=new_blocks)
+    transformed = TensorMap(keys=tensor.keys, blocks=new_blocks)
+    for info_key, info_value in tensor.info().items():
+        transformed.set_info(info_key, info_value)
+    return transformed

--- a/python/metatomic_torch/metatomic/torch/o3/_wigner.py
+++ b/python/metatomic_torch/metatomic/torch/o3/_wigner.py
@@ -1,9 +1,7 @@
 """Private helpers to build real Wigner-D matrices for augmentation.
 
 Complex Wigner-D matrices are delegated to :func:`wigners.wigner_D_array` using
-ZYZ Euler angles. This module then reshapes/indexes these matrices into the flat
-layout expected by the augmentation code and applies the complex-to-real
-change-of-basis.
+ZYZ Euler angles and then converted to the real spherical-harmonic basis.
 
 The indexing convention used here matches ``wigners``:
 ``D[mp + ell, m + ell] == D^ell_{mp,m}``.
@@ -14,94 +12,6 @@ import functools
 import numpy as np
 import torch
 from wigners import wigner_D_array
-
-
-def _wigner_d_size(ell_min: int, mp_max: int, ell_max: int) -> int:
-    if mp_max >= ell_max:
-        return (
-            ell_max * (ell_max * (4 * ell_max + 12) + 11)
-            + ell_min * (1 - 4 * ell_min**2)
-            + 3
-        ) // 3
-    if mp_max > ell_min:
-        return (
-            3 * ell_max * (ell_max + 2)
-            + ell_min * (1 - 4 * ell_min**2)
-            + mp_max
-            * (3 * ell_max * (2 * ell_max + 4) + mp_max * (-2 * mp_max - 3) + 5)
-            + 3
-        ) // 3
-
-    return (ell_max * (ell_max + 2) - ell_min**2) * (1 + 2 * mp_max) + 2 * mp_max + 1
-
-
-def _wigner_d_index(ell: int, mp: int, m: int, ell_min: int, mp_max: int) -> int:
-    idx = 0
-    for ell_prev in range(ell_min, ell):
-        local_mp_max = mp_max if mp_max < ell_prev else ell_prev
-        idx += (2 * local_mp_max + 1) * (2 * ell_prev + 1)
-
-    local_mp_max = mp_max if mp_max < ell else ell
-    idx += (mp + local_mp_max) * (2 * ell + 1)
-    idx += m + ell
-    return idx
-
-
-def _compute_wigner_d_complex(
-    ell_max: int, alpha: float, beta: float, gamma: float
-) -> np.ndarray:
-    """Compute complex Wigner-D matrix elements for all ell in ``[0, ell_max]``.
-
-    Calls :func:`wigners.wigner_D_array` for each input angle triplet, then packs
-    values into a flat output array indexed by :func:`_wigner_d_index`.
-
-    :param ell_max: maximum angular-momentum order
-    :param alpha: ZYZ first rotation angle, arbitrary shape
-    :param beta: ZYZ second rotation angle, same shape as ``alpha``
-    :param gamma: ZYZ third rotation angle, same shape as ``alpha``
-    :return: complex array of shape ``(*alpha.shape, dsize)``
-    """
-
-    mp_max = ell_max
-    dsize = _wigner_d_size(0, mp_max, ell_max)
-    result = np.zeros(dsize, dtype=np.complex128)
-
-    _wigner_D_array = wigner_D_array(ell_max, alpha, beta, gamma)
-
-    for ell in range(0, ell_max + 1):
-        for mp in range(-ell, ell + 1):
-            i_d = _wigner_d_index(ell, mp, -ell, 0, mp_max)
-            for m in range(-ell, ell + 1):
-                result[i_d] = _wigner_D_array[ell][mp + ell, m + ell]
-                i_d += 1
-
-    return result
-
-
-def _compute_complex_wigner_d_matrices(
-    ell_max: int,
-    angles: tuple[float, float, float],
-) -> dict[int, np.ndarray]:
-    """Return complex Wigner-D matrices for ell in ``[0, ell_max]`` at the given ZYZ
-    angles.
-
-    The returned matrices follow the standard ``wigners`` indexing convention:
-    ``matrix[..., mp + ell, m + ell] == D^ell_{mp,m}``.
-
-    :param ell_max: maximum angular-momentum order
-    :param angles: ``(alpha, beta, gamma)`` ZYZ Euler-angles
-    :return: ``{ell: array of shape (2*ell+1, 2*ell+1)}``
-    """
-    alpha, beta, gamma = angles
-    raw = _compute_wigner_d_complex(ell_max, alpha, beta, gamma)
-    matrices: dict[int, np.ndarray] = {}
-    for ell in range(ell_max + 1):
-        block = np.zeros((2 * ell + 1, 2 * ell + 1), dtype=np.complex128)
-        for mp in range(-ell, ell + 1):
-            for m in range(-ell, ell + 1):
-                block[mp + ell, m + ell] = raw[_wigner_d_index(ell, mp, m, 0, ell_max)]
-        matrices[ell] = block
-    return matrices
 
 
 def _compute_real_wigner_d_matrices(
@@ -116,11 +26,11 @@ def _compute_real_wigner_d_matrices(
     :param angles: ``(alpha, beta, gamma)`` ZYZ Euler-angles
     :param complex_to_real: ``{ell: (2*ell+1, 2*ell+1)}`` unitary transform from complex
         to real spherical harmonics
-    :return: ``{ell: real tensor of shape (*angles[0].shape, 2*ell+1, 2*ell+1)}``
+    :return: ``{ell: real tensor of shape (2*ell+1, 2*ell+1)}``
     """
-    complex_matrices = _compute_complex_wigner_d_matrices(ell_max, angles)
+    alpha, beta, gamma = angles
     real_matrices: dict[int, torch.Tensor] = {}
-    for ell, matrix in complex_matrices.items():
+    for ell, matrix in enumerate(wigner_D_array(ell_max, alpha, beta, gamma)):
         transform = complex_to_real[ell]
         matrix = np.einsum("ij,...jk,kl->...il", transform.conj(), matrix, transform.T)
         # The complex-to-real basis change can leave tiny imaginary residuals;
@@ -171,12 +81,17 @@ def _rotation_to_angles(
     """
 
     rotation = rotation if torch.det(rotation) > 0 else -rotation
-    # R = Rz(alpha) Ry(beta) Rz(gamma): element [2,2] = cos(beta)
+    # R = Rz(alpha) Ry(beta) Rz(gamma): element [2,2] = cos(beta), while
+    # hypot(R[0,2], R[1,2]) = sin(beta) for beta in [0, pi]. Recover beta
+    # with atan2 instead of arccos: close to a pole, arccos amplifies a one-ulp
+    # perturbation of R[2,2] into an O(sqrt(eps)) angle and can incorrectly
+    # bypass the gimbal-lock branch.
     cos_beta = rotation[2, 2].clamp(-1.0, 1.0)
-    beta = torch.arccos(cos_beta)
-    sin_beta = torch.sin(beta)
+    sin_beta = torch.sqrt(rotation[0, 2] ** 2 + rotation[1, 2] ** 2)
+    beta = torch.atan2(sin_beta, cos_beta)
     beta = float(beta)
-    if abs(sin_beta) < 1e-10:
+    pole_tolerance = 8.0 * torch.finfo(rotation.dtype).eps
+    if float(sin_beta) <= pole_tolerance:
         # Gimbal lock: only alpha +/- gamma is defined; fix gamma=0
         if cos_beta > 0:
             alpha = float(torch.atan2(rotation[1, 0], rotation[0, 0]))

--- a/python/metatomic_torch/metatomic/torch/symmetrized_model/_decompose.py
+++ b/python/metatomic_torch/metatomic/torch/symmetrized_model/_decompose.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, List
 
 import numpy as np
 import torch
@@ -11,15 +11,8 @@ def _l0_components_from_matrices(A: torch.Tensor) -> torch.Tensor:
 
     Expects ``A`` with shape ``(a, 3, 3, b)``; returns ``(a, 1, b)``.
     """
-    # move (3, 3) axes to the end for the assert and indexing below
-    A = A.permute(0, 3, 1, 2)
-    assert A.shape[-2:] == (3, 3), "The last two dimensions of A must be (3, 3)."
-
-    # Trace as L=0 component; unsqueeze preserves the autograd graph
-    l0_A = (A[..., 0, 0] + A[..., 1, 1] + A[..., 2, 2]).unsqueeze(-1)
-
-    l0_A = l0_A.permute(0, 2, 1)
-    return l0_A
+    assert A.shape[1:3] == (3, 3), "Cartesian component axes must have size (3, 3)."
+    return (A[:, 0, 0, :] + A[:, 1, 1, :] + A[:, 2, 2, :]).unsqueeze(1)
 
 
 def _l2_components_from_matrices(A: torch.Tensor) -> torch.Tensor:
@@ -28,25 +21,18 @@ def _l2_components_from_matrices(A: torch.Tensor) -> torch.Tensor:
 
     Expects ``A`` with shape ``(a, 3, 3, b)``; returns ``(a, 5, b)``.
     """
-    # move (3, 3) axes to the end for the assert and indexing below
-    A = A.permute(0, 3, 1, 2)
-    assert A.shape[-2:] == (3, 3), "The last two dimensions of A must be (3, 3)."
-
-    # Use torch.stack to preserve the autograd graph
-    l2_A = torch.stack(
+    assert A.shape[1:3] == (3, 3), "Cartesian component axes must have size (3, 3)."
+    return torch.stack(
         [
-            (A[..., 0, 1] + A[..., 1, 0]) / 2.0,
-            (A[..., 1, 2] + A[..., 2, 1]) / 2.0,
-            (2.0 * A[..., 2, 2] - A[..., 0, 0] - A[..., 1, 1]) / (2.0 * np.sqrt(3.0)),
-            (A[..., 0, 2] + A[..., 2, 0]) / 2.0,
-            (A[..., 0, 0] - A[..., 1, 1]) / 2.0,
+            (A[:, 0, 1, :] + A[:, 1, 0, :]) / 2.0,
+            (A[:, 1, 2, :] + A[:, 2, 1, :]) / 2.0,
+            (2.0 * A[:, 2, 2, :] - A[:, 0, 0, :] - A[:, 1, 1, :])
+            / (2.0 * np.sqrt(3.0)),
+            (A[:, 0, 2, :] + A[:, 2, 0, :]) / 2.0,
+            (A[:, 0, 0, :] - A[:, 1, 1, :]) / 2.0,
         ],
-        dim=-1,
+        dim=1,
     )
-
-    l2_A = l2_A.permute(0, 2, 1)
-
-    return l2_A
 
 
 def _single_mu_labels(device: torch.device) -> Labels:
@@ -59,12 +45,65 @@ def _single_mu_labels(device: torch.device) -> Labels:
 def _mu_range_labels(ell: int, device: torch.device) -> Labels:
     return Labels(
         names=["o3_mu"],
-        values=torch.tensor(
-            [[mu] for mu in range(-ell, ell + 1)],
-            device=device,
-            dtype=torch.int32,
+        values=torch.arange(-ell, ell + 1, device=device, dtype=torch.int32).reshape(
+            -1, 1
         ),
     )
+
+
+def _keys_with_irrep(keys: Labels, ell: int, sigma: int = 1) -> Labels:
+    """Add or validate the key metadata required by an ``o3_mu`` axis."""
+    names = list(keys.names)
+    values = keys.values
+    if names == ["_"]:
+        # ``_`` is metatensor's placeholder for a map with no semantic keys.
+        # Generated spherical targets use the canonical irrep-only schema.
+        if len(keys) != 1 or int(values[0, 0]) != 0:
+            raise ValueError(
+                "the sole '_' key must be the canonical one-row, zero-valued "
+                "placeholder before spherical decomposition"
+            )
+        names = []
+        values = values[:, :0]
+    for name, expected in (("o3_lambda", ell), ("o3_sigma", sigma)):
+        if name in names:
+            column = keys.column(name)
+            if not bool(torch.all(column == expected).item()):
+                raise ValueError(
+                    f"can not decompose output as ({ell}, {sigma}): existing "
+                    f"'{name}' key values are inconsistent"
+                )
+        else:
+            names.append(name)
+            values = torch.cat(
+                [
+                    values,
+                    torch.full(
+                        (len(keys), 1),
+                        expected,
+                        dtype=values.dtype,
+                        device=values.device,
+                    ),
+                ],
+                dim=1,
+            )
+    return Labels(names, values)
+
+
+def _decomposed_output_names(name: str) -> List[str]:
+    """Names produced by :func:`_decompose_output`, without inspecting values."""
+    quantity = name.split("/", 1)[0]
+    if quantity in ("energy", "energy_ensemble", "energy_uncertainty"):
+        return [name + "_l0"]
+    if quantity in (
+        "forces",
+        "non_conservative_force",
+        "non_conservative_forces",
+    ):
+        return [name + "_l1"]
+    if quantity in ("stress", "non_conservative_stress"):
+        return [name + "_l0", name + "_l2"]
+    return [name]
 
 
 def _decompose_output(name: str, tensor: TensorMap) -> Dict[str, TensorMap]:
@@ -76,18 +115,21 @@ def _decompose_output(name: str, tensor: TensorMap) -> Dict[str, TensorMap]:
     Forces (Cartesian vectors) become ``<name>_l1``, with the components
     reordered to spherical order (y, z, x) -> (m=-1, m=0, m=1) via a cyclic
     roll. Stresses (3x3 Cartesian matrices) are split into ``<name>_l0``
-    (trace) and ``<name>_l2`` (symmetric traceless) parts; the antisymmetric
-    L=1 part is zero for physical stress. Any other output is passed through
-    unchanged.
+    (trace) and ``<name>_l2`` (symmetric traceless) parts. Physical stress is
+    assumed symmetric; any skew input component is intentionally omitted
+    rather than returned as an L=1 diagnostic. Any other output is passed
+    through unchanged.
 
     :param name: name of the output
     :param tensor: the output values
     :return: dictionary of decomposed TensorMaps, keyed by the new names
     """
-    if name == "energy":
+    quantity = name.split("/", 1)[0]
+
+    if quantity in ("energy", "energy_ensemble", "energy_uncertainty"):
         return {
             name + "_l0": TensorMap(
-                tensor.keys,
+                _keys_with_irrep(tensor.keys, 0),
                 [
                     TensorBlock(
                         values=block.values.unsqueeze(1),
@@ -100,10 +142,14 @@ def _decompose_output(name: str, tensor: TensorMap) -> Dict[str, TensorMap]:
             )
         }
 
-    if name in ("forces", "non_conservative_force", "non_conservative_forces"):
+    if quantity in (
+        "forces",
+        "non_conservative_force",
+        "non_conservative_forces",
+    ):
         return {
             name + "_l1": TensorMap(
-                tensor.keys,
+                _keys_with_irrep(tensor.keys, 1),
                 [
                     TensorBlock(
                         values=block.values.roll(-1, 1),
@@ -116,7 +162,7 @@ def _decompose_output(name: str, tensor: TensorMap) -> Dict[str, TensorMap]:
             )
         }
 
-    if name in ("stress", "non_conservative_stress"):
+    if quantity in ("stress", "non_conservative_stress"):
         blocks_l0 = []
         blocks_l2 = []
         for block in tensor.blocks():
@@ -137,8 +183,8 @@ def _decompose_output(name: str, tensor: TensorMap) -> Dict[str, TensorMap]:
                 )
             )
         return {
-            name + "_l0": TensorMap(tensor.keys, blocks_l0),
-            name + "_l2": TensorMap(tensor.keys, blocks_l2),
+            name + "_l0": TensorMap(_keys_with_irrep(tensor.keys, 0), blocks_l0),
+            name + "_l2": TensorMap(_keys_with_irrep(tensor.keys, 2), blocks_l2),
         }
 
     return {name: tensor}

--- a/python/metatomic_torch/metatomic/torch/symmetrized_model/_gradients.py
+++ b/python/metatomic_torch/metatomic/torch/symmetrized_model/_gradients.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Callable, Dict, List, Optional
 
 import metatensor.torch as mts
@@ -13,6 +14,11 @@ from metatomic.torch import (
 from ..o3 import O3Transformation, transform_tensor
 
 
+def _range_labels(name: str, size: int, device: torch.device) -> Labels:
+    values = torch.arange(size, dtype=torch.int64, device=device).reshape(-1, 1)
+    return Labels(name, values)
+
+
 def _evaluate_with_gradients(
     model: Callable[
         [List[System], Dict[str, ModelOutput], Optional[Labels]],
@@ -26,29 +32,15 @@ def _evaluate_with_gradients(
     dtype: torch.dtype,
     energy_name: str = "energy",
     ell_max: int = 0,
+    cell_volume: Optional[torch.Tensor] = None,
+    quadrature_is_inverted: Optional[bool] = None,
 ) -> Dict[str, TensorMap]:
-    """
-    Evaluate model on a batch of rotated copies of one system and compute conservative
-    forces/stress via autograd.
+    """Evaluate rotated copies and derive conservative forces/stress with autograd.
 
     Forces are ``-dE/d(positions)`` in each rotated frame; stress is
-    ``(1/V) dE/d(strain)`` via the strain trick. Both are packaged as Cartesian
-    TensorMaps with one entry per rotation (sample axis = ``[system, atom]`` for
-    forces, ``[system]`` for stress) so the downstream back-rotation pipeline can
-    treat them like any other per-system output.
-
-    :param model: callable evaluating the base model with the
-        ``(systems, outputs, selected_atoms)`` signature
-    :param system: input system (original frame)
-    :param rotations: ``(N, 3, 3)`` rotation matrices (each may include inversion)
-    :param outputs: model output specifications
-    :param selected_atoms: optional atom selection (in the local batch index space)
-    :param device: device for tensors
-    :param dtype: dtype for tensors
-    :param energy_name: name of the output forces/stress are derived from
-    :param ell_max: maximum angular momentum used to transform custom system
-        data; only needed when the system carries data with spherical components
-    :return: model output dict with added ``"forces"`` and (if periodic) ``"stress"``
+    ``dE/d(strain)/V`` for fully periodic finite-volume cells. Returned Cartesian
+    TensorMaps contain one local ``system`` entry per rotation. Supplying
+    ``quadrature_is_inverted`` enables the validated internal transformation path.
     """
     if rotations.dim() != 3 or rotations.shape[-2:] != (3, 3):
         raise ValueError(
@@ -57,7 +49,10 @@ def _evaluate_with_gradients(
 
     n_rot = rotations.shape[0]
     n_atoms = system.positions.shape[0]
-    has_cell = bool(torch.any(system.pbc).item())
+    # A valid metatomic System has a zero cell vector along each non-periodic
+    # direction. The 3D volume/stress convention is therefore available only
+    # for fully periodic systems; lower-dimensional stress needs another schema.
+    compute_stress = cell_volume is not None or bool(torch.all(system.pbc).item())
 
     rotated_positions_list: List[torch.Tensor] = []
     strain_list: List[torch.Tensor] = []
@@ -65,17 +60,26 @@ def _evaluate_with_gradients(
 
     detached_positions = system.positions.detach()
     detached_cell = system.cell.detach()
+    volume = cell_volume
+    if compute_stress:
+        if volume is None:
+            volume = torch.abs(torch.linalg.det(detached_cell))
+            invalid_volume = (~torch.isfinite(volume)) | (volume == 0)
+            if bool(invalid_volume.item()):
+                raise ValueError(
+                    "can not compute 3D stress for a singular or non-finite "
+                    "periodic cell"
+                )
     # hoist device/dtype cast out of the per-rotation loop
     rotations = rotations.to(device=device, dtype=dtype)
 
-    for i in range(n_rot):
-        R = rotations[i]
-
+    data_names = system.known_data()
+    for R in rotations:
         rotated_positions = (detached_positions @ R.T).requires_grad_(True)
         rotated_cell = detached_cell @ R.T
         rotated_positions_list.append(rotated_positions)
 
-        if has_cell:
+        if compute_stress:
             strain = torch.eye(3, requires_grad=True, device=device, dtype=dtype)
             final_positions = rotated_positions @ strain
             final_cell = rotated_cell @ strain
@@ -108,12 +112,21 @@ def _evaluate_with_gradients(
             transformed.add_neighbor_list(options, rotated_neighbors)
 
         # custom data rotates with the system, like in o3.transform_system
-        if len(system.known_data()) > 0:
-            transformation = O3Transformation(R, ell_max)
-            for data_name in system.known_data():
-                data = system.get_data(data_name)
+        if data_names:
+            if quadrature_is_inverted is None:
+                transformation = O3Transformation(R, ell_max)
+            else:
+                transformation = O3Transformation._from_validated_matrix(
+                    R,
+                    ell_max,
+                    is_inverted=quadrature_is_inverted,
+                )
+            for data_name in data_names:
                 transformed.add_data(
-                    data_name, transform_tensor(data, [system], [transformation])
+                    data_name,
+                    transform_tensor(
+                        system.get_data(data_name), [system], [transformation]
+                    ),
                 )
 
         transformed_systems.append(transformed)
@@ -130,14 +143,34 @@ def _evaluate_with_gradients(
     energy_sum = out[energy_name].block().values.sum()
 
     grad_targets: List[torch.Tensor] = list(rotated_positions_list)
-    if has_cell:
+    if compute_stress:
         grad_targets.extend(strain_list)
-    grads = torch.autograd.grad(energy_sum, grad_targets, create_graph=False)
+    # Metatrain composition models legitimately return detached, type-only
+    # energies. Follow the suite convention: warn and treat any detached output
+    # as constant (autograd can not distinguish it from a severed graph), while
+    # graph-connected but unused targets are materialized as exact zeros.
+    if energy_sum.requires_grad:
+        grads = list(
+            torch.autograd.grad(
+                energy_sum,
+                grad_targets,
+                create_graph=False,
+                materialize_grads=True,
+            )
+        )
+    else:
+        warnings.warn(
+            f"'{energy_name}' is detached from autograd; treating it as constant "
+            "and returning zero derivatives",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        grads = [torch.zeros_like(target) for target in grad_targets]
 
     position_grads = grads[:n_rot]
-    strain_grads = grads[n_rot:] if has_cell else []
+    strain_grads = grads[n_rot:]
 
-    forces_values = torch.cat([-g for g in position_grads], dim=0)  # (n_rot*n_atoms, 3)
+    forces_values = -torch.cat(position_grads, dim=0)
 
     atom_range = torch.arange(n_atoms, dtype=torch.int64, device=device)
     system_indices = torch.arange(
@@ -149,34 +182,23 @@ def _evaluate_with_gradients(
         values=torch.stack([system_indices, atom_indices], dim=1),
     )
 
-    key_labels = Labels(
-        names=["_"],
-        values=torch.tensor([[0]], dtype=torch.int64, device=device),
-    )
+    key_labels = _range_labels("_", 1, device)
 
     forces_block = TensorBlock(
         values=forces_values.unsqueeze(-1),  # (n_rot*n_atoms, 3, 1)
         samples=forces_samples,
-        components=[
-            Labels(
-                "xyz",
-                torch.arange(3, dtype=torch.int64, device=device).reshape(-1, 1),
-            )
-        ],
-        properties=Labels(
-            names=["force"],
-            values=torch.tensor([[0]], dtype=torch.int64, device=device),
-        ),
+        components=[_range_labels("xyz", 3, device)],
+        properties=_range_labels("force", 1, device),
     )
     forces_tmap = TensorMap(key_labels, [forces_block])
     if selected_atoms is not None:
         forces_tmap = mts.slice(forces_tmap, axis="samples", selection=selected_atoms)
     out["forces"] = forces_tmap
 
-    if has_cell:
-        # volume is rotation-invariant, so the original cell volume is correct for
-        # every rotated copy
-        volume = torch.abs(torch.linalg.det(detached_cell))
+    if compute_stress:
+        # volume is rotation-invariant, so the validated original cell volume is
+        # correct for every rotated copy
+        assert volume is not None
         stress_values = torch.stack(strain_grads, dim=0) / volume  # (n_rot, 3, 3)
 
         stress_block = TensorBlock(
@@ -188,19 +210,10 @@ def _evaluate_with_gradients(
                 ),
             ),
             components=[
-                Labels(
-                    "xyz_1",
-                    torch.arange(3, dtype=torch.int64, device=device).reshape(-1, 1),
-                ),
-                Labels(
-                    "xyz_2",
-                    torch.arange(3, dtype=torch.int64, device=device).reshape(-1, 1),
-                ),
+                _range_labels("xyz_1", 3, device),
+                _range_labels("xyz_2", 3, device),
             ],
-            properties=Labels(
-                names=["stress"],
-                values=torch.tensor([[0]], dtype=torch.int64, device=device),
-            ),
+            properties=_range_labels("stress", 1, device),
         )
         out["stress"] = TensorMap(key_labels, [stress_block])
 

--- a/python/metatomic_torch/metatomic/torch/symmetrized_model/_gradients.py
+++ b/python/metatomic_torch/metatomic/torch/symmetrized_model/_gradients.py
@@ -37,10 +37,25 @@ def _evaluate_with_gradients(
 ) -> Dict[str, TensorMap]:
     """Evaluate rotated copies and derive conservative forces/stress with autograd.
 
-    Forces are ``-dE/d(positions)`` in each rotated frame; stress is
-    ``dE/d(strain)/V`` for fully periodic finite-volume cells. Returned Cartesian
-    TensorMaps contain one local ``system`` entry per rotation. Supplying
-    ``quadrature_is_inverted`` enables the validated internal transformation path.
+    Each operation receives independent leaf positions. When stress is enabled,
+    an independent identity strain is also applied to the positions and cell.
+    Summing the returned energy values before autograd still yields the per-copy
+    derivatives because the base model treats the rotated Systems independently.
+
+    Forces are ``-dE/d(positions)`` and have samples ``(system, atom)`` with one
+    ``xyz`` component axis. Stress is ``dE/d(strain)/V`` and has one ``system``
+    sample with ``xyz_1`` and ``xyz_2`` axes per rotated copy. Stress is enabled
+    by a supplied ``cell_volume`` or when all three PBC flags are true. The
+    wrapper supplies a volume only for fully periodic Systems, so non-periodic
+    and partially periodic Systems have no stress output. The volume must be
+    finite and nonzero; a supplied value is assumed to have been validated by
+    the caller.
+
+    A detached energy emits a warning and is treated as constant, while
+    graph-connected but unused position or strain targets produce exact zeros.
+    Neighbor lists and custom data are rebuilt in each transformed frame so
+    autograd registration and O(3) metadata remain consistent. Supplying
+    ``quadrature_is_inverted`` enables the trusted internal transformation path.
     """
     if rotations.dim() != 3 or rotations.shape[-2:] != (3, 3):
         raise ValueError(

--- a/python/metatomic_torch/metatomic/torch/symmetrized_model/_model.py
+++ b/python/metatomic_torch/metatomic/torch/symmetrized_model/_model.py
@@ -10,12 +10,17 @@ from metatomic.torch import (
     ModelOutput,
     System,
     is_atomistic_model,
+    register_autograd_neighbors,
 )
 
 from ..o3 import O3Transformation, transform_system, transform_tensor
-from ._decompose import _decompose_output
+from ._decompose import _decompose_output, _decomposed_output_names
 from ._gradients import _evaluate_with_gradients
-from ._projections import _accumulate_batch, _finalize_system, _wigner_stacks
+from ._projections import (
+    _accumulate_batch,
+    _finalize_system,
+    _wigner_stacks_from_matrices,
+)
 from ._quadrature import (
     _choose_quadrature,
     _rotations_from_angles,
@@ -27,63 +32,197 @@ from ._utils import (
     _prepend_system_to_samples,
     _reshape_block_by_local_system,
     _selected_atoms_for_local_systems,
+    _validated_integer,
 )
 
 
-def _reduce_weighted_batch_tensor(
+_DEFAULT_WIGNER_CACHE_MAX_BYTES = 64 * 1024**2
+_MPS_UNSUPPORTED_MESSAGE = (
+    "SymmetrizedModel does not support MPS because stable O(3) quadrature, "
+    "back-rotation, and statistical reduction require torch.float64, which "
+    "the MPS backend does not support. Use CPU or CUDA for the base model, "
+    "input Systems, and storage_device."
+)
+
+
+def _transform_system_batch(
+    system: System,
+    matrices: torch.Tensor,
+    max_angular_momentum: int,
+    *,
+    is_inverted: bool,
+) -> List[System]:
+    """Transform geometry in one batch; route heterogeneous custom data normally."""
+    if matrices.dim() != 3 or tuple(matrices.shape[1:]) != (3, 3):
+        raise ValueError(
+            f"matrices must have shape (N, 3, 3), got {tuple(matrices.shape)}"
+        )
+    # Batched-matmul setup is slower for one operation.
+    if len(matrices) == 1:
+        return [
+            transform_system(
+                system,
+                O3Transformation._from_validated_matrix(
+                    matrices[0],
+                    max_angular_momentum,
+                    is_inverted=is_inverted,
+                ),
+            )
+        ]
+    if matrices.device != system.positions.device or (
+        matrices.dtype != system.positions.dtype
+    ):
+        raise ValueError("system and quadrature matrices must share dtype/device")
+
+    transposed = matrices.transpose(1, 2)
+    positions = system.positions.unsqueeze(0) @ transposed
+    cells = system.cell.unsqueeze(0) @ transposed
+
+    transformations: List[O3Transformation] = []
+    data_names = system.known_data()
+    if len(data_names) != 0:
+        transformations = [
+            O3Transformation._from_validated_matrix(
+                matrix,
+                max_angular_momentum,
+                is_inverted=is_inverted,
+            )
+            for matrix in matrices.unbind(0)
+        ]
+
+    neighbor_batches = []
+    for options in system.known_neighbor_lists():
+        neighbors = system.get_neighbor_list(options)
+        # The input list can already be registered against ``system.positions``.
+        # Start a fresh graph for each transformed System, as the generic path does.
+        values = neighbors.values.detach().squeeze(-1).unsqueeze(0) @ transposed
+        neighbor_batches.append((options, neighbors, values))
+
+    transformed_systems: List[System] = []
+    for index in range(len(matrices)):
+        transformed = System(
+            types=system.types,
+            positions=positions[index],
+            cell=cells[index],
+            pbc=system.pbc,
+        )
+        for options, neighbors, values in neighbor_batches:
+            rotated_neighbors = TensorBlock(
+                values=values[index].unsqueeze(-1),
+                samples=neighbors.samples,
+                components=neighbors.components,
+                properties=neighbors.properties,
+            )
+            register_autograd_neighbors(transformed, rotated_neighbors)
+            transformed.add_neighbor_list(options, rotated_neighbors)
+        for data_name in data_names:
+            transformed.add_data(
+                data_name,
+                transform_tensor(
+                    system.get_data(data_name),
+                    [system],
+                    [transformations[index]],
+                ),
+            )
+        transformed_systems.append(transformed)
+
+    return transformed_systems
+
+
+def _reduce_weighted_batch_moments(
     tensor: TensorMap,
     weights: torch.Tensor,
     system_index: int,
-    *,
-    component_norm: bool = False,
-) -> TensorMap:
-    """Reduce a batch of rotated-copy outputs to its quadrature contribution.
+    reference: Optional[TensorMap] = None,
+) -> Tuple[TensorMap, TensorMap, TensorMap, TensorMap]:
+    """Return signed/absolute centered moments and the fixed reference.
 
-    With ``component_norm=False``, returns ``sum_g 0.5 w_g x(g)`` over the
-    batch, i.e. a partial sum of the O(3) mean of ``x``. With
-    ``component_norm=True``, the values are squared and summed over the
-    component axes first, giving a partial sum of the mean squared norm (the
-    second moment). Weights are halved because the caller sums the two
-    inversion passes (+1 and -1) to average over O(3). Samples are re-labeled
-    with the global ``system_index``.
+    Here ``y = tensor - reference``; the first copy becomes the reference on
+    the first call. The absolute second moment supplies a scale for distinguishing
+    signed-quadrature aliasing from floating-point round-off.
     """
     n_local_systems = weights.numel()
-    reduced_blocks: List[TensorBlock] = []
-    for block in tensor.blocks():
+    mean_blocks: List[TensorBlock] = []
+    second_moment_blocks: List[TensorBlock] = []
+    absolute_second_moment_blocks: List[TensorBlock] = []
+    reference_blocks: List[TensorBlock] = []
+    for key, block in tensor.items():
         values, sample_names, sample_values = _reshape_block_by_local_system(
             block, n_local_systems
         )
-
-        components = block.components
-        if component_norm:
-            component_dims = tuple(range(2, 2 + len(block.components)))
-            if len(component_dims) == 0:
-                values = values**2
-            else:
-                values = torch.sum(values**2, dim=component_dims)
-            components = []
+        if reference is None:
+            reference_values = values[0].clone()
+        else:
+            reference_values = reference.block(key).values
+            if tuple(reference_values.shape) != tuple(values.shape[1:]):
+                raise ValueError("reference and batch block shapes do not match")
+        values = values - reference_values.unsqueeze(0)
 
         weight = weights.to(dtype=values.dtype, device=values.device)
-        view = [values.shape[0]] + [1] * (values.ndim - 1)
-        reduced_values = torch.sum(0.5 * weight.view(view) * values, dim=0)
-        if reduced_values.ndim == 1:
-            reduced_values = reduced_values.unsqueeze(0)
+        mean_view = [values.shape[0]] + [1] * (values.ndim - 1)
+        mean_values = torch.sum(0.5 * weight.view(mean_view) * values, dim=0)
 
-        reduced_blocks.append(
+        component_dims = tuple(range(2, 2 + len(block.components)))
+        if len(component_dims) == 0:
+            squared_norms = values**2
+        else:
+            squared_norms = torch.sum(values**2, dim=component_dims)
+        moment_view = [squared_norms.shape[0]] + [1] * (squared_norms.ndim - 1)
+        second_moment_values = torch.sum(
+            0.5 * weight.view(moment_view) * squared_norms, dim=0
+        )
+        absolute_second_moment_values = torch.sum(
+            0.5 * torch.abs(weight).view(moment_view) * squared_norms, dim=0
+        )
+
+        samples = _prepend_system_to_samples(
+            sample_names,
+            sample_values,
+            system_index,
+            device=block.samples.values.device,
+        )
+        mean_blocks.append(
             TensorBlock(
-                values=reduced_values,
-                samples=_prepend_system_to_samples(
-                    sample_names,
-                    sample_values,
-                    system_index,
-                    device=block.samples.values.device,
-                ),
-                components=components,
+                values=mean_values,
+                samples=samples,
+                components=block.components,
                 properties=block.properties,
             )
         )
+        second_moment_blocks.append(
+            TensorBlock(
+                values=second_moment_values,
+                samples=samples,
+                components=[],
+                properties=block.properties,
+            )
+        )
+        absolute_second_moment_blocks.append(
+            TensorBlock(
+                values=absolute_second_moment_values,
+                samples=samples,
+                components=[],
+                properties=block.properties,
+            )
+        )
+        if reference is None:
+            reference_blocks.append(
+                TensorBlock(
+                    values=reference_values,
+                    samples=samples,
+                    components=block.components,
+                    properties=block.properties,
+                )
+            )
 
-    return TensorMap(tensor.keys, reduced_blocks)
+    if reference is None:
+        reference = TensorMap(tensor.keys, reference_blocks)
+    return (
+        TensorMap(tensor.keys, mean_blocks),
+        TensorMap(tensor.keys, second_moment_blocks),
+        TensorMap(tensor.keys, absolute_second_moment_blocks),
+        reference,
+    )
 
 
 def _accumulate_tensormap(
@@ -106,6 +245,46 @@ def _join_tensormap_list(tensors: List[TensorMap]) -> TensorMap:
     if len(tensors) == 1:
         return tensors[0]
     return mts.join(tensors, "samples", different_keys="union")
+
+
+def _wigner_stack_nbytes(n_rotations: int, ell_max: int, dtype: torch.dtype) -> int:
+    """Exact storage of stacked Wigner-D matrices through ``ell_max``."""
+    # sum_{ell=0}^L (2 ell + 1)^2
+    elements_per_rotation = (ell_max + 1) * (2 * ell_max + 1) * (2 * ell_max + 3) // 3
+    element_size = torch.empty((), dtype=dtype).element_size()
+    return n_rotations * elements_per_rotation * element_size
+
+
+def _attach_wigner_stacks(
+    transformations: List[O3Transformation],
+    stacks: Dict[int, torch.Tensor],
+    batch_start: int,
+) -> None:
+    """Seed transformations with views into immutable full-grid stacks."""
+    for local_index, transformation in enumerate(transformations):
+        grid_index = batch_start + local_index
+        transformation._wigner_D_cache = {
+            ell: stack[grid_index] for ell, stack in stacks.items()
+        }
+
+
+def _validate_base_outputs(
+    raw: Dict[str, TensorMap], requested_outputs: Dict[str, ModelOutput]
+) -> None:
+    """Check the base-model output contract before quadrature processing."""
+    missing = [name for name in requested_outputs if name not in raw]
+    if len(missing) != 0:
+        formatted = ", ".join(f"'{name}'" for name in missing)
+        raise ValueError(f"base model did not return requested output(s): {formatted}")
+
+    for name in requested_outputs:
+        for block in raw[name].blocks():
+            gradient_names = block.gradients_list()
+            if len(gradient_names) != 0:
+                raise ValueError(
+                    f"base model output '{name}' contains explicit gradient "
+                    f"'{gradient_names[0]}', which SymmetrizedModel does not support"
+                )
 
 
 def _mean_norm_squared_tensor(tensor: TensorMap) -> TensorMap:
@@ -144,6 +323,52 @@ def _finalize_variance(
     return mts.subtract(second_moment, mean_norm_sq)
 
 
+def _validate_nonnegative_diagnostic(
+    tensor: TensorMap,
+    scale: TensorMap,
+    *,
+    n_grid_points: int,
+    quantity: str,
+    max_o3_lambda_grid: int,
+) -> TensorMap:
+    """Clamp round-off-sized negatives and reject signed-grid aliasing."""
+    blocks: List[TensorBlock] = []
+    for key, block in tensor.items():
+        scale_values = scale.block(key).values
+        invalid = (
+            (~torch.isfinite(block.values))
+            | (~torch.isfinite(scale_values))
+            | (scale_values < 0)
+        )
+        if bool(torch.any(invalid).item()):
+            raise ValueError(f"O(3) {quantity} or its error scale is invalid")
+
+        epsilon = torch.finfo(block.values.dtype).eps
+        n_epsilon = n_grid_points * epsilon
+        gamma = n_epsilon / (1.0 - n_epsilon)
+        tolerance = (
+            64.0
+            * gamma
+            * torch.clamp(scale_values, min=torch.finfo(block.values.dtype).tiny)
+        )
+        if bool(torch.any(block.values < -tolerance).item()):
+            raise ValueError(
+                f"finite O(3) {quantity} is materially negative; the quadrature "
+                "does not resolve this response. Increase max_o3_lambda_grid "
+                f"above {max_o3_lambda_grid} and check convergence"
+            )
+
+        blocks.append(
+            TensorBlock(
+                values=torch.clamp(block.values, min=0.0),
+                samples=block.samples,
+                components=block.components,
+                properties=block.properties,
+            )
+        )
+    return TensorMap(tensor.keys, blocks)
+
+
 def per_system_equivariance_rmse(
     outputs: Dict[str, TensorMap],
     name: str,
@@ -158,12 +383,11 @@ def per_system_equivariance_rmse(
     the ``o3_lambda``/``o3_sigma`` blocks of a spherical target), one
     ``system`` sample per system, and the target's properties (e.g. radial
     channels). Within each block, the variance (already summed over the
-    component axes) is divided by the irrep multiplicity (:math:`2\\lambda+1`,
-    read from the component axes of the matching ``<name>_mean`` entry) and
-    averaged over the samples belonging to each system (e.g. over atoms for
-    per-atom outputs), before taking the square root. This matches the
-    normalization of an element-wise accuracy RMSE over the same block, so the
-    two are directly comparable.
+    component axes) is divided by the total component multiplicity read from
+    the matching ``<name>_mean`` block. This is :math:`2\\lambda+1` for one
+    irrep axis, and the product of the axis sizes for a higher-rank target. The
+    result is then averaged over each system's samples before taking the square
+    root, matching the normalization of an element-wise accuracy RMSE.
 
     Aggregating afterwards is up to the caller: to pool per-system values into
     a dataset-level RMSE, combine the squares weighted by the number of
@@ -173,6 +397,11 @@ def per_system_equivariance_rmse(
     that contribute no samples to a block get an RMSE of zero. Extensivity is
     not corrected either: for a total-energy output, dividing by the number of
     atoms per system is up to the caller.
+
+    Variances returned by :class:`SymmetrizedModel` are non-negative: round-off
+    residuals are set to zero, while materially negative signed-grid estimates
+    raise with grid-convergence guidance. This helper likewise rejects negative
+    or non-finite manually supplied variance entries.
 
     :param outputs: dictionary returned by :py:class:`SymmetrizedModel`
     :param name: name of the output to reduce, without the ``_var`` suffix
@@ -197,6 +426,8 @@ def per_system_equivariance_rmse(
             multiplicity *= len(component)
 
         values = block.values
+        if bool(torch.any((~torch.isfinite(values)) | (values < 0)).item()):
+            raise ValueError("variance values must be finite and non-negative")
         dtype = values.dtype
         device = values.device
         n_properties = values.shape[-1]
@@ -210,7 +441,7 @@ def per_system_equivariance_rmse(
         total = total / torch.clamp(count, min=1.0).unsqueeze(1)
         blocks.append(
             TensorBlock(
-                values=torch.sqrt(torch.clamp(total, min=0.0)),
+                values=torch.sqrt(total),
                 samples=Labels(
                     ["system"],
                     torch.arange(n_systems, device=device).unsqueeze(1),
@@ -225,123 +456,73 @@ def per_system_equivariance_rmse(
 
 class SymmetrizedModel(torch.nn.Module):
     r"""
-    Wrapper around an atomistic model that symmetrizes its outputs over :math:`O(3)`
-    and computes equivariance metrics.
+    Wrapper around an atomistic model that approximates symmetrization over
+    :math:`O(3)` with a deterministic finite quadrature and computes
+    equivariance metrics. The result equals the Haar projection when the
+    relevant orbit response and products are resolved by the chosen grid;
+    otherwise convergence must be checked.
 
-    The model is evaluated over a quadrature grid on :math:`O(3)`, constructed from a
-    Lebedev grid supplemented by in-plane rotations. For each sampled group element, the
-    model outputs are "back-rotated" according to the known :math:`O(3)` action
-    appropriate for their tensorial type (scalar, vector, tensor, etc.). Averaging these
-    back-rotated predictions over the quadrature grid yields fully
-    :math:`O(3)`-symmetrized outputs. In addition, two complementary equivariance
-    metrics are computed:
-
-    1. Variance under :math:`O(3)` of the back-rotated outputs.
-
-        For a perfectly equivariant model, the back-rotated output :math:`x(g)` is
-        independent of the group element :math:`g`. Deviations from perfect equivariance
-        are quantified by the difference between the average squared norm over
-        :math:`O(3)` and the squared norm of the :math:`O(3)`-averaged output:
-
-        .. math::
-
-            \mathrm{Var}_{O(3)}[x]
-            =
-            \left\langle \,\| x(g) \|^{2} \,\right\rangle_{O(3)}
-            -
-            \left\| \left\langle x(g) \right\rangle_{O(3)} \right\|^{2} .
-
-        Here, :math:`\|\cdot\|` denotes the Euclidean norm over the ``component`` axis,
-        and :math:`\langle \cdot \rangle_{O(3)}` denotes averaging over the quadrature
-        grid. This quantity is the squared norm of the component orthogonal to the
-        perfectly equivariant subspace and therefore provides a scalar measure of the
-        deviation from exact equivariance.
-
-    2. Decomposition into isotypical components of :math:`O(3)`.
-
-        Each output component may be viewed as a scalar function on :math:`O(3)`,
-        which can be decomposed into isotypical components labeled by the irreducible
-        representations :math:`\ell,\sigma` of :math:`O(3)`. The projection onto the
-        :math:`(\ell,\sigma)`-th isotypical subspace is computed as a convolution with
-        the corresponding character :math:`\chi_{\ell,\sigma}`:
-
-        .. math::
-
-            (P_{\ell,\sigma} x)(g)
-            =
-            (2\ell+1)
-            \int_{O(3)} \chi_{\ell,\sigma}(h^{-1} g)\, x(h)\, \mathrm{d}\mu(h),
-
-        where the prefactor is the dimension of the irreducible representation
-        and makes :math:`P_{\ell,\sigma}` idempotent, so that the squared norms
-        of the components of a band-limited function sum to :math:`\| x \|^{2}`.
-
-        The character is the trace of the representation matrices: on proper
-        rotations :math:`R` it does not depend on :math:`\sigma`,
-
-        .. math::
-
-            \chi_{\ell,\sigma}(R) = \operatorname{tr} D^{\ell}(R),
-
-        with :math:`D^{\ell}` the (real) Wigner-D matrix, while on the improper
-        coset (a rotation composed with the inversion :math:`i`) it becomes
-
-        .. math::
-
-            \chi_{\ell,\sigma}(i R)
-            =
-            \sigma \, (-1)^{\ell} \, \operatorname{tr} D^{\ell}(R).
-
-        Following the metatensor ``o3_sigma`` convention, :math:`\sigma = +1`
-        labels proper tensors (inversion parity :math:`(-1)^{\ell}`, e.g.
-        vectors at :math:`\ell = 1`) and :math:`\sigma = -1` pseudotensors
-        (inversion parity :math:`-(-1)^{\ell}`). These labels appear as
-        ``chi_lambda`` and ``chi_sigma`` in the keys of the returned character
-        projections.
-
-        The squared :math:`L^{2}` norm of the projection over :math:`O(3)` is
-
-        .. math::
-
-            \| P_{\ell,\sigma} x \|^{2}
-            =
-            \left\langle \, | (P_{\ell,\sigma} x)(g) |^{2} \, \right\rangle_{O(3)} .
-
-        These quantities describe how the model output is distributed across the
-        different :math:`O(3)` irreducible sectors. The complementary component,
-        orthogonal to all isotypical subspaces, is given by
-
-        .. math::
-
-            \| x \|^{2}
-            -
-            \sum_{\ell,\sigma} \| P_{\ell,\sigma} x \|^{2} ,
-
-        and provides a refined measure of the deviation from lying entirely within any
-        prescribed set of :math:`O(3)` irreducible representations.
+    For each grid operation :math:`g`, the direct response :math:`f(gX)` is
+    back-rotated to a common frame before its mean, norm, and orientation
+    variance are accumulated. Optional character projections instead act on
+    the direct orbit and report its norm in the included :math:`O(3)` sectors.
+    Generated standard spherical maps use canonical
+    ``o3_lambda``/``o3_sigma`` keys.
+    See the module reference for the projector, basis conventions, finite-grid
+    theorem, output schema, and convergence requirements.
 
     :param base_model: atomistic model to symmetrize, either a module following
         the :py:class:`ModelInterface` call convention or an exported
         :py:class:`AtomisticModel` (including one loaded with
         :py:func:`load_atomistic_model`)
-    :param max_o3_lambda_target: maximum O(3) angular momentum expected among the
-        model outputs to back-rotate
+    :param max_o3_lambda_target: validation ceiling for spherical ``o3_lambda``
+        components returned directly by the base model. Actual back-rotation
+        caches are sized from the ranks present in each batch. Canonical
+        Cartesian force/stress outputs are decomposed after this validation and
+        are not bounded by it. This value also controls the default grid when no
+        character cutoff is given, but is not an orbit-response bandwidth.
     :param max_o3_lambda_character: maximum O(3) angular momentum used for the
         character projections. If ``None`` (default), character projections are
         unavailable (calling :py:meth:`forward` with
         ``compute_character_projections=True`` raises an error) and the default
-        quadrature grid follows ``max_o3_lambda_target`` instead.
-    :param batch_size: number of rotations to evaluate in a single batch
-    :param max_o3_lambda_grid: maximum O(3) angular momentum the quadrature grid
-        integrates exactly. If ``None`` (default), set to
-        ``2 * max_o3_lambda_character + 1`` when ``max_o3_lambda_character`` is
-        given, and to ``2 * max_o3_lambda_target + 1`` otherwise.
+        quadrature grid follows ``max_o3_lambda_target`` instead. If given, it
+        must be a non-negative integer.
+    :param batch_size: positive integer number of rotations evaluated in one
+        base-model call. It changes peak batch memory, not the total number of
+        rotated copies.
+    :param max_o3_lambda_grid: declared product-quadrature integration degree
+        ``D``. It selects the smallest available Lebedev order at least ``D``
+        and ``D + 1`` in-plane angles. If ``None`` (default), set to
+        ``2 * max_o3_lambda_character`` when ``max_o3_lambda_character`` is
+        given, and to ``2 * max_o3_lambda_target + 1`` otherwise. The character
+        default is the exact product-quadrature boundary: a grid degree
+        ``2 * L`` selects ``2 * L + 1`` in-plane angles. The target-only
+        default keeps one additional in-plane angle as a conservative heuristic
+        because a target-rank ceiling is not an orbit-response bandwidth. It
+        must be a non-negative integer no larger than 131. For an unrestricted
+        response, increase it until the requested statistics converge.
     :param storage_device: device on which intermediate and final results are
-        kept. If ``None`` (default), everything stays on the model device. If set
-        (e.g. ``"cpu"`` for a model on GPU), base-model outputs are moved there
-        right after each forward pass, trading transfer bandwidth for GPU
-        memory, and back-rotation, accumulation, and the returned TensorMaps
-        live there.
+        kept. If ``None`` (default), back-rotation follows the System device and
+        final results are moved to the wrapper's quadrature-buffer device. If
+        set (e.g. ``"cpu"`` for a model on GPU), base-model outputs are moved
+        there after each forward pass, trading transfer bandwidth for GPU
+        memory; back-rotation, accumulation, and returned TensorMaps live there.
+    :param wigner_cache_max_bytes: tensor-memory budget for the lazy persistent
+        cache of full-grid Wigner-D matrices (default: 64 MiB). Transformation
+        wrappers are recreated one batch at a time and are not retained.
+        Reusing the matrices avoids rebuilding the same Wigner-D values for
+        every system, forward call, and molecular-dynamics step. The cache is
+        sized from the largest rank actually requested; if the complete tensor
+        allocation would exceed this byte limit, the wrapper falls back to its
+        bounded per-batch cache. Set this to zero to disable persistent caching.
+
+    ``SymmetrizedModel`` does not support MPS execution. Stable quadrature,
+    back-rotation, and reduction require float64, which the MPS backend does
+    not provide. Registered MPS base state is rejected at construction;
+    MPS storage, input Systems, and wrapper-controlled moves are rejected before
+    evaluation. Manually moving an individual base submodule after construction
+    is outside this preflight contract. This limitation is specific to this
+    wrapper and does not change general metatomic O(3) or metatrain MPS support.
 
     Keep the wrapper in the dtype it was constructed with: casting it to a
     lower precision (e.g. ``.to(torch.float32)``) degrades the quadrature grid
@@ -356,42 +537,66 @@ class SymmetrizedModel(torch.nn.Module):
         batch_size: int = 32,
         max_o3_lambda_grid: Optional[int] = None,
         storage_device: Optional[str] = None,
+        wigner_cache_max_bytes: int = _DEFAULT_WIGNER_CACHE_MAX_BYTES,
     ):
         super().__init__()
         self.base_model = base_model
         self._base_is_atomistic = is_atomistic_model(base_model)
 
-        try:
-            ref_param = next(base_model.parameters())
-            device = ref_param.device
-        except StopIteration:
-            device = torch.device("cpu")
+        max_o3_lambda_target = _validated_integer(
+            "max_o3_lambda_target", max_o3_lambda_target, 0
+        )
+        if max_o3_lambda_character is not None:
+            max_o3_lambda_character = _validated_integer(
+                "max_o3_lambda_character", max_o3_lambda_character, 0
+            )
+        if max_o3_lambda_grid is not None:
+            max_o3_lambda_grid = _validated_integer(
+                "max_o3_lambda_grid", max_o3_lambda_grid, 0
+            )
+        batch_size = _validated_integer("batch_size", batch_size, 1)
+        wigner_cache_max_bytes = _validated_integer(
+            "wigner_cache_max_bytes", wigner_cache_max_bytes, 0
+        )
+
+        storage_device = (
+            None if storage_device is None else torch.device(storage_device)
+        )
+        if storage_device is not None and storage_device.type == "mps":
+            raise ValueError(_MPS_UNSUPPORTED_MESSAGE)
+
+        device = torch.device("cpu")
+        found_reference_parameter = False
+        for parameter in base_model.parameters():
+            if not found_reference_parameter:
+                device = parameter.device
+                found_reference_parameter = True
+            if parameter.device.type == "mps":
+                raise ValueError(_MPS_UNSUPPORTED_MESSAGE)
+        for buffer in base_model.buffers():
+            if buffer.device.type == "mps":
+                raise ValueError(_MPS_UNSUPPORTED_MESSAGE)
 
         self.max_o3_lambda_target = max_o3_lambda_target
         self.batch_size = batch_size
-        self.storage_device = (
-            None if storage_device is None else torch.device(storage_device)
-        )
+        self.wigner_cache_max_bytes = wigner_cache_max_bytes
+        self.storage_device = storage_device
         if max_o3_lambda_grid is None:
             if max_o3_lambda_character is not None:
-                max_o3_lambda_grid = int(2 * max_o3_lambda_character + 1)
+                max_o3_lambda_grid = 2 * max_o3_lambda_character
             else:
-                max_o3_lambda_grid = int(2 * max_o3_lambda_target + 1)
+                max_o3_lambda_grid = 2 * max_o3_lambda_target + 1
         self.max_o3_lambda_grid = max_o3_lambda_grid
         self.max_o3_lambda_character = max_o3_lambda_character
 
         lebedev_order, n_inplane_rotations = _choose_quadrature(self.max_o3_lambda_grid)
-        # kept for the sufficiency check in forward() when character projections
-        # are requested
-        self._lebedev_order = lebedev_order
         alpha, beta, gamma, w_so3 = get_euler_angles_quadrature(
             lebedev_order, n_inplane_rotations
         )
+        w_so3 = w_so3 / np.sum(w_so3, dtype=np.float64)
         # the grid buffers are kept in float64: all statistics are accumulated
-        # in double precision (the variance is a difference of two second
-        # moments and cancels catastrophically in float32 for outputs of large
-        # magnitude); rotations are downcast to the model dtype only when
-        # transforming the input systems
+        # in double precision around a fixed reference value; rotations are
+        # downcast to the model dtype only when transforming the input systems
         # the weights are a plain CPU float64 attribute, not a buffer, so a
         # user cast like `.to(torch.float32)` cannot touch them (weights
         # quantized to float32 no longer sum to 1 within ~1e-8, which alone
@@ -403,11 +608,138 @@ class SymmetrizedModel(torch.nn.Module):
         ).to(device=device, dtype=torch.float64)
         self.register_buffer("so3_rotations", so3_rotations)
 
-        angles_inverse_rotations = (np.pi - gamma, beta, np.pi - alpha)
-        so3_inverse_rotations = torch.from_numpy(
-            _rotations_from_angles(*angles_inverse_rotations).as_matrix()
-        ).to(device=device, dtype=torch.float64)
-        self.register_buffer("so3_inverse_rotations", so3_inverse_rotations)
+        # Derived runtime data only: this is intentionally neither a parameter
+        # nor a buffer, and is removed from whole-module pickle state below.
+        # One device/dtype/grid entry is retained at a time, bounding persistent
+        # memory and avoiding stale multi-device copies.
+        self._wigner_cache: Dict[int, torch.Tensor] = {}
+        self._wigner_cache_key: Optional[Tuple] = None
+
+    def clear_wigner_cache(self) -> None:
+        """Release cached quadrature Wigner-D matrices.
+
+        The cache is also cleared automatically by :meth:`torch.nn.Module.to`
+        and related dtype/device transformations. Normal in-place changes to
+        the canonical quadrature buffer are detected through its tensor version;
+        call this method after unsupported ``.data`` mutation.
+        """
+        self._wigner_cache = {}
+        self._wigner_cache_key = None
+
+    def _validate_no_mps_execution(self, systems: List[System]) -> None:
+        """Reject MPS storage or inputs before model evaluation."""
+        if self.storage_device is not None and self.storage_device.type == "mps":
+            raise ValueError(_MPS_UNSUPPORTED_MESSAGE)
+        if any(system.device.type == "mps" for system in systems):
+            raise ValueError(_MPS_UNSUPPORTED_MESSAGE)
+
+    def _apply(self, fn, recurse=True):
+        # Preflight standard Module.to(...) targets before clearing derived
+        # caches or moving any parameter/buffer in this wrapper subtree. An
+        # integral probe follows the target device without requesting an
+        # unsupported float64 allocation on MPS.
+        try:
+            target = fn(torch.empty(0, dtype=torch.int64, device="cpu"))
+        except (RuntimeError, NotImplementedError) as error:
+            if "mps" in str(error).casefold():
+                raise ValueError(_MPS_UNSUPPORTED_MESSAGE) from error
+            raise
+        if target.device.type == "mps":
+            raise ValueError(_MPS_UNSUPPORTED_MESSAGE)
+
+        # A cached tensor dictionary is not registered as module state, so it
+        # would not follow `.to(...)`. Drop it before parameters/buffers move;
+        # the next spherical operation rebuilds it on the requested device.
+        self.clear_wigner_cache()
+        return super()._apply(fn, recurse=recurse)
+
+    def __getstate__(self):
+        # Wigner stacks are deterministically derived from serialized
+        # quadrature buffers. Excluding them keeps whole-module torch.save and
+        # deepcopy payloads independent of whether a wrapper has been warmed.
+        state = super().__getstate__()
+        state["_wigner_cache"] = {}
+        state["_wigner_cache_key"] = None
+        return state
+
+    def _persistent_wigner_stacks(
+        self,
+        ell_max: int,
+        *,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> Optional[Dict[int, torch.Tensor]]:
+        """Return full-grid Wigner stacks, or ``None`` when they exceed the cap."""
+        # ``torch.device("cuda")`` follows the current device and therefore
+        # can denote different physical devices across calls. Resolve it before
+        # keying or allocating so such a change replaces, rather than reuses,
+        # an entry on the old device.
+        if device.type == "cuda" and device.index is None:
+            device = torch.device("cuda", torch.cuda.current_device())
+
+        required_bytes = _wigner_stack_nbytes(
+            self.so3_rotations.shape[0], ell_max, dtype
+        )
+        if required_bytes > self.wigner_cache_max_bytes:
+            # Honor a budget lowered after the cache was built. Avoid replacing
+            # empty dictionaries on every batch of an always-uncached run.
+            if self._wigner_cache_key is not None:
+                self.clear_wigner_cache()
+            return None
+
+        source = self.so3_rotations
+        key = (
+            device.type,
+            -1 if device.index is None else device.index,
+            str(dtype),
+            source.device.type,
+            -1 if source.device.index is None else source.device.index,
+            str(source.dtype),
+            tuple(source.shape),
+            id(source),
+            source.data_ptr(),
+            source._version,
+        )
+        if key == self._wigner_cache_key and all(
+            ell in self._wigner_cache for ell in range(ell_max + 1)
+        ):
+            retained_bytes = sum(
+                tensor.numel() * tensor.element_size()
+                for tensor in self._wigner_cache.values()
+            )
+            if retained_bytes <= self.wigner_cache_max_bytes:
+                return self._wigner_cache
+
+        # Release old stacks before allocating replacements to bound peak memory.
+        self.clear_wigner_cache()
+
+        # Use the fallback path so cached and uncached results remain identical.
+        n_rotations = source.shape[0]
+        # Publish only after every batch succeeds.
+        new_cache = {
+            ell: torch.empty(
+                (n_rotations, 2 * ell + 1, 2 * ell + 1),
+                device=device,
+                dtype=dtype,
+            )
+            for ell in range(ell_max + 1)
+        }
+        for batch_start in range(0, n_rotations, self.batch_size):
+            batch_stop = min(batch_start + self.batch_size, n_rotations)
+            batch_matrices = source[batch_start:batch_stop].transpose(-1, -2)
+            batch_stacks = _wigner_stacks_from_matrices(
+                batch_matrices,
+                ell_max,
+                is_inverted=False,
+                output_device=device,
+                output_dtype=dtype,
+            )
+            for ell, stack in batch_stacks.items():
+                new_cache[ell][batch_start:batch_stop] = stack
+        self._wigner_cache = new_cache
+        # Publish the validity key last, after all potentially failing work.
+        self._wigner_cache_key = key
+        return self._wigner_cache
 
     def forward(
         self,
@@ -426,39 +758,53 @@ class SymmetrizedModel(torch.nn.Module):
         :param outputs: dictionary of model outputs to symmetrize
         :param selected_atoms: optional Labels specifying which atoms to consider
         :param compute_character_projections: if True, also compute character
-            projections. Requires ``max_o3_lambda_character`` to be set and a
-            quadrature grid able to integrate the projections exactly.
-        :param compute_gradients: if True, compute conservative forces and stress
-            via autograd. When False (default), the grid evaluation runs under
-            ``torch.no_grad()`` to save memory.
+            projections. Requires ``max_o3_lambda_character`` to be set and
+            ``max_o3_lambda_grid >= 2 * max_o3_lambda_character``. Exact Haar
+            projections additionally require the response bandwidth to be
+            covered by the cutoff and grid.
+        :param compute_gradients: if True, compute conservative forces and, for
+            fully periodic systems, 3D stress via autograd. When False (default),
+            the grid evaluation runs under ``torch.no_grad()`` to save memory.
         :param energy_name: name of the output used to derive forces and stress
             when ``compute_gradients=True``; it must be present in ``outputs``.
             The derived quantities are always returned under the ``forces`` and
-            ``stress`` names.
+            ``stress`` names, which are reserved in this mode.
         :return: dictionary with symmetrized outputs and equivariance metrics.
             Statistics are accumulated and returned in float64, independently
             of the model dtype; the model itself runs in its own dtype, so
             errors below the round-off of its outputs remain unmeasurable.
         """
+        self._validate_no_mps_execution(systems)
+
+        for name, output in outputs.items():
+            if len(output.explicit_gradients) != 0:
+                raise ValueError(
+                    "SymmetrizedModel does not support explicit gradients for "
+                    f"output '{name}'; request it without explicit_gradients. "
+                    "Use compute_gradients=True to derive conservative forces "
+                    "and stress from an energy output."
+                )
+
         if compute_character_projections:
             if self.max_o3_lambda_character is None:
                 raise ValueError(
                     "max_o3_lambda_character must be set to compute character "
                     "projections"
                 )
-            if self._lebedev_order < 2 * self.max_o3_lambda_character:
+            required_grid_degree = 2 * self.max_o3_lambda_character
+            if self.max_o3_lambda_grid < required_grid_degree:
                 raise ValueError(
                     "the quadrature grid is too coarse for character projections "
-                    f"up to lambda={self.max_o3_lambda_character} (Lebedev order "
-                    f"{self._lebedev_order} < {2 * self.max_o3_lambda_character}); "
-                    "set max_o3_lambda_grid >= 2 * max_o3_lambda_character, or "
-                    "leave it None to use a sufficient default"
+                    f"up to lambda={self.max_o3_lambda_character} "
+                    f"(max_o3_lambda_grid={self.max_o3_lambda_grid} < "
+                    f"{required_grid_degree}); set max_o3_lambda_grid >= 2 * "
+                    "max_o3_lambda_character, or leave it None to use a "
+                    "sufficient default"
                 )
 
         device = self.so3_rotations.device
         # outputs are detached from any autograd graph before back-rotation,
         # so offloading is safe in compute_gradients mode too
-        offload = self.storage_device is not None
         result_device = (
             self.storage_device if self.storage_device is not None else device
         )
@@ -470,7 +816,6 @@ class SymmetrizedModel(torch.nn.Module):
                 selected_atoms,
                 compute_character_projections=compute_character_projections,
                 compute_gradients=compute_gradients,
-                offload=offload,
                 energy_name=energy_name,
             )
 
@@ -501,7 +846,7 @@ class SymmetrizedModel(torch.nn.Module):
         :param outputs: dictionary of model outputs to symmetrize
         :param selected_atoms: optional Labels specifying which atoms to consider
         :param compute_gradients: if True, also compute the error of the
-            conservative forces (and stress, for periodic systems) obtained
+            conservative forces (and stress, for fully periodic systems) obtained
             from the ``energy_name`` output via autograd
         :param energy_name: name of the output used to derive forces and stress
             when ``compute_gradients=True``
@@ -540,18 +885,7 @@ class SymmetrizedModel(torch.nn.Module):
         outputs: Dict[str, ModelOutput],
         selected_atoms: Optional[Labels],
     ) -> Dict[str, TensorMap]:
-        """Evaluate the base model, adapting the call to its kind.
-
-        Modules following the :py:class:`ModelInterface` convention are called
-        directly; exported :py:class:`AtomisticModel` instances are called with
-        a :py:class:`ModelEvaluationOptions` (empty ``length_unit``, i.e. no
-        conversion of the input systems) and ``check_consistency=False``.
-
-        The requested outputs are forwarded unchanged: each base-model kind
-        keeps its usual metatomic semantics, so exported models apply their
-        normal output-unit conversion when a requested ``unit`` differs from
-        the declared one, while raw modules ignore units entirely.
-        """
+        """Call a raw module or adapt options for an exported AtomisticModel."""
         if self._base_is_atomistic:
             options = ModelEvaluationOptions(
                 length_unit="",
@@ -571,15 +905,10 @@ class SymmetrizedModel(torch.nn.Module):
         energy_name: str,
         forward_ell_max: int,
         backrotation_device: torch.device,
+        cell_volume: Optional[torch.Tensor],
+        is_inverted: bool,
     ) -> Dict[str, TensorMap]:
-        """Evaluate the base model on one batch of rotated copies of a system.
-
-        The returned outputs are detached from any autograd graph, moved to the
-        back-rotation device, and upcast to float64: everything downstream
-        (back-rotation, mean/second-moment, projections) runs in float64 to
-        avoid catastrophic cancellation in the variance for outputs of large
-        magnitude.
-        """
+        """Evaluate one rotation batch and move detached outputs to float64 storage."""
         work_device = system.positions.device
         work_dtype = system.positions.dtype
 
@@ -594,7 +923,10 @@ class SymmetrizedModel(torch.nn.Module):
                 work_dtype,
                 energy_name=energy_name,
                 ell_max=forward_ell_max,
+                cell_volume=cell_volume,
+                quadrature_is_inverted=is_inverted,
             )
+            _validate_base_outputs(raw, outputs)
             # the statistics need no gradients, and the forces and stress are
             # already materialized: detach so each batch's autograd graph is
             # freed instead of being kept alive by the accumulators for the
@@ -604,18 +936,18 @@ class SymmetrizedModel(torch.nn.Module):
                 for k, v in raw.items()
             }
 
-        transformed_systems = [
-            transform_system(
-                system,
-                O3Transformation(R.to(device=work_device), forward_ell_max),
-            )
-            for R in inversion_batch
-        ]
+        transformed_systems = _transform_system_batch(
+            system,
+            inversion_batch.to(device=work_device, dtype=work_dtype),
+            forward_ell_max,
+            is_inverted=is_inverted,
+        )
         raw = self._run_base_model(
             transformed_systems,
             outputs,
             local_selected_atoms,
         )
+        _validate_base_outputs(raw, outputs)
         return {
             k: v.to(device=backrotation_device, dtype=torch.float64)
             for k, v in raw.items()
@@ -630,45 +962,52 @@ class SymmetrizedModel(torch.nn.Module):
         selected_atoms: Optional[Labels],
         compute_character_projections: bool,
         compute_gradients: bool,
-        offload: bool,
         energy_name: str,
-        ell_max: int,
-    ) -> Tuple[Dict[str, TensorMap], Dict[str, TensorMap], Dict[str, TensorMap]]:
-        """Accumulate the quadrature statistics of a single system.
-
-        Streams the rotation batches through :py:meth:`_evaluate_batch`,
-        back-rotates and decomposes each output, and accumulates the weighted
-        partial sums. Returns per-output mean and second-moment sums, plus the
-        finalized character projections (empty unless requested).
-        """
-        mean_accumulators: Dict[str, TensorMap] = {}
-        second_moment_accumulators: Dict[str, TensorMap] = {}
+    ) -> Tuple[
+        Dict[str, TensorMap],
+        Dict[str, TensorMap],
+        Dict[str, TensorMap],
+        Dict[str, TensorMap],
+    ]:
+        """Stream and reduce all rotation batches for one input system."""
+        references: Dict[str, TensorMap] = {}
+        centered_mean_accumulators: Dict[str, TensorMap] = {}
+        centered_second_moment_accumulators: Dict[str, TensorMap] = {}
+        absolute_second_moment_accumulators: Dict[str, TensorMap] = {}
         proj_pos: Dict[str, Dict] = {}
         proj_neg: Dict[str, Dict] = {}
 
         n_rotations = self.so3_rotations.size(0)
         work_device = system.positions.device
         work_dtype = system.positions.dtype
-        backrotation_device = self.storage_device if offload else work_device
-        # back-rotation and accumulation always happen in float64
-        augmentation_system = system.to(device=backrotation_device, dtype=torch.float64)
+        backrotation_device = (
+            self.storage_device if self.storage_device is not None else work_device
+        )
+        selected_atoms_by_batch_size: Dict[int, Optional[Labels]] = {}
 
-        # fail loud on data beyond the declared band limit, instead of dying
-        # later inside the Wigner-D cache with an opaque message
+        # Validate the 3D volume once per original system. The gradient helper is
+        # called once per rotation batch and inversion, so doing this there would
+        # introduce repeated device synchronizations for the same cell.
+        cell_volume: Optional[torch.Tensor] = None
+        if compute_gradients and bool(torch.all(system.pbc).item()):
+            candidate_volume = torch.abs(torch.linalg.det(system.cell.detach()))
+            invalid_volume = (~torch.isfinite(candidate_volume)) | (
+                candidate_volume == 0
+            )
+            if bool(invalid_volume.item()):
+                raise ValueError(
+                    "can not compute 3D stress for a singular or non-finite "
+                    "periodic cell"
+                )
+            cell_volume = candidate_volume
+
+        # Input and output angular momenta are independent: inspect custom data
+        # directly instead of coupling its transformation cache to the declared
+        # output limit.
+        forward_ell_max = 0
         for data_name in system.known_data():
             data_lambda = _max_spherical_lambda(system.get_data(data_name))
-            if data_lambda > self.max_o3_lambda_target:
-                raise ValueError(
-                    f"system data '{data_name}' contains "
-                    f"o3_lambda={data_lambda} components, larger than "
-                    f"max_o3_lambda_target={self.max_o3_lambda_target}; "
-                    "increase max_o3_lambda_target"
-                )
-
-        # the forward transformation only needs Wigner-D caches to rotate
-        # custom data with spherical components; positions, cell, and neighbor
-        # lists use the 3x3 matrix only
-        forward_ell_max = ell_max if len(system.known_data()) > 0 else 0
+            forward_ell_max = max(forward_ell_max, data_lambda)
 
         for batch_start in range(0, n_rotations, self.batch_size):
             batch_stop = min(batch_start + self.batch_size, n_rotations)
@@ -677,11 +1016,17 @@ class SymmetrizedModel(torch.nn.Module):
             batch_rotations = self.so3_rotations[batch_start:batch_stop].to(
                 device=work_device, dtype=work_dtype
             )
-            local_selected_atoms = _selected_atoms_for_local_systems(
-                selected_atoms,
-                i_sys,
-                n_local_systems,
-            )
+            if n_local_systems not in selected_atoms_by_batch_size:
+                selected_atoms_by_batch_size[n_local_systems] = (
+                    _selected_atoms_for_local_systems(
+                        selected_atoms,
+                        i_sys,
+                        n_local_systems,
+                    )
+                )
+            local_selected_atoms = selected_atoms_by_batch_size[n_local_systems]
+            proper_uncached_wigner_stacks: Dict[int, torch.Tensor] = {}
+            proper_transformation_ell_max = -1
 
             for inversion in (1, -1):
                 out = self._evaluate_batch(
@@ -693,6 +1038,8 @@ class SymmetrizedModel(torch.nn.Module):
                     energy_name,
                     forward_ell_max,
                     backrotation_device,
+                    cell_volume,
+                    is_inverted=inversion == -1,
                 )
 
                 present_output_names = [
@@ -701,22 +1048,15 @@ class SymmetrizedModel(torch.nn.Module):
                 if len(present_output_names) == 0:
                     continue
 
-                inverse_mats = (
-                    inversion * self.so3_inverse_rotations[batch_start:batch_stop]
-                ).to(device=backrotation_device, dtype=torch.float64)
-                transformations = [
-                    O3Transformation(R, ell_max) for R in inverse_mats.unbind(0)
-                ]
-                wigner_stacks: Dict[int, torch.Tensor] = (
-                    _wigner_stacks(transformations, ell_max)
-                    if compute_character_projections
-                    else {}
-                )
-
+                # Size inverse-frame Wigner caches from the spherical ranks that
+                # are actually present in this batch. ``max_o3_lambda_target`` is
+                # a validation ceiling, and can be much larger than the output in
+                # a particular call; using it as an allocation target needlessly
+                # makes every character operation scale with that ceiling.
+                output_ell_max = 0
+                has_spherical_output = False
                 for name in present_output_names:
-                    tensor = out[name]
-
-                    output_lambda = _max_spherical_lambda(tensor)
+                    output_lambda = _max_spherical_lambda(out[name])
                     if output_lambda > self.max_o3_lambda_target:
                         raise ValueError(
                             f"output '{name}' contains "
@@ -725,29 +1065,135 @@ class SymmetrizedModel(torch.nn.Module):
                             f"{self.max_o3_lambda_target}; increase "
                             "max_o3_lambda_target"
                         )
+                    if output_lambda >= 0:
+                        has_spherical_output = True
+                        output_ell_max = max(output_ell_max, output_lambda)
+
+                transformation_ell_max = output_ell_max
+                if compute_character_projections:
+                    assert self.max_o3_lambda_character is not None
+                    transformation_ell_max = max(
+                        transformation_ell_max,
+                        self.max_o3_lambda_character,
+                    )
+
+                needs_wigner = has_spherical_output or compute_character_projections
+                persistent_wigner_stacks: Optional[Dict[int, torch.Tensor]] = None
+                if needs_wigner:
+                    persistent_wigner_stacks = self._persistent_wigner_stacks(
+                        transformation_ell_max,
+                        device=backrotation_device,
+                        dtype=torch.float64,
+                    )
+
+                inverse_mats = (
+                    inversion
+                    * self.so3_rotations[batch_start:batch_stop].transpose(-1, -2)
+                ).to(device=backrotation_device, dtype=torch.float64)
+                transformations = [
+                    O3Transformation._from_validated_matrix(
+                        R,
+                        transformation_ell_max,
+                        is_inverted=inversion == -1,
+                    )
+                    for R in inverse_mats.unbind(0)
+                ]
+                if persistent_wigner_stacks is not None:
+                    _attach_wigner_stacks(
+                        transformations,
+                        persistent_wigner_stacks,
+                        batch_start,
+                    )
+
+                uncached_wigner_stacks: Dict[int, torch.Tensor] = {}
+                if persistent_wigner_stacks is None:
+                    if (
+                        inversion == -1
+                        and needs_wigner
+                        and len(proper_uncached_wigner_stacks) != 0
+                        and transformation_ell_max <= proper_transformation_ell_max
+                    ):
+                        uncached_wigner_stacks = {
+                            ell: proper_uncached_wigner_stacks[ell]
+                            for ell in range(transformation_ell_max + 1)
+                        }
+                        _attach_wigner_stacks(
+                            transformations,
+                            uncached_wigner_stacks,
+                            0,
+                        )
+                    elif needs_wigner:
+                        uncached_wigner_stacks = _wigner_stacks_from_matrices(
+                            inverse_mats,
+                            transformation_ell_max,
+                            is_inverted=inversion == -1,
+                            output_device=backrotation_device,
+                            output_dtype=torch.float64,
+                        )
+                        _attach_wigner_stacks(
+                            transformations,
+                            uncached_wigner_stacks,
+                            0,
+                        )
+
+                    if inversion == 1:
+                        proper_uncached_wigner_stacks = uncached_wigner_stacks
+                        proper_transformation_ell_max = transformation_ell_max
+                wigner_stacks: Dict[int, torch.Tensor] = {}
+                if compute_character_projections:
+                    assert self.max_o3_lambda_character is not None
+                    if persistent_wigner_stacks is None:
+                        wigner_stacks = {
+                            ell: uncached_wigner_stacks[ell]
+                            for ell in range(self.max_o3_lambda_character + 1)
+                        }
+                    else:
+                        wigner_stacks = {
+                            ell: persistent_wigner_stacks[ell][batch_start:batch_stop]
+                            for ell in range(self.max_o3_lambda_character + 1)
+                        }
+
+                for name in present_output_names:
+                    tensor = out[name]
 
                     backtransformed = transform_tensor(
                         tensor,
-                        [augmentation_system] * n_local_systems,
+                        # transform_tensor uses these Systems only to establish
+                        # batch cardinality; reusing the original avoids copying
+                        # all custom data and neighbor lists to the reduction device.
+                        [system] * n_local_systems,
                         transformations,
                     )
                     for final_name, decomposed_tensor in _decompose_output(
                         name, backtransformed
                     ).items():
-                        for accumulators, component_norm in (
-                            (mean_accumulators, False),
-                            (second_moment_accumulators, True),
-                        ):
-                            _accumulate_tensormap(
-                                accumulators,
-                                final_name,
-                                _reduce_weighted_batch_tensor(
-                                    decomposed_tensor,
-                                    weights,
-                                    i_sys,
-                                    component_norm=component_norm,
-                                ),
-                            )
+                        (
+                            mean_contribution,
+                            second_moment_contribution,
+                            absolute_second_moment_contribution,
+                            reference,
+                        ) = _reduce_weighted_batch_moments(
+                            decomposed_tensor,
+                            weights,
+                            i_sys,
+                            reference=references.get(final_name),
+                        )
+                        references[final_name] = reference
+                        _accumulate_tensormap(
+                            centered_mean_accumulators,
+                            final_name,
+                            mean_contribution,
+                        )
+                        _accumulate_tensormap(
+                            centered_second_moment_accumulators,
+                            final_name,
+                            second_moment_contribution,
+                        )
+                        _accumulate_tensormap(
+                            absolute_second_moment_accumulators,
+                            final_name,
+                            absolute_second_moment_contribution,
+                        )
 
                     if compute_character_projections:
                         _accumulate_batch(
@@ -769,7 +1215,56 @@ class SymmetrizedModel(torch.nn.Module):
                 self.max_o3_lambda_character,
             )
 
-        return mean_accumulators, second_moment_accumulators, projections
+        means: Dict[str, TensorMap] = {}
+        variances: Dict[str, TensorMap] = {}
+        norm_squared: Dict[str, TensorMap] = {}
+        n_grid_points = 2 * n_rotations
+        absolute_weight_sum = float(
+            torch.sum(torch.abs(self._so3_weights_float64)).item()
+        )
+        for name, reference in references.items():
+            centered_mean = centered_mean_accumulators[name]
+            mean = mts.add(reference, centered_mean)
+            raw_variance = _finalize_variance(
+                centered_second_moment_accumulators[name],
+                centered_mean,
+            )
+            absolute_second_moment = absolute_second_moment_accumulators[name]
+            variance_scale = mts.add(
+                absolute_second_moment,
+                _mean_norm_squared_tensor(centered_mean),
+            )
+            variance = _validate_nonnegative_diagnostic(
+                raw_variance,
+                variance_scale,
+                n_grid_points=n_grid_points,
+                quantity="variance",
+                max_o3_lambda_grid=self.max_o3_lambda_grid,
+            )
+            raw_norm_squared = mts.add(
+                raw_variance,
+                _mean_norm_squared_tensor(mean),
+            )
+            norm_scale = mts.multiply(
+                mts.add(
+                    mts.multiply(
+                        _mean_norm_squared_tensor(reference), absolute_weight_sum
+                    ),
+                    absolute_second_moment,
+                ),
+                2.0,
+            )
+            means[name] = mean
+            variances[name] = variance
+            norm_squared[name] = _validate_nonnegative_diagnostic(
+                raw_norm_squared,
+                norm_scale,
+                n_grid_points=n_grid_points,
+                quantity="squared norm",
+                max_o3_lambda_grid=self.max_o3_lambda_grid,
+            )
+
+        return means, variances, norm_squared, projections
 
     def _eval_over_grid(
         self,
@@ -778,7 +1273,6 @@ class SymmetrizedModel(torch.nn.Module):
         selected_atoms: Optional[Labels],
         compute_character_projections: bool,
         compute_gradients: bool = False,
-        offload: bool = False,
         energy_name: str = "energy",
     ) -> Dict[str, TensorMap]:
         """
@@ -791,8 +1285,6 @@ class SymmetrizedModel(torch.nn.Module):
         :param compute_character_projections: if True, also compute character
             projections
         :param compute_gradients: if True, compute forces/stress via autograd
-        :param offload: if True, move base-model outputs to ``storage_device``
-            right after each forward pass
         :param energy_name: name of the output forces/stress are derived from
         :return: dictionary with all symmetrized outputs and metrics
         """
@@ -810,27 +1302,28 @@ class SymmetrizedModel(torch.nn.Module):
                         "output or evaluate it in a separate call"
                     )
 
-            requested_output_names = list(
-                dict.fromkeys(requested_output_names + ["forces"])
-            )
-            if any(bool(torch.any(s.pbc).item()) for s in systems):
-                requested_output_names = list(
-                    dict.fromkeys(requested_output_names + ["stress"])
-                )
+            requested_output_names.append("forces")
+            if any(bool(torch.all(s.pbc).item()) for s in systems):
+                requested_output_names.append("stress")
 
-        # Wigner-D caches beyond the target order are only needed for
-        # character projections
-        ell_max = self.max_o3_lambda_target
-        if compute_character_projections:
-            assert self.max_o3_lambda_character is not None
-            ell_max = max(ell_max, self.max_o3_lambda_character)
+        decomposed_origins: Dict[str, str] = {}
+        for source_name in requested_output_names:
+            for final_name in _decomposed_output_names(source_name):
+                if final_name in decomposed_origins:
+                    raise ValueError(
+                        f"output names '{decomposed_origins[final_name]}' and "
+                        f"'{source_name}' both produce '{final_name}' after "
+                        "spherical decomposition; rename one requested output"
+                    )
+                decomposed_origins[final_name] = source_name
 
         mean_accumulators: Dict[str, List[TensorMap]] = {}
-        second_moment_accumulators: Dict[str, List[TensorMap]] = {}
+        variance_accumulators: Dict[str, List[TensorMap]] = {}
+        norm_squared_accumulators: Dict[str, List[TensorMap]] = {}
         character_projection_accumulators: Dict[str, List[TensorMap]] = {}
 
         for i_sys, system in enumerate(systems):
-            means, second_moments, projections = self._accumulate_system(
+            means, variances, norm_squared, projections = self._accumulate_system(
                 system,
                 i_sys,
                 outputs,
@@ -838,28 +1331,26 @@ class SymmetrizedModel(torch.nn.Module):
                 selected_atoms,
                 compute_character_projections,
                 compute_gradients,
-                offload,
                 energy_name,
-                ell_max,
             )
             for name, tensor in means.items():
                 _append_tensormap(mean_accumulators, name, tensor)
-            for name, tensor in second_moments.items():
-                _append_tensormap(second_moment_accumulators, name, tensor)
+            for name, tensor in variances.items():
+                _append_tensormap(variance_accumulators, name, tensor)
+            for name, tensor in norm_squared.items():
+                _append_tensormap(norm_squared_accumulators, name, tensor)
             for name, tensor in projections.items():
                 _append_tensormap(character_projection_accumulators, name, tensor)
 
         results: Dict[str, TensorMap] = {}
         for name, mean_tensors in mean_accumulators.items():
-            mean_tensor = _join_tensormap_list(mean_tensors)
-            results[name + "_mean"] = mean_tensor
-
-            norm_squared = _join_tensormap_list(second_moment_accumulators[name])
-            results[name + "_var"] = _finalize_variance(norm_squared, mean_tensor)
-            results[name + "_norm_squared"] = norm_squared
+            results[name + "_mean"] = _join_tensormap_list(mean_tensors)
+            results[name + "_var"] = _join_tensormap_list(variance_accumulators[name])
+            results[name + "_norm_squared"] = _join_tensormap_list(
+                norm_squared_accumulators[name]
+            )
 
         for name, tensors in character_projection_accumulators.items():
-            if tensors:
-                results[name + "_character_projection"] = _join_tensormap_list(tensors)
+            results[name + "_character_projection"] = _join_tensormap_list(tensors)
 
         return results

--- a/python/metatomic_torch/metatomic/torch/symmetrized_model/_model.py
+++ b/python/metatomic_torch/metatomic/torch/symmetrized_model/_model.py
@@ -52,7 +52,20 @@ def _transform_system_batch(
     *,
     is_inverted: bool,
 ) -> List[System]:
-    """Transform geometry in one batch; route heterogeneous custom data normally."""
+    """Apply one validated O(3) matrix batch to a System.
+
+    This is equivalent to calling :func:`transform_system` once per matrix, but
+    positions, cells, and neighbor-list displacement vectors are rotated with
+    batched matrix multiplications. Custom TensorMap data still follows the
+    general O(3) metadata path. Each returned System preserves the atom types
+    and PBC flags and receives a distinct neighbor-list block registered against
+    its transformed geometry.
+
+    ``matrices`` must have shape ``(N, 3, 3)``, match the System position
+    dtype/device, and all belong to the O(3) component identified by
+    ``is_inverted``. Orthogonality and determinant parity are trusted because
+    the caller constructs these matrices from the validated quadrature grid.
+    """
     if matrices.dim() != 3 or tuple(matrices.shape[1:]) != (3, 3):
         raise ValueError(
             f"matrices must have shape (N, 3, 3), got {tuple(matrices.shape)}"
@@ -135,11 +148,21 @@ def _reduce_weighted_batch_moments(
     system_index: int,
     reference: Optional[TensorMap] = None,
 ) -> Tuple[TensorMap, TensorMap, TensorMap, TensorMap]:
-    """Return signed/absolute centered moments and the fixed reference.
+    """Accumulate centered moments for one batch and one O(3) coset.
 
-    Here ``y = tensor - reference``; the first copy becomes the reference on
-    the first call. The absolute second moment supplies a scale for distinguishing
-    signed-quadrature aliasing from floating-point round-off.
+    Let ``z_i`` be a back-rotated response, choose the fixed reference ``r``,
+    and define ``y_i = z_i - r``. ``weights`` contains normalized SO(3)
+    quadrature weights; each of the two O(3) cosets has half the Haar measure,
+    so this function uses ``q_i = weights_i / 2``. It returns, in order,
+    ``sum_i q_i y_i``, ``sum_i q_i ||y_i||^2``,
+    ``sum_i |q_i| ||y_i||^2``, and ``r``.
+
+    The first map retains the response component axes. The two squared-moment
+    maps sum over these axes and retain only samples and properties. On the
+    first call, the first response becomes ``r``; all later batches and both
+    cosets must reuse the returned reference with the same block and sample
+    layout. The absolute second moment provides the round-off scale used to
+    distinguish cancellation from an under-resolved signed quadrature.
     """
     n_local_systems = weights.numel()
     mean_blocks: List[TensorBlock] = []
@@ -669,7 +692,21 @@ class SymmetrizedModel(torch.nn.Module):
         device: torch.device,
         dtype: torch.dtype,
     ) -> Optional[Dict[int, torch.Tensor]]:
-        """Return full-grid Wigner stacks, or ``None`` when they exceed the cap."""
+        """Return reusable full-grid proper-part Wigner-D stacks within the cap.
+
+        The derived cache retains at most one quadrature/device/dtype state. Its
+        validity key includes the quadrature buffer's storage identity and tensor
+        version, so normal in-place buffer mutations invalidate it; module
+        dtype/device moves clear it, and serialization excludes it. Ranks from
+        zero through ``ell_max`` are published only after the complete build
+        succeeds.
+
+        If the complete allocation would exceed ``wigner_cache_max_bytes``, any
+        stale retained state is released and ``None`` is returned so the caller
+        uses the numerically equivalent per-batch construction. The same
+        proper-part stacks serve both O(3) cosets; their discrete inversion
+        parity is applied separately.
+        """
         # ``torch.device("cuda")`` follows the current device and therefore
         # can denote different physical devices across calls. Resolve it before
         # keying or allocating so such a change replaces, rather than reuses,
@@ -770,9 +807,15 @@ class SymmetrizedModel(torch.nn.Module):
             The derived quantities are always returned under the ``forces`` and
             ``stress`` names, which are reserved in this mode.
         :return: dictionary with symmetrized outputs and equivariance metrics.
-            Statistics are accumulated and returned in float64, independently
-            of the model dtype; the model itself runs in its own dtype, so
-            errors below the round-off of its outputs remain unmeasurable.
+            Standard energy, force, and stress quantities are first decomposed
+            into their named O(3) irreducible blocks; custom outputs retain their
+            names and metadata. For every resulting ``<name>``, the dictionary
+            contains ``<name>_mean``, component-summed ``<name>_var``, and
+            component-summed ``<name>_norm_squared``. With character projections
+            enabled it also contains ``<name>_character_projection``. Statistics
+            are accumulated and returned in float64, independently of the model
+            dtype; the model itself runs in its own dtype, so errors below the
+            round-off of its outputs remain unmeasurable.
         """
         self._validate_no_mps_execution(systems)
 
@@ -969,7 +1012,24 @@ class SymmetrizedModel(torch.nn.Module):
         Dict[str, TensorMap],
         Dict[str, TensorMap],
     ]:
-        """Stream and reduce all rotation batches for one input system."""
+        """Evaluate and reduce the complete finite O(3) orbit of one System.
+
+        For every SO(3) grid batch and each proper/improper coset, this evaluates
+        the direct response ``f(gX)``. Requested outputs are moved to float64
+        storage, back-rotated as ``rho(g^-1) f(gX)``, decomposed into standard
+        irreducible outputs, and accumulated around one fixed reference without
+        retaining the full orbit. Character coefficients, when requested, are
+        accumulated from the direct response rather than the back-rotated one.
+
+        Wigner-D work is sized from the spherical ranks actually present. The
+        full-grid cache is reused when it fits its byte budget; otherwise the
+        same matrices are constructed one batch at a time. Every rotated copy
+        must return identical block metadata and the same non-``system`` sample
+        labels in the same order.
+
+        :return: ``(means, variances, norm_squared, projections)`` dictionaries.
+            Each TensorMap carries the original global ``i_sys`` sample label.
+        """
         references: Dict[str, TensorMap] = {}
         centered_mean_accumulators: Dict[str, TensorMap] = {}
         centered_second_moment_accumulators: Dict[str, TensorMap] = {}

--- a/python/metatomic_torch/metatomic/torch/symmetrized_model/_projections.py
+++ b/python/metatomic_torch/metatomic/torch/symmetrized_model/_projections.py
@@ -16,9 +16,10 @@ from ._utils import (
 
 @dataclass
 class _ProjectionBlock:
-    """Block metadata plus the running quadrature sums of ``D^ell(g) x(g)``
-    (one ``(2 ell + 1, 2 ell + 1, ...)`` tensor per ``ell``) for one block of
-    one output."""
+    """Block metadata plus the running quadrature sums of
+    ``D^ell(R^{-1}) u(sR)`` (one ``(2 ell + 1, 2 ell + 1, ...)`` tensor per
+    ``ell``) for one block of one direct orbit output, where ``R`` is the SO(3)
+    representative and ``s`` selects the proper or improper coset."""
 
     key_names: List[str]
     key_values: torch.Tensor
@@ -37,10 +38,44 @@ _ProjectionAccumulator = Dict[Tuple[int, ...], _ProjectionBlock]
 def _wigner_stacks(
     transformations: List[O3Transformation], ell_max: int
 ) -> Dict[int, torch.Tensor]:
-    """Stack the Wigner-D matrices of a batch of transformations per ell."""
+    """Stack cached Wigner-D matrices without public defensive copies."""
     return {
-        ell: torch.stack([t.wigner_D_matrix(ell) for t in transformations])
+        ell: torch.stack([t._wigner_D_matrix(ell) for t in transformations])
         for ell in range(ell_max + 1)
+    }
+
+
+def _wigner_stacks_from_matrices(
+    matrices: torch.Tensor,
+    ell_max: int,
+    *,
+    is_inverted: bool,
+    output_device: torch.device,
+    output_dtype: torch.dtype,
+) -> Dict[int, torch.Tensor]:
+    """Build one validated Wigner batch on CPU and transfer it in stacks.
+
+    Wigner-D construction is CPU-backed. Recovering Euler angles separately
+    from CUDA matrices would therefore synchronize the device for every
+    rotation and transfer every small matrix separately. Staging the current
+    matrix batch once keeps the same calculation while requiring only one
+    device-to-host transfer per batch and one host-to-device transfer per rank.
+    """
+    calculation_matrices = matrices.detach().to(
+        device=torch.device("cpu"), dtype=output_dtype
+    )
+    transformations = [
+        O3Transformation._from_validated_matrix(
+            matrix,
+            ell_max,
+            is_inverted=is_inverted,
+        )
+        for matrix in calculation_matrices.unbind(0)
+    ]
+    cpu_stacks = _wigner_stacks(transformations, ell_max)
+    return {
+        ell: stack.to(device=output_device, dtype=output_dtype)
+        for ell, stack in cpu_stacks.items()
     }
 
 
@@ -53,9 +88,12 @@ def _compute_batch_projection_contributions(
     """Compute one batch's contribution to the projection coefficients.
 
     For every block and every ``ell`` up to ``max_o3_lambda_character``, this
-    computes the weighted partial quadrature sum ``sum_g w_g D^ell_mn(g) x(g)``
-    over the batch of group elements ``g``, i.e. the Fourier coefficients of
-    the direct (un-back-rotated) output ``x`` seen as a function on the group.
+    computes the weighted partial quadrature sum
+    ``sum_R w_R D^ell_mn(R^{-1}) u(sR)`` over the batch's SO(3)
+    representatives ``R`` for one proper or improper coset ``s``. These are
+    the Fourier coefficients of the direct (un-back-rotated) orbit output
+    ``u`` in the convention used by the public convolution formula; the
+    inversion parity is inserted only when the two cosets are finalized.
     Coefficients have shape ``(2 ell + 1, 2 ell + 1)`` in front of the block's
     sample/component/property axes. Block metadata is carried along so the
     final TensorMap can be rebuilt once all batches are merged.
@@ -106,10 +144,7 @@ def _merge_projection_contributions(
             continue
         existing = accumulator[key_tuple].coefficients
         for ell, tensor in entry.coefficients.items():
-            if ell in existing:
-                existing[ell] = existing[ell] + tensor
-            else:
-                existing[ell] = tensor
+            existing[ell] = existing[ell] + tensor
 
 
 def _accumulate_batch(
@@ -163,14 +198,14 @@ def _finalize_projection_tensor(
 ) -> Optional[TensorMap]:
     """Combine the two coset sums into squared isotypical-projection norms.
 
-    ``positive``/``negative`` hold the quadrature sums of ``D^ell(g) x(g)``
-    over the proper rotations and over the rotations composed with the
-    inversion, respectively. For each ``ell`` and ``sigma``, the O(3) isotypical
-    projection combines them as ``plus + sigma * (-1)^ell * minus``, and its
-    squared norm is ``(2 ell + 1) / 4 * sum_mn combined^2``, one value per
-    sample. Results are packed into a TensorMap keyed by the original block
-    keys extended with ``chi_lambda``/``chi_sigma`` (``None`` if there is
-    nothing to finalize).
+    ``positive``/``negative`` hold the quadrature sums of
+    ``D^ell(R^{-1}) u(R)`` and ``D^ell(R^{-1}) u(-R)``, respectively, with
+    ``R`` in SO(3). For each ``ell`` and ``sigma``, the O(3) isotypical
+    projection inserts the inversion parity and combines them as
+    ``plus + sigma * (-1)^ell * minus``, and its squared norm is
+    ``(2 ell + 1) / 4 * sum_mn combined^2``, one value per sample. Results are
+    packed into a TensorMap keyed by the original block keys extended with
+    ``chi_lambda``/``chi_sigma`` (``None`` if there is nothing to finalize).
     """
     all_keys = list(positive.keys())
     for key in negative.keys():
@@ -259,9 +294,15 @@ def per_system_character_fractions(
     For each system and each ``(chi_lambda, chi_sigma)`` key, the projection is
     summed over all samples, components and properties belonging to the system,
     and normalized by the per-system total squared norm (from the
-    ``<name>_norm_squared`` entry). For an output lying entirely within the
-    resolved sectors, the fractions sum to 1 over all
-    ``(chi_lambda, chi_sigma)``.
+    ``<name>_norm_squared`` entry). Fractions sum to 1 only when the response is
+    resolved by the grid and lies entirely within the included character
+    sectors.
+
+    Negative or non-finite squared norms and sector weights are rejected rather
+    than repaired: they indicate inconsistent input or an unresolved finite
+    quadrature. A zero total norm has no mathematical fractions; this helper
+    returns all-zero fractions when every sector weight is also zero, and rejects
+    a nonzero sector weight paired with a zero norm.
 
     :param outputs: dictionary returned by :py:class:`SymmetrizedModel` with
         ``compute_character_projections=True``
@@ -271,7 +312,7 @@ def per_system_character_fractions(
         (default), inferred from the largest ``system`` sample index; trailing
         systems that contributed no samples are then silently missing from the
         result, so pass it explicitly whenever systems can be empty.
-    :return: ``(proper, improper, lambdas)`` where ``proper`` and ``improper``
+    :return: ``(sigma_plus, sigma_minus, lambdas)`` where the first two tensors
         have shape ``(n_systems, n_lambda)`` and hold the fractions for
         ``chi_sigma = +1`` and ``chi_sigma = -1`` respectively, and ``lambdas``
         holds the sorted ``chi_lambda`` values
@@ -287,21 +328,37 @@ def per_system_character_fractions(
 
     norm = torch.zeros(n_systems, dtype=dtype, device=device)
     for block in norm_squared.blocks():
+        if bool(torch.any((~torch.isfinite(block.values)) | (block.values < 0)).item()):
+            raise ValueError("squared norm must be finite and non-negative")
         system = block.samples.column("system").to(dtype=torch.long, device=device)
-        per_sample = block.values.reshape(block.values.shape[0], -1).sum(dim=1)
+        per_sample = torch.flatten(block.values, start_dim=1).sum(dim=1)
         norm.index_add_(0, system, per_sample.to(dtype=dtype, device=device))
-    norm = torch.clamp(torch.abs(norm), min=torch.finfo(dtype).tiny)
+    if bool(torch.any((~torch.isfinite(norm)) | (norm < 0)).item()):
+        raise ValueError("squared norm must be finite and non-negative")
 
     lambdas = torch.unique(character_projection.keys.column("chi_lambda"))
     lambda_to_index = {int(ell.item()): i for i, ell in enumerate(lambdas)}
 
-    proper = torch.zeros(n_systems, len(lambdas), dtype=dtype, device=device)
-    improper = torch.zeros(n_systems, len(lambdas), dtype=dtype, device=device)
+    sigma_plus = torch.zeros(n_systems, len(lambdas), dtype=dtype, device=device)
+    sigma_minus = torch.zeros(n_systems, len(lambdas), dtype=dtype, device=device)
     for key, block in character_projection.items():
-        target = proper if int(key["chi_sigma"]) == 1 else improper
+        if bool(torch.any((~torch.isfinite(block.values)) | (block.values < 0)).item()):
+            raise ValueError(
+                "character-projection weights must be finite and non-negative"
+            )
+        target = sigma_plus if int(key["chi_sigma"]) == 1 else sigma_minus
         column = lambda_to_index[int(key["chi_lambda"])]
         system = block.samples.column("system").to(dtype=torch.long, device=device)
-        per_sample = torch.abs(block.values).reshape(block.values.shape[0], -1)
+        per_sample = torch.flatten(block.values, start_dim=1)
         target[:, column].index_add_(0, system, per_sample.sum(dim=1))
 
-    return proper / norm.unsqueeze(1), improper / norm.unsqueeze(1), lambdas
+    sector_total = sigma_plus.sum(dim=1) + sigma_minus.sum(dim=1)
+    zero_norm = norm == 0
+    if bool(torch.any(zero_norm & (sector_total != 0)).item()):
+        raise ValueError("zero squared norm is inconsistent with nonzero sector weight")
+    denominator = torch.where(zero_norm, torch.ones_like(norm), norm)
+    return (
+        sigma_plus / denominator.unsqueeze(1),
+        sigma_minus / denominator.unsqueeze(1),
+        lambdas,
+    )

--- a/python/metatomic_torch/metatomic/torch/symmetrized_model/_quadrature.py
+++ b/python/metatomic_torch/metatomic/torch/symmetrized_model/_quadrature.py
@@ -123,14 +123,20 @@ def get_rotation_quadrature(
     Get rotation matrices and weights for a quadrature on SO(3), optionally
     extended to O(3).
 
+    Proper matrices use the active ZYZ convention
+    ``Rz(alpha) @ Ry(beta) @ Rz(gamma)``. The weights are normalized Haar
+    product-rule weights and can be signed for some Lebedev orders. Extending
+    to O(3) appends the complete improper coset ``-R`` and splits each SO(3)
+    weight equally between its proper and improper representatives.
+
     :param lebedev_order: order of the Lebedev quadrature on the unit sphere
     :param n_rotations: positive integer number of in-plane rotations per Lebedev node
     :param include_inversion: if ``True``, extend the quadrature to O(3) by
         appending, for every rotation ``R``, the improper operation ``-R``,
         with halved weights
-    :return: float64 rotations of shape (N, 3, 3) and weights of shape (N,), summing
-        to 1. ``lebedev_order`` must be one of the orders supported by
-        ``scipy.integrate.lebedev_rule``.
+    :return: float64 rotations of shape ``(N, 3, 3)`` and weights of shape
+        ``(N,)``, summing to 1. ``lebedev_order`` must be one of the orders
+        supported by ``scipy.integrate.lebedev_rule``.
     """
     alpha, beta, gamma, weights = get_euler_angles_quadrature(
         lebedev_order, n_rotations

--- a/python/metatomic_torch/metatomic/torch/symmetrized_model/_quadrature.py
+++ b/python/metatomic_torch/metatomic/torch/symmetrized_model/_quadrature.py
@@ -2,6 +2,44 @@ from typing import Tuple
 
 import numpy as np
 
+from ._utils import _validated_integer
+
+
+_LEBEDEV_ORDERS = (
+    3,
+    5,
+    7,
+    9,
+    11,
+    13,
+    15,
+    17,
+    19,
+    21,
+    23,
+    25,
+    27,
+    29,
+    31,
+    35,
+    41,
+    47,
+    53,
+    59,
+    65,
+    71,
+    77,
+    83,
+    89,
+    95,
+    101,
+    107,
+    113,
+    119,
+    125,
+    131,
+)
+
 
 def _import_scipy():
     # deferred: scipy is only needed for quadrature/rotation construction at
@@ -26,47 +64,14 @@ def _choose_quadrature(L_max: int) -> Tuple[int, int]:
     :param L_max: maximum spherical harmonic degree
     :return: (lebedev_order, n_inplane_rotations)
     """
-    available = [
-        3,
-        5,
-        7,
-        9,
-        11,
-        13,
-        15,
-        17,
-        19,
-        21,
-        23,
-        25,
-        27,
-        29,
-        31,
-        35,
-        41,
-        47,
-        53,
-        59,
-        65,
-        71,
-        77,
-        83,
-        89,
-        95,
-        101,
-        107,
-        113,
-        119,
-        125,
-        131,
-    ]
-    if L_max > available[-1]:
+    L_max = _validated_integer("L_max", L_max, 0)
+    if L_max > _LEBEDEV_ORDERS[-1]:
         raise ValueError(
             f"the requested quadrature degree L_max={L_max} exceeds the largest "
-            f"available Lebedev order ({available[-1]})"
+            f"available Lebedev order ({_LEBEDEV_ORDERS[-1]})"
         )
     # pick smallest order >= L_max
-    n = min(o for o in available if o >= L_max)
+    n = min(o for o in _LEBEDEV_ORDERS if o >= L_max)
     # minimal gamma count
     K = L_max + 1
     return n, K
@@ -80,11 +85,19 @@ def get_euler_angles_quadrature(
     rotations for SO(3) integration.
 
     :param lebedev_order: order of the Lebedev quadrature on the unit sphere
-    :param n_rotations: number of in-plane rotations per Lebedev node
+    :param n_rotations: positive integer number of in-plane rotations per Lebedev node
     :return: alpha, beta, gamma, w arrays, each of shape (M*K,), where M is the
         number of Lebedev nodes and K the number of in-plane rotations; entries
         are paired elementwise, one per rotation of the grid.
     """
+
+    lebedev_order = _validated_integer("lebedev_order", lebedev_order, 1)
+    n_rotations = _validated_integer("n_rotations", n_rotations, 1)
+    if lebedev_order not in _LEBEDEV_ORDERS:
+        raise ValueError(
+            f"unsupported Lebedev order {lebedev_order}; supported orders are "
+            f"{list(_LEBEDEV_ORDERS)}"
+        )
 
     lebedev_rule, _ = _import_scipy()
     # Lebedev nodes (X: (3, M))
@@ -111,12 +124,13 @@ def get_rotation_quadrature(
     extended to O(3).
 
     :param lebedev_order: order of the Lebedev quadrature on the unit sphere
-    :param n_rotations: number of in-plane rotations per Lebedev node
+    :param n_rotations: positive integer number of in-plane rotations per Lebedev node
     :param include_inversion: if ``True``, extend the quadrature to O(3) by
         appending, for every rotation ``R``, the improper operation ``-R``,
         with halved weights
-    :return: rotations of shape (N, 3, 3) and weights of shape (N,), summing
-        to 1
+    :return: float64 rotations of shape (N, 3, 3) and weights of shape (N,), summing
+        to 1. ``lebedev_order`` must be one of the orders supported by
+        ``scipy.integrate.lebedev_rule``.
     """
     alpha, beta, gamma, weights = get_euler_angles_quadrature(
         lebedev_order, n_rotations

--- a/python/metatomic_torch/metatomic/torch/symmetrized_model/_utils.py
+++ b/python/metatomic_torch/metatomic/torch/symmetrized_model/_utils.py
@@ -100,7 +100,16 @@ def _selected_atoms_for_local_systems(
 def _reshape_block_by_local_system(
     block: TensorBlock, n_local_systems: int
 ) -> Tuple[torch.Tensor, List[str], torch.Tensor]:
-    """Stack equal per-copy samples along a new leading rotation axis."""
+    """Group equal per-copy samples along a leading local-system axis.
+
+    The block must contain a ``system`` sample column, and every one of the
+    ``n_local_systems`` rotated copies must produce identical non-``system``
+    sample labels in the same order. Input rows may interleave local systems;
+    they are stably grouped before validation.
+
+    :return: values with shape ``(n_local_systems, n_samples, ...)``, sample names
+        without ``system``, and the common non-``system`` sample-label values.
+    """
     sample_names = list(block.samples.names)
     system_column = sample_names.index("system")
     local_ids = block.samples.column("system").to(dtype=torch.long)

--- a/python/metatomic_torch/metatomic/torch/symmetrized_model/_utils.py
+++ b/python/metatomic_torch/metatomic/torch/symmetrized_model/_utils.py
@@ -1,7 +1,27 @@
+import operator
 from typing import List, Optional, Tuple
 
+import numpy as np
 import torch
 from metatensor.torch import Labels, TensorBlock, TensorMap
+
+
+def _validated_integer(name: str, value, minimum: int) -> int:
+    """Normalize an integer-like public argument and enforce its lower bound."""
+    if isinstance(value, (bool, np.bool_)) or (
+        isinstance(value, torch.Tensor) and value.dtype == torch.bool
+    ):
+        raise TypeError(f"{name} must be an integer, not a boolean")
+    try:
+        normalized = int(operator.index(value))
+    except TypeError as error:
+        raise TypeError(
+            f"{name} must be an integer, got {type(value).__name__}"
+        ) from error
+    if normalized < minimum:
+        qualifier = "positive" if minimum == 1 else "non-negative"
+        raise ValueError(f"{name} must be {qualifier}, got {normalized}")
+    return normalized
 
 
 def _key_to_tuple(key_entry) -> Tuple[int, ...]:
@@ -20,9 +40,7 @@ def _infer_n_systems(tensors: List[TensorMap]) -> int:
 
 
 def _max_spherical_lambda(tensor: TensorMap) -> int:
-    """Largest angular momentum among the ``o3_mu``-like component axes of the
-    tensor's blocks (each axis has length ``2*lambda + 1``), or ``-1`` if no
-    block has spherical components."""
+    """Largest rank of any ``o3_mu``-like axis, or ``-1`` when absent."""
     max_lambda = -1
     for block in tensor.blocks():
         for component in block.components:
@@ -38,23 +56,19 @@ def _prepend_system_to_samples(
     *,
     device: torch.device,
 ) -> Labels:
-    """Rebuild sample Labels with a leading ``system`` column.
-
-    After reducing over the rotated copies of one system, the remaining samples
-    no longer carry a system index; this re-attaches the index of the original
-    system in the caller's list, so per-system results can be joined.
-    """
+    """Reattach the original ``system`` index after rotation-batch reduction."""
     system_values = torch.full(
-        (sample_values.shape[0],),
+        (sample_values.shape[0], 1),
         system_index,
-        dtype=torch.int32,
+        dtype=sample_values.dtype,
         device=device,
     )
     if len(sample_names) == 0:
-        return Labels(["system"], system_values.unsqueeze(1))
-
-    samples = Labels(sample_names, sample_values.to(device=device, dtype=torch.int32))
-    return samples.insert(0, "system", system_values)
+        return Labels(["system"], system_values)
+    return Labels(
+        ["system"] + sample_names,
+        torch.cat([system_values, sample_values.to(device=device)], dim=1),
+    )
 
 
 def _selected_atoms_for_local_systems(
@@ -62,13 +76,7 @@ def _selected_atoms_for_local_systems(
     system_index: int,
     n_local_systems: int,
 ) -> Optional[Labels]:
-    """Map a global atom selection onto one system's batch of rotated copies.
-
-    ``selected_atoms`` uses the caller's global system indices, but the base
-    model is evaluated on ``n_local_systems`` rotated copies of the system at
-    ``system_index``: the selection for that system is replicated once per
-    copy, with the ``system`` column rewritten to the local copy index.
-    """
+    """Replicate one global system's atom selection over its rotated copies."""
     if selected_atoms is None:
         return None
 
@@ -80,55 +88,76 @@ def _selected_atoms_for_local_systems(
             selected_atoms.values.new_empty((0, len(selected_atoms.names))),
         )
 
-    system_column = list(selected_atoms.names).index("system")
-    local_selected_atoms: List[torch.Tensor] = []
-    for local_system_index in range(n_local_systems):
-        local_values = system_selected_atoms.clone()
-        local_values[:, system_column] = local_system_index
-        local_selected_atoms.append(local_values)
-
-    return Labels(
-        list(selected_atoms.names),
-        torch.cat(local_selected_atoms, dim=0),
-    )
+    local_values = system_selected_atoms.repeat((n_local_systems, 1))
+    local_values[:, list(selected_atoms.names).index("system")] = torch.arange(
+        n_local_systems,
+        dtype=local_values.dtype,
+        device=local_values.device,
+    ).repeat_interleave(len(system_selected_atoms))
+    return Labels(list(selected_atoms.names), local_values)
 
 
 def _reshape_block_by_local_system(
     block: TensorBlock, n_local_systems: int
 ) -> Tuple[torch.Tensor, List[str], torch.Tensor]:
-    """Split a block over batched rotated copies into a stacked per-copy tensor.
-
-    Returns ``(values, sample_names, sample_values)``: ``values`` gains a
-    leading axis of size ``n_local_systems`` (one entry per rotated copy), and
-    ``sample_names``/``sample_values`` describe the per-copy samples shared by
-    all copies, with the leading ``system`` column removed. Every copy must
-    produce identical sample labels in the same order for the stacking (and
-    any later reduction over the new axis) to be meaningful.
-    """
+    """Stack equal per-copy samples along a new leading rotation axis."""
+    sample_names = list(block.samples.names)
+    system_column = sample_names.index("system")
     local_ids = block.samples.column("system").to(dtype=torch.long)
-    if len(local_ids) != 0:
-        min_local_id = int(torch.min(local_ids).item())
-        max_local_id = int(torch.max(local_ids).item())
-        if min_local_id < 0 or max_local_id >= n_local_systems:
-            raise ValueError(
-                "Encountered output samples with out-of-range system indices."
-            )
+    non_system_sample_values = torch.cat(
+        [
+            block.samples.values[:, :system_column],
+            block.samples.values[:, system_column + 1 :],
+        ],
+        dim=1,
+    )
+    if len(local_ids) != 0 and bool(
+        torch.any((local_ids < 0) | (local_ids >= n_local_systems)).item()
+    ):
+        raise ValueError("Encountered output samples with out-of-range system indices.")
 
-    split_values: List[torch.Tensor] = []
-    base_sample_values: Optional[torch.Tensor] = None
-    for local_system_index in range(n_local_systems):
-        local_mask = local_ids == local_system_index
-        local_values = block.values[local_mask]
-        local_sample_values = block.samples.values[local_mask][:, 1:]
-        if base_sample_values is None:
-            base_sample_values = local_sample_values
-        elif not torch.equal(local_sample_values, base_sample_values):
-            raise ValueError(
-                "Streaming SymmetrizedModel expects each rotated copy of a system to "
-                "produce the same sample labels in the same order."
-            )
-        split_values.append(local_values)
+    # Avoid sorting the overwhelmingly common scalar batch-size-one case.
+    if n_local_systems == 1:
+        return (
+            block.values.unsqueeze(0),
+            sample_names[:system_column] + sample_names[system_column + 1 :],
+            non_system_sample_values,
+        )
 
-    assert base_sample_values is not None
-    stacked_values = torch.stack(split_values, dim=0)
-    return stacked_values, list(block.samples.names[1:]), base_sample_values
+    if len(local_ids) % n_local_systems != 0:
+        raise ValueError(
+            "Streaming SymmetrizedModel expects each rotated copy of a system to "
+            "produce the same sample labels in the same order."
+        )
+    n_samples = len(local_ids) // n_local_systems
+    order = torch.argsort(local_ids, stable=True)
+    expected_ids = torch.arange(
+        n_local_systems, dtype=local_ids.dtype, device=local_ids.device
+    ).repeat_interleave(n_samples)
+    if not torch.equal(local_ids[order], expected_ids):
+        raise ValueError(
+            "Streaming SymmetrizedModel expects each rotated copy of a system to "
+            "produce the same sample labels in the same order."
+        )
+
+    stacked_values = block.values[order].reshape(
+        n_local_systems, n_samples, *block.values.shape[1:]
+    )
+    stacked_sample_values = non_system_sample_values[order].reshape(
+        n_local_systems, n_samples, non_system_sample_values.shape[1]
+    )
+    base_sample_values = stacked_sample_values[0]
+    if not torch.equal(
+        stacked_sample_values,
+        base_sample_values.unsqueeze(0).expand_as(stacked_sample_values),
+    ):
+        raise ValueError(
+            "Streaming SymmetrizedModel expects each rotated copy of a system to "
+            "produce the same sample labels in the same order."
+        )
+
+    return (
+        stacked_values,
+        sample_names[:system_column] + sample_names[system_column + 1 :],
+        base_sample_values,
+    )

--- a/python/metatomic_torch/setup.py
+++ b/python/metatomic_torch/setup.py
@@ -320,7 +320,7 @@ if __name__ == "__main__":
         f"torch {torch_version}",
         "metatensor-torch >=0.10.0,<0.11",
         "metatensor-operations >=0.5.0,<0.6",
-        "wigners",
+        "wigners >=0.4.0",
     ]
 
     # when packaging a sdist for release, we should never use local dependencies

--- a/python/metatomic_torch/tests/o3.py
+++ b/python/metatomic_torch/tests/o3.py
@@ -8,12 +8,19 @@ from metatensor.torch import Labels, TensorBlock, TensorMap
 from metatomic.torch import (
     NeighborListOptions,
     System,
+    register_autograd_neighbors,
 )
 from metatomic.torch.o3 import (
     O3Transformation,
     random_transformations,
+    transform_block,
     transform_system,
     transform_tensor,
+)
+from metatomic.torch.o3._wigner import (
+    _complex_to_real_spherical_harmonics_transform,
+    _compute_real_wigner_d_matrices,
+    build_wigner_D_cache,
 )
 
 from ._tests_utils import can_use_mps_backend
@@ -54,6 +61,19 @@ def _make_system(
         positions=positions,
         cell=cell,
         pbc=pbc,
+    )
+
+
+def _tensor_map(values, samples, components, *, keys=None, properties=None):
+    """Single-block TensorMap factory for transformation tests."""
+    device = values.device
+    if keys is None:
+        keys = Labels(["_"], torch.tensor([[0]], device=device))
+    if properties is None:
+        properties = Labels(["p"], torch.tensor([[0]], device=device))
+    return TensorMap(
+        keys,
+        [TensorBlock(values, samples, components, properties)],
     )
 
 
@@ -116,6 +136,8 @@ def test_transform_system(device, dtype):
             ),
         ],
     )
+    scalar.set_info("unit", "eV")
+    scalar.set_info("custom", "preserved by rotation")
 
     # xyz vector per-atom data: must rotate by R on the component axis
     vector_values = torch.tensor(
@@ -139,16 +161,7 @@ def test_transform_system(device, dtype):
     system.add_data("custom::scalar", scalar)
     system.add_data("custom::vector", vector)
 
-    # Apply a transformation to it
-    matrix = torch.tensor(
-        [
-            [np.cos(np.pi / 3), -np.sin(np.pi / 3), 0.0],
-            [np.sin(np.pi / 3), np.cos(np.pi / 3), 0.0],
-            [0.0, 0.0, 1.0],
-        ],
-        dtype=dtype,
-        device=device,
-    )
+    matrix = _zyz_matrix(np.pi / 3, 0.0, 0.0, dtype).to(device=device)
     transformation = O3Transformation(matrix, max_angular_momentum=0)
 
     rotated = transform_system(system, transformation)
@@ -165,6 +178,7 @@ def test_transform_system(device, dtype):
     assert torch.allclose(new_neighbors, expected, atol=atol)
 
     new_scalar = rotated.get_data("custom::scalar")
+    assert new_scalar.info() == scalar.info()
     for block_id in range(len(scalar.keys)):
         assert torch.allclose(
             new_scalar.block_by_id(block_id).values,
@@ -174,6 +188,41 @@ def test_transform_system(device, dtype):
     new_vector = rotated.get_data("custom::vector").block().values
     expected_vector = (vector_values.squeeze(-1) @ matrix.T).unsqueeze(-1)
     assert torch.allclose(new_vector, expected_vector, atol=atol)
+
+
+def test_transform_system_reregisters_autograd_neighbors():
+    positions = torch.tensor(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
+        dtype=torch.float64,
+        requires_grad=True,
+    )
+    system = _make_system([1, 1], positions=positions)
+    options = NeighborListOptions(cutoff=2.0, full_list=True, strict=False)
+    neighbors = TensorBlock(
+        values=torch.tensor([[[1.0], [0.0], [0.0]]], dtype=torch.float64),
+        samples=Labels(
+            [
+                "first_atom",
+                "second_atom",
+                "cell_shift_a",
+                "cell_shift_b",
+                "cell_shift_c",
+            ],
+            torch.tensor([[0, 1, 0, 0, 0]]),
+        ),
+        components=[Labels.range("xyz", 3)],
+        properties=Labels.range("distance", 1),
+    )
+    register_autograd_neighbors(system, neighbors)
+    system.add_neighbor_list(options, neighbors)
+
+    rotation = _zyz_matrix(np.pi / 3, np.pi / 4, 0.0, torch.float64)
+    rotated = transform_system(system, O3Transformation(rotation, 0))
+    loss = torch.sum(rotated.get_neighbor_list(options).values ** 2)
+
+    gradient = torch.autograd.grad(loss, positions)[0]
+    expected = torch.tensor([[-2.0, 0.0, 0.0], [2.0, 0.0, 0.0]], dtype=torch.float64)
+    assert torch.allclose(gradient, expected, atol=1e-12)
 
 
 def test_random_rotations_are_orthogonal():
@@ -201,6 +250,95 @@ def test_random_rotations_include_inversions():
     dets = torch.stack([torch.det(T.matrix) for T in transformations])
     assert torch.allclose(dets.abs(), torch.ones(100, dtype=torch.float64), atol=1e-10)
     assert (dets > 0).any() and (dets < 0).any()
+    assert all(
+        T.is_inverted == bool(det < 0)
+        for T, det in zip(transformations, dets, strict=True)
+    )
+
+
+def test_random_transformations_use_trusted_batch_validation(monkeypatch):
+    def unexpected_checked_construction(*args, **kwargs):
+        raise AssertionError("random_transformations repeated per-matrix validation")
+
+    monkeypatch.setattr(O3Transformation, "__init__", unexpected_checked_construction)
+    transformations = random_transformations(
+        8,
+        max_angular_momentum=2,
+        device=torch.device("cpu"),
+        dtype=torch.float64,
+        include_inversions=True,
+        generator=torch.Generator().manual_seed(20260712),
+    )
+    assert len(transformations) == 8
+
+
+def test_public_transformation_constructor_still_validates_matrix():
+    with pytest.raises(ValueError, match="shape"):
+        O3Transformation(torch.eye(2, dtype=torch.float64), 0)
+
+    non_orthogonal = torch.eye(3, dtype=torch.float64)
+    non_orthogonal[0, 0] = 2.0
+    with pytest.raises(ValueError, match="not orthogonal"):
+        O3Transformation(non_orthogonal, 0)
+
+
+@pytest.mark.parametrize(
+    ("value", "error"),
+    [
+        (-1, ValueError),
+        (True, TypeError),
+        (1.5, TypeError),
+    ],
+)
+def test_angular_momentum_limit_validation(value, error):
+    with pytest.raises(error, match="max_angular_momentum"):
+        O3Transformation(torch.eye(3, dtype=torch.float64), value)
+
+    with pytest.raises(error, match="max_angular_momentum"):
+        random_transformations(
+            0,
+            max_angular_momentum=value,
+            device=torch.device("cpu"),
+            dtype=torch.float64,
+        )
+
+
+@pytest.mark.parametrize(
+    ("value", "error"),
+    [
+        (-1, ValueError),
+        (True, TypeError),
+        (1.5, TypeError),
+    ],
+)
+def test_random_transformation_count_validation(value, error):
+    with pytest.raises(error, match="n must"):
+        random_transformations(
+            value,
+            device=torch.device("cpu"),
+            dtype=torch.float64,
+        )
+
+
+@pytest.mark.parametrize("inversion", [1.0, -1.0])
+def test_trusted_transformation_matches_checked_constructor(inversion):
+    matrix = inversion * _zyz_matrix(np.pi / 3, 0.0, 0.0, torch.float64)
+    checked = O3Transformation(matrix, max_angular_momentum=3)
+    trusted = O3Transformation._from_validated_matrix(
+        matrix,
+        max_angular_momentum=3,
+        is_inverted=inversion < 0,
+    )
+
+    assert trusted.is_inverted == checked.is_inverted
+    assert torch.equal(trusted.matrix, checked.matrix)
+    for ell in range(4):
+        assert torch.allclose(
+            trusted.wigner_D_matrix(ell),
+            checked.wigner_D_matrix(ell),
+            atol=1e-14,
+            rtol=1e-14,
+        )
 
 
 def _axis_angle(axis, theta):
@@ -229,6 +367,36 @@ def _axis_angle(axis, theta):
             ],
         ]
     )
+
+
+def _zyz_matrix(alpha, beta, gamma, dtype):
+    """Construct ``Rz(alpha) Ry(beta) Rz(gamma)`` without angle recovery."""
+    ca, sa = np.cos(alpha), np.sin(alpha)
+    cb, sb = np.cos(beta), np.sin(beta)
+    cg, sg = np.cos(gamma), np.sin(gamma)
+    return torch.tensor(
+        [
+            [ca * cb * cg - sa * sg, -ca * cb * sg - sa * cg, ca * sb],
+            [sa * cb * cg + ca * sg, -sa * cb * sg + ca * cg, sa * sb],
+            [-sb * cg, sb * sg, cb],
+        ],
+        dtype=dtype,
+    )
+
+
+def _direct_wigner(ell_max, alpha, beta, gamma, dtype):
+    transforms = {
+        ell: _complex_to_real_spherical_harmonics_transform(ell)
+        for ell in range(ell_max + 1)
+    }
+    return {
+        ell: matrix.to(dtype=dtype)
+        for ell, matrix in _compute_real_wigner_d_matrices(
+            ell_max,
+            (alpha, beta, gamma),
+            transforms,
+        ).items()
+    }
 
 
 # Change of basis from Cartesian (x, y, z) to real ell=1 spherical harmonics, ordered
@@ -272,7 +440,142 @@ def test_general_rotation_L1_wigner_matches_cartesian(matrix):
     transformation = O3Transformation(matrix, max_angular_momentum=1)
 
     expected = CARTESIAN_TO_SPHERICAL_L1 @ proper @ CARTESIAN_TO_SPHERICAL_L1.T
-    assert torch.allclose(transformation._wigner_D_cache[1], expected, atol=1e-12)
+    assert torch.allclose(transformation.wigner_D_matrix(1), expected, atol=1e-12)
+
+
+@pytest.mark.parametrize("dtype", [torch.float64, torch.float32])
+@pytest.mark.parametrize("inverted", [False, True])
+def test_wigner_angle_recovery_random_and_near_poles(dtype, inverted):
+    """Recover generating ZYZ matrices through ell=8 across difficult angles."""
+    ell_max = 8
+    atol = 2.0e-11 if dtype == torch.float64 else 4.0e-5
+    rng = np.random.default_rng(20260711)
+
+    angles = []
+    # Haar-distributed generic rotations exercise the non-degenerate branch.
+    for _ in range(32):
+        alpha = rng.uniform(-np.pi, np.pi)
+        beta = np.arccos(rng.uniform(-1.0, 1.0))
+        gamma = rng.uniform(-np.pi, np.pi)
+        angles.append((alpha, beta, gamma))
+
+    # Exact and near-pole rotations cover both gimbal branches and the stable
+    # atan2 recovery immediately outside them. The scales straddle float32 and
+    # float64 machine precision.
+    distances = [0.0, 1.0e-14, 1.0e-10, 1.0e-8, 1.0e-5, 1.0e-3]
+    for distance in distances:
+        angles.append((0.37, distance, -1.19))
+        angles.append((-0.83, np.pi - distance, 2.11))
+
+    for alpha, beta, gamma in angles:
+        proper = _zyz_matrix(alpha, beta, gamma, dtype)
+        matrix = -proper if inverted else proper
+        recovered = build_wigner_D_cache(
+            ell_max, matrix, device=matrix.device, dtype=dtype
+        )
+        expected = _direct_wigner(ell_max, alpha, beta, gamma, dtype)
+        for ell in range(ell_max + 1):
+            assert torch.allclose(recovered[ell], expected[ell], rtol=0.0, atol=atol), (
+                f"Wigner mismatch for ell={ell}, dtype={dtype}, "
+                f"inverted={inverted}, beta={beta}"
+            )
+
+
+@pytest.mark.parametrize("matrix", [torch.eye(3), -torch.eye(3)])
+@pytest.mark.parametrize("ell", [0, 1])
+@pytest.mark.parametrize("sigma", [1, -1])
+def test_transform_spherical_o3_parity(matrix, ell, sigma):
+    """The public helper follows the same O(3) irrep convention as TensorMaps."""
+    matrix = matrix.to(dtype=torch.float64)
+    transformation = O3Transformation(matrix, max_angular_momentum=ell)
+    values = torch.arange(
+        1,
+        2 * (2 * ell + 1) + 1,
+        dtype=torch.float64,
+    ).reshape(2, 2 * ell + 1)
+
+    parity = 1 if torch.det(matrix) > 0 else sigma * (-1) ** ell
+    expected = values * parity
+
+    assert torch.allclose(
+        transformation.transform_spherical(values, ell, sigma),
+        expected,
+        atol=1e-12,
+    )
+
+
+@pytest.mark.parametrize("inversion", [1.0, -1.0])
+def test_invalid_spherical_parity_is_rejected(inversion):
+    transformation = O3Transformation(
+        inversion * torch.eye(3, dtype=torch.float64), max_angular_momentum=0
+    )
+    with pytest.raises(ValueError, match="sigma must be either -1 or \\+1"):
+        transformation.transform_spherical(
+            torch.ones((1, 1), dtype=torch.float64), ell=0, sigma=2
+        )
+
+    tensor = _tensor_map(
+        torch.ones((1, 1, 1), dtype=torch.float64),
+        Labels(["system"], torch.tensor([[0]], dtype=torch.int64)),
+        [Labels(["o3_mu"], torch.tensor([[0]], dtype=torch.int64))],
+        keys=Labels(
+            ["o3_lambda", "o3_sigma"],
+            torch.tensor([[0, 2]], dtype=torch.int64),
+        ),
+    )
+    with pytest.raises(ValueError, match="sigma must be either -1 or \\+1"):
+        transform_tensor(tensor, [_make_system([1])], [transformation])
+
+
+@pytest.mark.parametrize("ell", [True, 1.0])
+def test_public_wigner_methods_reject_non_integer_ell(ell):
+    transformation = O3Transformation(torch.eye(3, dtype=torch.float64), 1)
+
+    with pytest.raises(TypeError, match="ell must be a non-negative integer"):
+        transformation.wigner_D_matrix(ell)
+    with pytest.raises(TypeError, match="ell must be a non-negative integer"):
+        transformation.transform_spherical(
+            torch.ones((1, 3), dtype=torch.float64), ell=ell, sigma=1
+        )
+
+
+def test_public_wigner_methods_enforce_configured_ell_bound():
+    transformation = O3Transformation(torch.eye(3, dtype=torch.float64), 0)
+
+    with pytest.raises(ValueError, match="ell=1 exceeds max_angular_momentum=0"):
+        transformation.wigner_D_matrix(1)
+    with pytest.raises(ValueError, match="ell=1 exceeds max_angular_momentum=0"):
+        transformation.transform_spherical(
+            torch.ones((1, 3), dtype=torch.float64), ell=1, sigma=1
+        )
+
+
+def test_wigner_cache_is_built_lazily():
+    transformation = O3Transformation(torch.eye(3, dtype=torch.float64), 2)
+    assert transformation._wigner_D_cache is None
+    transformation.transform_cartesian(torch.ones(4, 3, dtype=torch.float64))
+    assert transformation._wigner_D_cache is None
+
+    transformation.wigner_D_matrix(1)
+    cache = transformation._wigner_D_cache
+    assert cache is not None
+    transformation.wigner_D_matrix(2)
+    assert transformation._wigner_D_cache is cache
+
+
+def test_transformation_matrix_is_immutable():
+    source = torch.eye(3, dtype=torch.float64)
+    transformation = O3Transformation(source, max_angular_momentum=1)
+    expected_wigner = transformation.wigner_D_matrix(1).clone()
+
+    source[:] = _zyz_matrix(np.pi / 2, 0.0, 0.0, torch.float64)
+    exposed = transformation.matrix
+    exposed[:] = -torch.eye(3, dtype=torch.float64)
+    transformation.wigner_D_matrix(1).zero_()
+
+    assert torch.equal(transformation.matrix, torch.eye(3, dtype=torch.float64))
+    assert not transformation.is_inverted
+    assert torch.equal(transformation.wigner_D_matrix(1), expected_wigner)
 
 
 @pytest.mark.parametrize("matrix", TRANSFORMATIONS)
@@ -287,40 +590,22 @@ def test_spherical_rotation_matches_cartesian(matrix, device, dtype):
 
     cartesian_vectors = torch.randn(2, 3, 1, dtype=dtype, device=device)
 
-    cartesian = TensorMap(
-        Labels(["_"], torch.tensor([[0]], device=device)),
-        [
-            TensorBlock(
-                values=cartesian_vectors,
-                samples=Labels(
-                    ["system", "atom"],
-                    torch.tensor([[0, 0], [0, 1]], device=device),
-                ),
-                components=[
-                    Labels(["xyz"], torch.arange(3, device=device).reshape(-1, 1))
-                ],
-                properties=Labels(["p"], torch.tensor([[0]], device=device)),
-            )
-        ],
+    samples = Labels(["system", "atom"], torch.tensor([[0, 0], [0, 1]], device=device))
+    cartesian = _tensor_map(
+        cartesian_vectors,
+        samples,
+        [Labels(["xyz"], torch.arange(3, device=device).reshape(-1, 1))],
     )
     # spherical encoding: w = C @ v along the component axis
     cart_to_sph = CARTESIAN_TO_SPHERICAL_L1.to(device=device, dtype=dtype)
-    spherical_values = torch.einsum("Aa,iap->iAp", cart_to_sph, cartesian_vectors)
-    spherical = TensorMap(
-        Labels(["o3_lambda", "o3_sigma"], torch.tensor([[1, 1]], device=device)),
-        [
-            TensorBlock(
-                values=spherical_values,
-                samples=Labels(
-                    ["system", "atom"],
-                    torch.tensor([[0, 0], [0, 1]], device=device),
-                ),
-                components=[
-                    Labels(["o3_mu"], torch.arange(-1, 2, device=device).reshape(-1, 1))
-                ],
-                properties=Labels(["p"], torch.tensor([[0]], device=device)),
-            )
-        ],
+    spherical_values = torch.einsum(
+        "Aa,iap->iAp", cart_to_sph, cartesian_vectors
+    ).requires_grad_()
+    spherical = _tensor_map(
+        spherical_values,
+        samples,
+        [Labels(["o3_mu"], torch.arange(-1, 2, device=device).reshape(-1, 1))],
+        keys=Labels(["o3_lambda", "o3_sigma"], torch.tensor([[1, 1]], device=device)),
     )
 
     transformation = O3Transformation(matrix, max_angular_momentum=1)
@@ -335,6 +620,10 @@ def test_spherical_rotation_matches_cartesian(matrix, device, dtype):
     assert torch.allclose(
         spherical_transformed.block().values, expected_spherical, atol=atol
     )
+    gradient = torch.autograd.grad(
+        spherical_transformed.block().values.square().sum(), spherical_values
+    )[0]
+    assert torch.allclose(gradient, 2.0 * spherical_values, atol=atol)
 
 
 def test_gradients_are_rotated():
@@ -418,16 +707,10 @@ def test_gradients_are_rotated():
 def test_unsupported_component_axis_raises():
     """Unknown component-axis names fail loudly."""
     systems = [_make_system([1])]
-    tensor = TensorMap(
-        Labels(["_"], torch.tensor([[0]])),
-        [
-            TensorBlock(
-                values=torch.zeros(1, 3, 1, dtype=torch.float64),
-                samples=Labels(["system"], torch.tensor([[0]])),
-                components=[Labels(["direction"], torch.arange(3).reshape(-1, 1))],
-                properties=Labels(["p"], torch.tensor([[0]])),
-            )
-        ],
+    tensor = _tensor_map(
+        torch.zeros(1, 3, 1, dtype=torch.float64),
+        Labels(["system"], torch.tensor([[0]])),
+        [Labels(["direction"], torch.arange(3).reshape(-1, 1))],
     )
 
     message = (
@@ -441,83 +724,274 @@ def test_unsupported_component_axis_raises():
         )
 
 
-def test_system_ids_explicit_match():
-    """Explicit ``system_ids`` correctly routes rows with non-contiguous labels."""
+_EMPTY_SCHEMA_CASES = [
+    pytest.param("o3_mu", [0], (0, 2), "sigma must", id="parity"),
+    pytest.param("direction", range(3), None, "component axis 'direction'", id="axis"),
+    pytest.param(
+        "xyz", range(2), None, "axis 'xyz' must contain 3", id="cartesian-size"
+    ),
+    pytest.param("o3_mu", [-1, 0], (1, 1), "ell=1 must contain 3", id="spherical-size"),
+    pytest.param(
+        "xyz", [2, 0, 1], None, "axis 'xyz' must use labels", id="cartesian-order"
+    ),
+    pytest.param(
+        "o3_mu", [1, -1, 0], (1, 1), "ell=1 must use labels", id="spherical-order"
+    ),
+]
+
+
+@pytest.mark.parametrize("location", ["values", "gradient"])
+@pytest.mark.parametrize(
+    ("component_name", "component_values", "irrep", "message"),
+    _EMPTY_SCHEMA_CASES,
+)
+def test_empty_blocks_still_validate_component_schema(
+    location, component_name, component_values, irrep, message
+):
+    """Selected-atom outputs must not bypass representation validation."""
+    components = [
+        Labels(
+            [component_name],
+            torch.as_tensor(component_values, dtype=torch.int64).reshape(-1, 1),
+        )
+    ]
+    if irrep is None:
+        keys = Labels(["_"], torch.tensor([[0]], dtype=torch.int64))
+    else:
+        keys = Labels(
+            ["o3_lambda", "o3_sigma"], torch.tensor([irrep], dtype=torch.int64)
+        )
+
+    component_size = len(components[0])
+    if location == "values":
+        tensor = _tensor_map(
+            torch.empty((0, component_size, 1), dtype=torch.float64),
+            Labels(["system"], torch.empty((0, 1), dtype=torch.int64)),
+            components,
+            keys=keys,
+        )
+    else:
+        block = TensorBlock(
+            values=torch.ones((1, 1), dtype=torch.float64),
+            samples=Labels(["system"], torch.tensor([[0]], dtype=torch.int64)),
+            components=[],
+            properties=Labels(["p"], torch.tensor([[0]], dtype=torch.int64)),
+        )
+        block.add_gradient(
+            "positions",
+            TensorBlock(
+                values=torch.empty((0, component_size, 1), dtype=torch.float64),
+                samples=Labels(
+                    ["sample", "atom"], torch.empty((0, 2), dtype=torch.int64)
+                ),
+                components=components,
+                properties=block.properties,
+            ),
+        )
+        tensor = TensorMap(keys, [block])
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        transform_tensor(
+            tensor,
+            [_make_system([1])],
+            [O3Transformation(torch.eye(3, dtype=torch.float64), 0)],
+        )
+
+
+def test_empty_blocks_enforce_component_axis_limit():
+    components = [
+        Labels([f"xyz{suffix}"], torch.arange(3).reshape(-1, 1))
+        for suffix in [""] + [f"_{index}" for index in range(1, 10)]
+    ]
+    components.append(Labels(["o3_mu"], torch.tensor([[0]])))
+    tensor = _tensor_map(
+        torch.empty([0] + [3] * 10 + [1, 1], dtype=torch.float64),
+        Labels(["system"], torch.empty((0, 1), dtype=torch.int64)),
+        components,
+        keys=Labels(
+            ["o3_lambda", "o3_sigma"], torch.tensor([[0, 1]], dtype=torch.int64)
+        ),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="can not transform a tensor with 11 component axes; at most 10",
+    ):
+        transform_tensor(
+            tensor,
+            [_make_system([1])],
+            [O3Transformation(torch.eye(3, dtype=torch.float64), 0)],
+        )
+
+
+def _system_ids_test_case(sample_system_ids=(92, -7)):
     systems = [_make_system([1, 8]), _make_system([1, 8])]
 
     R0 = O3Transformation(torch.eye(3, dtype=torch.float64), 1)
-    # 90-degree rotation around z: (x,y) -> (-y, x)
-    c, s = np.cos(np.pi / 2), np.sin(np.pi / 2)
-    R1 = O3Transformation(
-        torch.tensor([[c, -s, 0], [s, c, 0], [0, 0, 1]], dtype=torch.float64), 1
-    )
+    R1 = O3Transformation(_zyz_matrix(np.pi / 2, 0, 0, torch.float64).round(), 1)
 
-    # row 0 (label 92) -> R0 (identity): unchanged
-    # row 1 (label 38) -> R1 (z-90): (0,2,0) -> (-2,0,0)
     vector_values = torch.tensor(
         [[[1.0], [0.0], [0.0]], [[0.0], [2.0], [0.0]]],
         dtype=torch.float64,
+    )[: len(sample_system_ids)]
+    tensor = _tensor_map(
+        vector_values.clone(),
+        Labels(
+            ["system", "atom"],
+            torch.tensor(
+                [[system_id, atom] for atom, system_id in enumerate(sample_system_ids)]
+            ),
+        ),
+        [Labels(["xyz"], torch.arange(3).reshape(-1, 1))],
     )
-    tensor = TensorMap(
-        Labels(["_"], torch.tensor([[0]])),
-        [
-            TensorBlock(
-                values=vector_values.clone(),
-                samples=Labels(
-                    ["system", "atom"],
-                    torch.tensor([[92, 0], [38, 0]]),
-                ),
-                components=[Labels(["xyz"], torch.arange(3).reshape(-1, 1))],
-                properties=Labels(["p"], torch.tensor([[0]])),
-            )
-        ],
+    return tensor, systems, [R0, R1], vector_values
+
+
+def _transform_system_ids_case(api, tensor, systems, transformations, system_ids):
+    if api == "tensor":
+        return transform_tensor(
+            tensor,
+            systems,
+            transformations,
+            system_ids=system_ids,
+        ).block()
+    return transform_block(
+        tensor.keys[0],
+        tensor.block(),
+        systems,
+        transformations,
+        system_ids=system_ids,
     )
 
-    transformed = transform_tensor(tensor, systems, [R0, R1], system_ids=[92, 38])
-    result = transformed.block().values
+
+_CARDINALITY_ERROR = "exactly one entry per system"
+_DIMENSION_ERROR = "system_ids must be one-dimensional"
+_INTEGER_ERROR = "system_ids must contain integers"
+
+
+@pytest.mark.parametrize("api", ["tensor", "block"])
+@pytest.mark.parametrize(
+    "system_ids",
+    [
+        pytest.param([92, -7], id="python-list"),
+        pytest.param(torch.tensor([92, -7]), id="tensor"),
+    ],
+)
+def test_system_ids_explicit_match(api, system_ids):
+    """Arbitrary, unsorted IDs preserve their positional system mapping."""
+    tensor, systems, transformations, vector_values = _system_ids_test_case()
+
+    result = _transform_system_ids_case(
+        api, tensor, systems, transformations, system_ids
+    ).values
     # row 0 (system 92) rotated by R0 (identity)
-    assert torch.allclose(result[0], vector_values[0])
-    # row 1 (system 38) rotated by R1 (z-90)
-    expected = torch.tensor([[[-2.0], [0.0], [0.0]]], dtype=torch.float64)
-    assert torch.allclose(result[1], expected)
+    assert torch.equal(result[0], vector_values[0])
+    # row 1 (system -7) rotated by R1 (z-90)
+    expected = torch.tensor([[-2.0], [0.0], [0.0]], dtype=torch.float64)
+    assert torch.equal(result[1], expected)
 
 
-def test_system_ids_uncovered_samples_raises():
+@pytest.mark.parametrize("api", ["tensor", "block"])
+def test_system_ids_can_be_absent_from_a_block(api):
+    """A system may legitimately contribute no samples to an individual block."""
+    tensor, systems, transformations, vector_values = _system_ids_test_case((92,))
+    result = _transform_system_ids_case(
+        api, tensor, systems, transformations, [92, 2**40]
+    ).values
+    assert torch.equal(result, vector_values)
+
+
+@pytest.mark.parametrize("api", ["tensor", "block"])
+@pytest.mark.parametrize(
+    "system_ids,message",
+    [
+        pytest.param([92], _CARDINALITY_ERROR, id="too-few"),
+        pytest.param([92, 92], "one distinct entry per system", id="duplicate"),
+        pytest.param(torch.tensor([[92, -7]]), _DIMENSION_ERROR, id="row-tensor"),
+        pytest.param(torch.tensor([92.0, -7.0]), _INTEGER_ERROR, id="float-tensor"),
+        pytest.param([92.0, -7.0], _INTEGER_ERROR, id="float-list"),
+        pytest.param([True, False], _INTEGER_ERROR, id="boolean-list"),
+    ],
+)
+def test_system_ids_invalid_raises(api, system_ids, message):
+    tensor, systems, transformations, _ = _system_ids_test_case()
+    with pytest.raises(ValueError, match=message):
+        _transform_system_ids_case(api, tensor, systems, transformations, system_ids)
+
+
+@pytest.mark.parametrize("api", ["tensor", "block"])
+def test_system_and_transformation_count_must_match(api):
+    tensor, systems, transformations, _ = _system_ids_test_case()
+    with pytest.raises(ValueError, match="Expected one transformation per system"):
+        _transform_system_ids_case(
+            api,
+            tensor,
+            systems,
+            transformations[:1],
+            [92, -7],
+        )
+
+
+@pytest.mark.parametrize("api", ["tensor", "block"])
+def test_every_transformation_must_match_values(api):
+    """A mismatch after the first transformation is rejected before routing."""
+    tensor, systems, transformations, _ = _system_ids_test_case()
+    transformations[1] = O3Transformation(torch.eye(3, dtype=torch.float32), 1)
+
+    with pytest.raises(ValueError, match="Transformation at index 1 has dtype/device"):
+        _transform_system_ids_case(api, tensor, systems, transformations, [92, -7])
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+@pytest.mark.parametrize("api", ["tensor", "block"])
+def test_cpu_system_ids_reject_for_cuda_values(api):
+    tensor, systems, transformations, _ = _system_ids_test_case()
+    device = torch.device("cuda")
+    tensor = tensor.to(device=device)
+    systems = [system.to(device=device) for system in systems]
+    transformations = [
+        O3Transformation(transformation.matrix.to(device=device), 1)
+        for transformation in transformations
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match="system_ids are on device cpu, but the values to transform are on device",
+    ):
+        _transform_system_ids_case(
+            api,
+            tensor,
+            systems,
+            transformations,
+            torch.tensor([92, -7]),
+        )
+
+
+@pytest.mark.parametrize(
+    "kwargs,missing_ids",
+    [
+        pytest.param({"system_ids": [99, 100]}, [99, 100], id="explicit"),
+        pytest.param({}, [0, 1], id="default"),
+    ],
+)
+def test_system_ids_uncovered_samples_raises(kwargs, missing_ids):
     """All distinct system indices in samples must appear in ``system_ids``."""
     systems = [_make_system([1, 8]), _make_system([1, 8])]
     R = O3Transformation(torch.eye(3, dtype=torch.float64), 1)
 
-    tensor = TensorMap(
-        Labels(["_"], torch.tensor([[0]])),
-        [
-            TensorBlock(
-                values=torch.zeros(2, 3, 1, dtype=torch.float64),
-                samples=Labels(
-                    ["system", "atom"],
-                    torch.tensor([[92, 0], [38, 0]]),
-                ),
-                components=[Labels(["xyz"], torch.arange(3).reshape(-1, 1))],
-                properties=Labels(["p"], torch.tensor([[0]])),
-            )
-        ],
+    tensor = _tensor_map(
+        torch.zeros(2, 3, 1, dtype=torch.float64),
+        Labels(["system", "atom"], torch.tensor([[92, 0], [38, 0]])),
+        [Labels(["xyz"], torch.arange(3).reshape(-1, 1))],
     )
 
     message = (
         "Block samples contain system labels [38, 92] that are not in "
-        "system_ids=[99, 100]. Every sample must be assigned to a system "
+        f"system_ids={missing_ids}. Every sample must be assigned to a system "
         "in the transformation."
     )
     with pytest.raises(ValueError, match=re.escape(message)):
-        transform_tensor(tensor, systems, [R, R], system_ids=[99, 100])
-
-    message = (
-        "Block samples contain system labels [38, 92] that are not in "
-        "system_ids=[0, 1]. Every sample must be assigned to a system "
-        "in the transformation."
-    )
-    with pytest.raises(ValueError, match=re.escape(message)):
-        # default system_ids=[0, 1] also misses labels 92 and 38
-        transform_tensor(tensor, systems, [R, R])
+        transform_tensor(tensor, systems, [R, R], **kwargs)
 
 
 def test_system_ids_single_system_ignores_label():
@@ -525,16 +999,10 @@ def test_system_ids_single_system_ignores_label():
     systems = [_make_system([1])]
     values = torch.tensor([[[1.0], [2.0], [3.0]]], dtype=torch.float64)
 
-    tensor = TensorMap(
-        Labels(["_"], torch.tensor([[0]])),
-        [
-            TensorBlock(
-                values=values.clone(),
-                samples=Labels(["system", "atom"], torch.tensor([[4, 0]])),
-                components=[Labels(["xyz"], torch.arange(3).reshape(-1, 1))],
-                properties=Labels(["p"], torch.tensor([[0]])),
-            )
-        ],
+    tensor = _tensor_map(
+        values.clone(),
+        Labels(["system", "atom"], torch.tensor([[4, 0]])),
+        [Labels(["xyz"], torch.arange(3).reshape(-1, 1))],
     )
 
     transformation = O3Transformation(torch.eye(3, dtype=torch.float64), 1)
@@ -542,23 +1010,21 @@ def test_system_ids_single_system_ignores_label():
     assert torch.allclose(transformed.block().values, values)
 
 
-def _z_rotation(alpha):
-    return torch.tensor(
-        [
-            [np.cos(alpha), -np.sin(alpha), 0.0],
-            [np.sin(alpha), np.cos(alpha), 0.0],
-            [0.0, 0.0, 1.0],
-        ],
-        dtype=torch.float64,
-    )
-
-
-def test_rank2_transform_with_missing_system_rows():
-    """Rank-2 (``o3_mu_1``/``o3_mu_2``) blocks rotate correctly when one of the
-    systems contributes no rows at all."""
+@pytest.mark.parametrize("inverted", [False, True])
+@pytest.mark.parametrize("sigma_2", [1, -1])
+def test_rank2_transform_with_missing_system_rows(inverted, sigma_2):
+    """Rank-2 blocks combine per-axis parity even with missing system rows."""
     systems = [_make_system([1, 1]), _make_system([8, 8])]
-    T0 = O3Transformation(_z_rotation(np.pi / 2), max_angular_momentum=1)
-    T1 = O3Transformation(_z_rotation(np.pi), max_angular_momentum=1)
+    matrix = _zyz_matrix(np.pi / 2, 0.0, 0.0, torch.float64)
+    if inverted:
+        matrix = -matrix
+    T0 = O3Transformation(
+        matrix,
+        max_angular_momentum=1,
+    )
+    T1 = O3Transformation(
+        _zyz_matrix(np.pi, 0.0, 0.0, torch.float64), max_angular_momentum=1
+    )
 
     components = [
         Labels(["o3_mu_1"], torch.arange(-1, 2, dtype=torch.int32).reshape(-1, 1)),
@@ -569,7 +1035,7 @@ def test_rank2_transform_with_missing_system_rows():
     tensor = TensorMap(
         Labels(
             ["o3_lambda_1", "o3_lambda_2", "o3_sigma_1", "o3_sigma_2", "atom_type"],
-            torch.tensor([[1, 1, 1, 1, 1]], dtype=torch.int32),
+            torch.tensor([[1, 1, 1, sigma_2, 1]], dtype=torch.int32),
         ),
         [
             TensorBlock(
@@ -589,7 +1055,42 @@ def test_rank2_transform_with_missing_system_rows():
 
     D0 = T0.wigner_D_matrix(1)
     expected_values = torch.einsum("Aa,iabp,bB->iABp", D0, values, D0.T)
+    if inverted:
+        # The first ell=1, sigma=+1 axis contributes -1; the second contributes
+        # -sigma_2. Their product is therefore sigma_2.
+        expected_values = sigma_2 * expected_values
 
     assert transformed.block().samples == tensor.block().samples
     assert torch.allclose(transformed.block().values, expected_values, atol=1e-12)
     assert not torch.allclose(transformed.block().values, values)
+
+
+def test_transform_supports_all_recognized_component_suffixes():
+    """The public ``o3_mu`` naming convention recognizes ten component axes."""
+    suffixes = [""] + [f"_{index}" for index in range(1, 10)]
+    components = [
+        Labels([f"o3_mu{suffix}"], torch.tensor([[0]], dtype=torch.int32))
+        for suffix in suffixes
+    ]
+    key_names = [f"o3_lambda{suffix}" for suffix in suffixes] + [
+        f"o3_sigma{suffix}" for suffix in suffixes
+    ]
+    tensor = TensorMap(
+        Labels(key_names, torch.tensor([[0] * 10 + [1] * 10], dtype=torch.int32)),
+        [
+            TensorBlock(
+                values=torch.ones([1] + [1] * 10 + [1], dtype=torch.float64),
+                samples=Labels(["system"], torch.tensor([[0]], dtype=torch.int32)),
+                components=components,
+                properties=Labels(["p"], torch.tensor([[0]], dtype=torch.int32)),
+            )
+        ],
+    )
+
+    transformed = transform_tensor(
+        tensor,
+        [_make_system([1])],
+        [O3Transformation(torch.eye(3, dtype=torch.float64), 0)],
+    )
+
+    assert torch.equal(transformed.block().values, tensor.block().values)

--- a/python/metatomic_torch/tests/symmetrized_model.py
+++ b/python/metatomic_torch/tests/symmetrized_model.py
@@ -1,5 +1,6 @@
 """Tests for symmetrized_model.py standalone functions and SymmetrizedModel class."""
 
+import io
 from typing import Dict, List, Optional
 
 import metatensor.torch as mts
@@ -17,211 +18,407 @@ from metatomic.torch import (
     NeighborListOptions,
     System,
     load_atomistic_model,
+    register_autograd_neighbors,
     unit_conversion_factor,
 )
-from metatomic.torch.o3._wigner import build_wigner_D_cache
+from metatomic.torch.o3 import O3Transformation, transform_system, transform_tensor
+from metatomic.torch.o3 import _tranformations as transformation_module
+from metatomic.torch.o3._wigner import (
+    _complex_to_real_spherical_harmonics_transform,
+    _compute_real_wigner_d_matrices,
+    build_wigner_D_cache,
+)
 from metatomic.torch.symmetrized_model import (
     SymmetrizedModel,
     get_rotation_quadrature,
     per_system_character_fractions,
     per_system_equivariance_rmse,
 )
+from metatomic.torch.symmetrized_model import _model as symmetrized_model_module
 from metatomic.torch.symmetrized_model._decompose import (
     _decompose_output,
     _l0_components_from_matrices,
     _l2_components_from_matrices,
 )
 from metatomic.torch.symmetrized_model._gradients import _evaluate_with_gradients
+from metatomic.torch.symmetrized_model._model import (
+    _reduce_weighted_batch_moments,
+    _transform_system_batch,
+    _validate_nonnegative_diagnostic,
+)
 from metatomic.torch.symmetrized_model._quadrature import (
     _choose_quadrature,
     _rotations_from_angles,
     get_euler_angles_quadrature,
 )
 from metatomic.torch.symmetrized_model._utils import (
+    _reshape_block_by_local_system,
     _selected_atoms_for_local_systems,
 )
 
+from ._tests_utils import can_use_mps_backend
 
-class TestL0Components:
-    """Test extraction of L=0 (trace) components from 3x3 matrices."""
 
-    def test_identity_trace(self):
-        # Identity matrix has trace 3. The function expects shape (a, 3, 3, b).
-        A = torch.eye(3, dtype=torch.float64).unsqueeze(0).unsqueeze(-1)
-        result = _l0_components_from_matrices(A)
-        assert result.shape == (1, 1, 1)
-        assert torch.allclose(result, torch.tensor([[[3.0]]], dtype=torch.float64))
+_ENERGY_OUTPUTS = {"energy": ModelOutput(sample_kind="system")}
 
-    def test_traceless_matrix(self):
-        # A traceless matrix should give L=0 = 0
-        M = torch.tensor(
-            [[1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, 0.0]],
-            dtype=torch.float64,
+
+def _symmetrized(base_model, **kwargs):
+    """Build the float64 wrapper used by most behavioral tests."""
+    kwargs.setdefault("max_o3_lambda_target", 1)
+    kwargs.setdefault("batch_size", 4)
+    return SymmetrizedModel(base_model, **kwargs).to(dtype=torch.float64)
+
+
+def _evaluate_gradients(model, system, rotations=None, **kwargs):
+    if rotations is None:
+        rotations = torch.eye(3, dtype=torch.float64).unsqueeze(0)
+    return _evaluate_with_gradients(
+        model,
+        system,
+        rotations,
+        _ENERGY_OUTPUTS,
+        None,
+        torch.device("cpu"),
+        torch.float64,
+        **kwargs,
+    )
+
+
+def _single_block_tensor_map(
+    values: torch.Tensor,
+    *,
+    samples: Labels,
+    components: List[Labels],
+    properties: Labels,
+    keys: Optional[Labels] = None,
+) -> TensorMap:
+    """Build a TensorMap without repeating single-block test boilerplate."""
+    if keys is None:
+        keys = Labels(
+            ["_"], torch.tensor([[0]], dtype=torch.int64, device=values.device)
         )
-        A = M.unsqueeze(0).unsqueeze(-1)
-        result = _l0_components_from_matrices(A)
-        assert torch.allclose(
-            result, torch.tensor([[[0.0]]], dtype=torch.float64), atol=1e-14
+    return TensorMap(
+        keys,
+        [
+            TensorBlock(
+                values=values,
+                samples=samples,
+                components=components,
+                properties=properties,
+            )
+        ],
+    )
+
+
+def _system_tensor_map(
+    values: torch.Tensor,
+    property_name: str = "energy",
+    ell: int = -1,
+) -> TensorMap:
+    """Build the single-block, per-system outputs used by the mock models."""
+    device = values.device
+    if ell < 0:
+        keys = Labels(["_"], torch.tensor([[0]], dtype=torch.int64, device=device))
+        components: List[Labels] = []
+    else:
+        keys = Labels(
+            ["o3_lambda", "o3_sigma"],
+            torch.tensor([[ell, 1]], dtype=torch.int64, device=device),
         )
+        components = [
+            Labels(
+                ["o3_mu"],
+                torch.arange(-ell, ell + 1, dtype=torch.int64, device=device).reshape(
+                    -1, 1
+                ),
+            )
+        ]
 
-    def test_batch_dimensions(self):
-        # Test with batch size > 1 and multiple properties
-        batch = 5
-        n_prop = 3
-        A = torch.randn(batch, 3, 3, n_prop, dtype=torch.float64)
-        result = _l0_components_from_matrices(A)
-        assert result.shape == (batch, 1, n_prop)
-        for i in range(batch):
-            for p in range(n_prop):
-                expected_trace = A[i, 0, 0, p] + A[i, 1, 1, p] + A[i, 2, 2, p]
-                assert torch.allclose(result[i, 0, p], expected_trace, atol=1e-14)
+    return TensorMap(
+        keys,
+        [
+            TensorBlock(
+                values=values,
+                samples=Labels(
+                    ["system"],
+                    torch.arange(
+                        values.shape[0], dtype=torch.int64, device=device
+                    ).reshape(-1, 1),
+                ),
+                components=components,
+                properties=Labels.range(property_name, values.shape[-1]).to(
+                    device=device
+                ),
+            ),
+        ],
+    )
 
 
-class TestL2Components:
-    """Test extraction of L=2 (symmetric traceless) components from 3x3 matrices."""
+class TestStressDecomposition:
+    """L=0 and L=2 together describe the symmetric part of a 3x3 tensor."""
 
-    def test_identity_gives_zero(self):
-        # Identity is proportional to L=0 only; L=2 components should be zero.
-        A = torch.eye(3, dtype=torch.float64).unsqueeze(0).unsqueeze(-1)
-        result = _l2_components_from_matrices(A)
-        assert result.shape == (1, 5, 1)
-        assert torch.allclose(
-            result, torch.zeros(1, 5, 1, dtype=torch.float64), atol=1e-14
-        )
-
-    def test_diagonal_traceless(self):
-        # diag(1, -1, 0) is traceless and has known L=2 components
-        M = torch.tensor(
-            [[1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, 0.0]],
-            dtype=torch.float64,
-        )
-        A = M.unsqueeze(0).unsqueeze(-1)
-        result = _l2_components_from_matrices(A)
-        assert result.shape == (1, 5, 1)
-        # m=0: (2*0 - 1 - (-1)) / (2*sqrt(3)) = 0
-        assert torch.allclose(result[0, 2, 0], torch.tensor(0.0, dtype=torch.float64))
-        # m=2 (last component): (1 - (-1)) / 2 = 1
-        assert torch.allclose(result[0, 4, 0], torch.tensor(1.0, dtype=torch.float64))
-
-    def test_frobenius_norm_relation(self):
-        """For a symmetric traceless matrix S, the L=2 decomposition should satisfy
-        a norm relation: sum(c_i^2) relates to (1/2) * sum(S_ij * S_ji).
-        """
-        # Build a symmetric traceless matrix
-        S = torch.tensor(
+    def test_trace_l2_norm_and_skew_contracts(self):
+        identity = torch.eye(3, dtype=torch.float64)
+        diagonal = torch.diag(torch.tensor([1.0, -1.0, 0.0], dtype=torch.float64))
+        traceless = torch.tensor(
             [[2.0, 1.0, 0.5], [1.0, -1.0, 0.3], [0.5, 0.3, -1.0]],
             dtype=torch.float64,
         )
-        A = S.unsqueeze(0).unsqueeze(-1)
-        l2 = _l2_components_from_matrices(A)
-        l2_norm_sq = (l2**2).sum()
-
-        # The L=2 norm squared should equal half the Frobenius norm of the
-        # symmetric part (since the decomposition extracts the symmetric part)
-        sym_S = 0.5 * (S + S.T)
-        half_frob = 0.5 * (sym_S**2).sum()
-        # They won't be exactly equal because S has an L=0 part too.
-        # But for a traceless symmetric matrix, L=0 is zero, so they match.
-        trace = S[0, 0] + S[1, 1] + S[2, 2]
-        assert abs(trace) < 1e-14, "Matrix should be traceless for this test"
-        assert torch.allclose(l2_norm_sq, half_frob, atol=1e-12)
-
-
-class TestDecomposeStressRoundtrip:
-    """Test that L=0 + L=2 decomposition covers the symmetric part of a 3x3 tensor."""
-
-    def test_norm_conservation(self):
-        """The sum of L=0 and L=2 squared norms should equal
-        the Frobenius norm squared of the symmetrized matrix."""
-        M = torch.randn(1, 3, 3, 1, dtype=torch.float64)
-        sym_M = 0.5 * (M + M.transpose(1, 2))
-
-        l0 = _l0_components_from_matrices(sym_M)
-        l2 = _l2_components_from_matrices(sym_M)
-
-        # L=0 norm: trace^2 / 3 (the trace component carries norm trace^2/3
-        # in the irrep normalization). Actually, the L=0 extraction returns
-        # the raw trace, and L=2 the 5 components. Let's check reconstruction.
-        trace_val = l0[0, 0, 0]
-        # Reconstruct L=0 part: (trace/3) * I
-        l0_matrix = (trace_val / 3.0) * torch.eye(3, dtype=torch.float64)
-
-        # Reconstruct L=2 part from components
-        c = l2[0, :, 0]  # 5 components: (m=-2, m=-1, m=0, m=1, m=2)
-        l2_matrix = torch.zeros(3, 3, dtype=torch.float64)
-        # Reverse of the extraction formulas:
-        l2_matrix[0, 1] = c[0]
-        l2_matrix[1, 0] = c[0]
-        l2_matrix[1, 2] = c[1]
-        l2_matrix[2, 1] = c[1]
-        l2_matrix[0, 2] = c[3]
-        l2_matrix[2, 0] = c[3]
-        l2_matrix[0, 0] = c[4] + c[2] * np.sqrt(3) / 3 * (-1)
-        l2_matrix[1, 1] = -c[4] + c[2] * np.sqrt(3) / 3 * (-1)
-        l2_matrix[2, 2] = c[2] * 2.0 * np.sqrt(3) / 3
-
-        reconstructed = l0_matrix + l2_matrix
-        original_sym = sym_M[0, :, :, 0]
-        assert torch.allclose(reconstructed, original_sym, atol=1e-12)
-
-
-class TestWignerD:
-    """Test properties of real Wigner D matrices."""
-
-    def test_orthogonality(self):
-        """D(R)^T D(R) = I for all ell."""
-        rng = np.random.default_rng(42)
-        R = Rotation.random(5, random_state=rng)
-        l_max = 4
-        for i in range(5):
-            matrix = torch.tensor(R[i].as_matrix(), dtype=torch.float64)
-            wigner = build_wigner_D_cache(
-                l_max, matrix, device=matrix.device, dtype=matrix.dtype
-            )
-            for ell in range(l_max + 1):
-                Di = wigner[ell]
-                product = Di.T @ Di
-                identity = torch.eye(2 * ell + 1, dtype=Di.dtype)
-                assert torch.allclose(product, identity, atol=1e-10), (
-                    f"D^T D != I for ell={ell}, rotation {i}"
-                )
-
-    def test_identity_rotation(self):
-        """D(identity) = I for all ell."""
-        l_max = 4
-        matrix = torch.eye(3, dtype=torch.float64)
-        wigner = build_wigner_D_cache(
-            l_max, matrix, device=matrix.device, dtype=matrix.dtype
+        skew = torch.tensor(
+            [[0.0, 2.0, -3.0], [-2.0, 0.0, 5.0], [3.0, -5.0, 0.0]],
+            dtype=torch.float64,
         )
-        for ell in range(l_max + 1):
-            D = wigner[ell]
-            identity = torch.eye(2 * ell + 1, dtype=D.dtype)
-            assert torch.allclose(D, identity, atol=1e-10), (
-                f"D(identity) != I for ell={ell}"
+        matrices = torch.stack([identity, diagonal, traceless, skew]).unsqueeze(-1)
+        matrices = torch.cat([matrices, 2.0 * matrices], dim=-1)
+
+        l0 = _l0_components_from_matrices(matrices)
+        l2 = _l2_components_from_matrices(matrices)
+        assert l0.shape == (4, 1, 2)
+        assert l2.shape == (4, 5, 2)
+        assert torch.equal(l0[:, :, 1], 2.0 * l0[:, :, 0])
+        assert torch.equal(l2[:, :, 1], 2.0 * l2[:, :, 0])
+        assert torch.equal(
+            l0[:, 0, 0], torch.tensor([3.0, 0.0, 0.0, 0.0], dtype=torch.float64)
+        )
+
+        # Identity is purely L=0; the known diagonal tensor has only m=2.
+        assert torch.count_nonzero(l2[0]) == 0
+        assert l2[1, 2, 0] == 0.0
+        assert l2[1, 4, 0] == 1.0
+
+        # The five real components preserve the symmetric-traceless norm in
+        # the normalization used by the stress decomposition.
+        assert torch.allclose(
+            torch.sum(l2[2, :, 0] ** 2),
+            0.5 * torch.sum(traceless**2),
+            atol=1e-12,
+        )
+        assert torch.count_nonzero(l2[3]) == 0
+
+    def test_l0_l2_reconstruct_the_symmetric_part(self):
+        matrix = torch.randn(1, 3, 3, 1, dtype=torch.float64)
+        symmetric = 0.5 * (matrix + matrix.transpose(1, 2))
+        l0 = _l0_components_from_matrices(symmetric)
+        l2 = _l2_components_from_matrices(symmetric)
+        a, b, c, d, e = l2[0, :, 0]
+        sqrt3 = np.sqrt(3.0)
+        traceless = torch.stack(
+            [
+                torch.stack([e - c / sqrt3, a, d]),
+                torch.stack([a, -e - c / sqrt3, b]),
+                torch.stack([d, b, 2 * c / sqrt3]),
+            ]
+        )
+        reconstructed = l0.item() / 3 * torch.eye(3) + traceless
+        assert torch.allclose(reconstructed, symmetric[0, :, :, 0], atol=1e-12)
+
+
+class TestWeightedBatchMoments:
+    @pytest.mark.parametrize("component_shape", [(), (2, 3)])
+    def test_signed_weights_and_component_reduction(self, component_shape):
+        n_systems = 3
+        n_samples = 2
+        n_properties = 2
+        sample_ids = (2**40, 2**40 + 1)
+        samples = Labels(
+            ["system", "item"],
+            torch.tensor(
+                [[system, item] for system in range(n_systems) for item in sample_ids],
+                dtype=torch.int64,
+            ),
+        )
+        properties = Labels.range("property", n_properties)
+        shape = (n_systems * n_samples, *component_shape, n_properties)
+        values = torch.arange(int(np.prod(shape)), dtype=torch.float64).reshape(shape)
+        components = [
+            Labels.range(name, size)
+            for name, size in zip(("a", "b"), component_shape, strict=False)
+        ]
+        tensor = _single_block_tensor_map(
+            values,
+            samples=samples,
+            components=components,
+            properties=properties,
+            keys=Labels("kind", torch.tensor([[0]], dtype=torch.int64)),
+        )
+        weights = torch.tensor([0.2, -0.1, 0.4], dtype=torch.float64)
+        mean, second, absolute_second, reference = _reduce_weighted_batch_moments(
+            tensor, weights, system_index=7
+        )
+        expected_samples = Labels(
+            ["system", "item"],
+            torch.tensor([[7, sample_ids[0]], [7, sample_ids[1]]], dtype=torch.int64),
+        )
+        assert mean.block().samples == expected_samples
+        assert second.block().samples == expected_samples
+        assert second.block().components == []
+        assert mean.block().components == components
+        assert mean.block().properties == second.block().properties == properties
+
+        reshaped = values.reshape(n_systems, n_samples, *component_shape, n_properties)
+        centered = reshaped - reshaped[0]
+        weight_shape = (n_systems,) + (1,) * (centered.ndim - 1)
+        assert torch.allclose(
+            mean.block().values,
+            torch.sum(0.5 * weights.reshape(weight_shape) * centered, dim=0),
+        )
+        squared = centered**2
+        if component_shape:
+            squared = squared.sum(dim=tuple(range(2, 2 + len(component_shape))))
+        assert torch.allclose(
+            second.block().values,
+            torch.sum(0.5 * weights.reshape(n_systems, 1, 1) * squared, dim=0),
+        )
+        assert torch.allclose(
+            absolute_second.block().values,
+            torch.sum(
+                0.5 * torch.abs(weights).reshape(n_systems, 1, 1) * squared,
+                dim=0,
+            ),
+        )
+        assert torch.equal(reference.block().values, reshaped[0])
+
+
+@pytest.mark.parametrize(
+    ("sample_values", "message"),
+    [
+        ([[0, 0], [2, 0]], "out-of-range system indices"),
+        ([[0, 0], [0, 1], [1, 0]], "same sample labels"),
+        ([[0, 0], [0, 1], [0, 2], [1, 0]], "same sample labels"),
+        ([[0, 0], [0, 1], [1, 0], [1, 2]], "same sample labels"),
+    ],
+)
+def test_streaming_layout_rejects_inconsistent_rotated_samples(sample_values, message):
+    """Streaming must never mix samples from different rotated copies."""
+    samples = Labels(["system", "atom"], torch.tensor(sample_values, dtype=torch.int64))
+    block = TensorBlock(
+        values=torch.zeros((len(samples), 1), dtype=torch.float64),
+        samples=samples,
+        components=[],
+        properties=Labels.range("p", 1),
+    )
+
+    with pytest.raises(ValueError, match=message):
+        _reshape_block_by_local_system(block, n_local_systems=2)
+
+
+@pytest.mark.parametrize("scale", [1.0e-12, 1.0, 1.0e12])
+def test_nonnegative_diagnostic_uses_scale_aware_tolerance(scale):
+    n_grid_points = 100
+    gamma = n_grid_points * torch.finfo(torch.float64).eps
+    gamma /= 1.0 - gamma
+    tolerance = 64.0 * gamma * scale
+    samples = Labels("system", torch.tensor([[0]]))
+    properties = Labels.range("p", 1)
+
+    def tensor(value):
+        return _single_block_tensor_map(
+            torch.tensor([[value]], dtype=torch.float64),
+            samples=samples,
+            components=[],
+            properties=properties,
+        )
+
+    cleaned = _validate_nonnegative_diagnostic(
+        tensor(-0.5 * tolerance),
+        tensor(scale),
+        n_grid_points=n_grid_points,
+        quantity="variance",
+        max_o3_lambda_grid=3,
+    )
+    assert cleaned.block().values.item() == 0.0
+
+    with pytest.raises(ValueError, match="materially negative"):
+        _validate_nonnegative_diagnostic(
+            tensor(-2.0 * tolerance),
+            tensor(scale),
+            n_grid_points=n_grid_points,
+            quantity="variance",
+            max_o3_lambda_grid=3,
+        )
+
+
+@pytest.mark.parametrize(
+    ("value", "scale"),
+    [
+        (float("nan"), 1.0),
+        (float("inf"), 1.0),
+        (0.0, float("nan")),
+        (0.0, float("inf")),
+        (0.0, -1.0),
+    ],
+)
+def test_nonnegative_diagnostic_rejects_invalid_value_or_scale(value, scale):
+    samples = Labels("system", torch.tensor([[0]]))
+    properties = Labels.range("p", 1)
+
+    def tensor(number):
+        return _single_block_tensor_map(
+            torch.tensor([[number]], dtype=torch.float64),
+            samples=samples,
+            components=[],
+            properties=properties,
+        )
+
+    with pytest.raises(ValueError, match="variance or its error scale is invalid"):
+        _validate_nonnegative_diagnostic(
+            tensor(value),
+            tensor(scale),
+            n_grid_points=100,
+            quantity="variance",
+            max_o3_lambda_grid=3,
+        )
+
+
+class TestQuadratureWignerD:
+    """Cross-check the quadrature pole rotations against their generating angles."""
+
+    @pytest.mark.parametrize("dtype", [torch.float64, torch.float32])
+    @pytest.mark.parametrize("inverted", [False, True])
+    def test_scipy_quadrature_poles_recover_generating_wigner(self, dtype, inverted):
+        """Check every polar node for gamma counts selected by degrees 0..16."""
+        ell_max = 8
+        transforms = {
+            ell: _complex_to_real_spherical_harmonics_transform(ell)
+            for ell in range(ell_max + 1)
+        }
+        atol = 2.0e-11 if dtype == torch.float64 else 4.0e-5
+
+        for degree in range(17):
+            order, n_rotations = _choose_quadrature(degree)
+            alpha, beta, gamma, _ = get_euler_angles_quadrature(order, n_rotations)
+            matrices = _rotations_from_angles(alpha, beta, gamma).as_matrix()
+            polar_indices = np.flatnonzero(
+                (np.abs(beta) < 1.0e-12) | (np.abs(beta - np.pi) < 1.0e-12)
             )
-
-    def test_composition(self):
-        """D(R1) @ D(R2) ≈ D(R1 @ R2) for random rotations."""
-        rng = np.random.default_rng(123)
-        R1 = Rotation.random(random_state=rng)
-        R2 = Rotation.random(random_state=rng)
-        R12 = R1 * R2
-
-        l_max = 3
-        m1 = torch.tensor(R1.as_matrix(), dtype=torch.float64)
-        m2 = torch.tensor(R2.as_matrix(), dtype=torch.float64)
-        m12 = torch.tensor(R12.as_matrix(), dtype=torch.float64)
-
-        D1 = build_wigner_D_cache(l_max, m1, device=m1.device, dtype=m1.dtype)
-        D2 = build_wigner_D_cache(l_max, m2, device=m2.device, dtype=m2.dtype)
-        D12 = build_wigner_D_cache(l_max, m12, device=m12.device, dtype=m12.dtype)
-
-        for ell in range(l_max + 1):
-            product = D1[ell] @ D2[ell]
-            expected = D12[ell]
-            assert torch.allclose(product, expected, atol=1e-10), (
-                f"D(R1)D(R2) != D(R1R2) for ell={ell}"
-            )
+            for index in polar_indices:
+                proper = torch.tensor(matrices[index], dtype=dtype)
+                matrix = -proper if inverted else proper
+                recovered = build_wigner_D_cache(
+                    ell_max,
+                    matrix,
+                    device=matrix.device,
+                    dtype=dtype,
+                )
+                expected = _compute_real_wigner_d_matrices(
+                    ell_max,
+                    (
+                        float(alpha[index]),
+                        float(beta[index]),
+                        float(gamma[index]),
+                    ),
+                    transforms,
+                )
+                for ell in range(ell_max + 1):
+                    assert torch.allclose(
+                        recovered[ell],
+                        expected[ell].to(dtype=dtype),
+                        rtol=0.0,
+                        atol=atol,
+                    ), (
+                        f"pole mismatch for degree={degree}, gamma index={index}, "
+                        f"ell={ell}, dtype={dtype}, inverted={inverted}"
+                    )
 
 
 class TestQuadrature:
@@ -260,6 +457,93 @@ class TestQuadrature:
         with pytest.raises(ValueError, match="exceeds the largest"):
             _choose_quadrature(132)
 
+    @pytest.mark.parametrize("value", [-1, -2])
+    def test_choose_quadrature_rejects_negative_degree(self, value):
+        with pytest.raises(ValueError, match="non-negative"):
+            _choose_quadrature(value)
+
+    @pytest.mark.parametrize("value", [1.5, True])
+    def test_choose_quadrature_rejects_non_integer_degree(self, value):
+        with pytest.raises(TypeError, match="must be an integer"):
+            _choose_quadrature(value)
+
+    @pytest.mark.parametrize("value", [0, -1])
+    def test_rotation_quadrature_rejects_non_positive_rotation_count(self, value):
+        with pytest.raises(ValueError, match="positive"):
+            get_rotation_quadrature(3, value)
+
+    @pytest.mark.parametrize("value", [1.5, True])
+    def test_rotation_quadrature_rejects_non_integer_rotation_count(self, value):
+        with pytest.raises(TypeError, match="must be an integer"):
+            get_rotation_quadrature(3, value)
+
+    def test_rotation_quadrature_rejects_unsupported_lebedev_order(self):
+        with pytest.raises(ValueError, match="unsupported Lebedev order"):
+            get_rotation_quadrature(4, 3)
+
+    def test_degree_two_grid_resolves_l1_products(self):
+        order, n_rotations = _choose_quadrature(2)
+        rotations, weights = get_rotation_quadrature(order, n_rotations)
+        function = rotations[:, 2, 0]
+
+        norm = np.sum(weights * function**2)
+        projection_matrix = np.einsum("g,gij,g->ij", weights, rotations, function)
+        projected_norm = 3.0 * np.sum(projection_matrix**2)
+        assert np.isclose(norm, 1.0 / 3.0, atol=1e-12)
+        assert np.isclose(projected_norm, 1.0 / 3.0, atol=1e-12)
+
+    @pytest.mark.parametrize("ell_max", range(5))
+    def test_default_character_grid_resolves_o3_wigner_products_at_boundary(
+        self, ell_max
+    ):
+        """Degree 2L, hence 2L+1 gamma points, resolves products through L.
+
+        The Gram matrix includes both O(3) parities. It therefore checks the
+        exact boundary used by character projections, rather than only an
+        SO(3) scalar moment.
+        """
+        model = SymmetrizedModel(
+            torch.nn.Identity(),
+            max_o3_lambda_target=0,
+            max_o3_lambda_character=ell_max,
+        )
+        assert model.max_o3_lambda_grid == 2 * ell_max
+
+        weights = model._so3_weights_float64
+        transformations = [
+            O3Transformation(rotation, ell_max)
+            for rotation in model.so3_rotations.transpose(-1, -2)
+        ]
+        columns = []
+        expected_diagonal = []
+        for ell in range(ell_max + 1):
+            wigner = torch.stack(
+                [
+                    transformation.wigner_D_matrix(ell)
+                    for transformation in transformations
+                ]
+            ).reshape(len(transformations), -1)
+            for sigma in (1, -1):
+                improper_factor = sigma * (-1) ** ell
+                columns.append(torch.cat([wigner, improper_factor * wigner], dim=0))
+                expected_diagonal.extend([1.0 / (2 * ell + 1)] * wigner.shape[1])
+
+        basis = torch.cat(columns, dim=1)
+        o3_weights = torch.cat([0.5 * weights, 0.5 * weights])
+        gram = basis.T @ (o3_weights[:, None] * basis)
+        expected = torch.diag(torch.tensor(expected_diagonal, dtype=torch.float64))
+        # Wigner matrices are reconstructed from rotation matrices, so their
+        # Euler-angle round trip currently limits this check to about 1e-8.
+        assert torch.allclose(gram, expected, rtol=0.0, atol=2.0e-8)
+
+    @pytest.mark.parametrize("ell_max", range(5))
+    def test_default_target_grid_keeps_conservative_extra_degree(self, ell_max):
+        model = SymmetrizedModel(
+            torch.nn.Identity(),
+            max_o3_lambda_target=ell_max,
+        )
+        assert model.max_o3_lambda_grid == 2 * ell_max + 1
+
     def test_rotation_quadrature_matrices(self):
         """get_rotation_quadrature returns orthogonal matrices with normalized
         weights, and doubles the grid with improper partners on request."""
@@ -296,6 +580,123 @@ def _two_atom_system(positions=_POSITIONS_A, dtype=torch.float64):
     )
 
 
+@pytest.mark.parametrize("inversion", [1.0, -1.0])
+@pytest.mark.parametrize("n_matrices", [1, 2])
+def test_batched_quadrature_system_transform_matches_generic_path(
+    inversion, n_matrices
+):
+    system = System(
+        types=torch.tensor([1, 8], dtype=torch.int32),
+        positions=torch.tensor(_POSITIONS_A, dtype=torch.float64),
+        cell=3.0 * torch.eye(3, dtype=torch.float64),
+        pbc=torch.tensor([True, True, True]),
+    )
+    options = NeighborListOptions(cutoff=2.0, full_list=True, strict=False)
+    neighbors = TensorBlock(
+        values=torch.tensor([[[1.0], [2.0], [3.0]]], dtype=torch.float64),
+        samples=Labels(
+            [
+                "first_atom",
+                "second_atom",
+                "cell_shift_a",
+                "cell_shift_b",
+                "cell_shift_c",
+            ],
+            torch.tensor([[0, 1, 0, 0, 0]], dtype=torch.int64),
+        ),
+        components=[Labels.range("xyz", 3)],
+        properties=Labels.range("distance", 1),
+    )
+    system.add_neighbor_list(options, neighbors)
+    field = _single_block_tensor_map(
+        torch.tensor([[[0.3], [-0.2], [0.7]]], dtype=torch.float64),
+        samples=Labels(["system"], torch.tensor([[0]], dtype=torch.int64)),
+        components=[Labels.range("xyz", 3)],
+        properties=Labels.range("field", 1),
+    )
+    system.add_data("mtt::field", field)
+
+    rotations = torch.tensor(
+        [
+            [[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]],
+            [[-1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, 1.0]],
+        ],
+        dtype=torch.float64,
+    )
+    matrices = (inversion * rotations)[:n_matrices]
+    actual = _transform_system_batch(
+        system,
+        matrices,
+        0,
+        is_inverted=inversion < 0,
+    )
+    expected = [
+        transform_system(system, O3Transformation(matrix, 0)) for matrix in matrices
+    ]
+
+    for actual_system, expected_system in zip(actual, expected, strict=True):
+        assert torch.equal(actual_system.positions, expected_system.positions)
+        assert torch.equal(actual_system.cell, expected_system.cell)
+        assert torch.equal(
+            actual_system.get_neighbor_list(options).values,
+            expected_system.get_neighbor_list(options).values,
+        )
+        assert torch.equal(
+            actual_system.get_data("mtt::field").block().values,
+            expected_system.get_data("mtt::field").block().values,
+        )
+
+
+def test_batched_system_transform_reregisters_autograd_neighbors():
+    positions = torch.tensor(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
+        dtype=torch.float64,
+        requires_grad=True,
+    )
+    system = System(
+        types=torch.tensor([1, 1], dtype=torch.int32),
+        positions=positions,
+        cell=torch.zeros((3, 3), dtype=torch.float64),
+        pbc=torch.tensor([False, False, False]),
+    )
+    options = NeighborListOptions(cutoff=2.0, full_list=True, strict=False)
+    neighbors = TensorBlock(
+        values=torch.tensor([[[1.0], [0.0], [0.0]]], dtype=torch.float64),
+        samples=Labels(
+            [
+                "first_atom",
+                "second_atom",
+                "cell_shift_a",
+                "cell_shift_b",
+                "cell_shift_c",
+            ],
+            torch.tensor([[0, 1, 0, 0, 0]]),
+        ),
+        components=[Labels.range("xyz", 3)],
+        properties=Labels.range("distance", 1),
+    )
+    register_autograd_neighbors(system, neighbors)
+    system.add_neighbor_list(options, neighbors)
+
+    matrices = torch.stack(
+        [
+            torch.eye(3, dtype=torch.float64),
+            torch.tensor(
+                [[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]],
+                dtype=torch.float64,
+            ),
+        ]
+    )
+    transformed = _transform_system_batch(system, matrices, 0, is_inverted=False)
+    loss = sum(
+        torch.sum(item.get_neighbor_list(options).values ** 2) for item in transformed
+    )
+
+    gradient = torch.autograd.grad(loss, positions)[0]
+    expected = torch.tensor([[-4.0, 0.0, 0.0], [4.0, 0.0, 0.0]], dtype=torch.float64)
+    assert torch.allclose(gradient, expected, atol=1e-12)
+
+
 class _QuadraticEnergyModel(torch.nn.Module):
     """Minimal model where E = sum(positions^2). Analytical forces = -2*positions."""
 
@@ -305,28 +706,136 @@ class _QuadraticEnergyModel(torch.nn.Module):
         outputs: Dict[str, ModelOutput],
         selected_atoms: Optional[Labels] = None,
     ) -> Dict[str, TensorMap]:
-        n_sys = len(systems)
-        energies = []
-        for sys in systems:
-            energies.append(torch.sum(sys.positions**2))
-
-        key = Labels(
-            names=["_"],
-            values=torch.tensor([[0]], dtype=torch.int64),
-        )
-        energy_block = TensorBlock(
-            values=torch.stack(energies).unsqueeze(-1),
+        energies = torch.stack([torch.sum(system.positions**2) for system in systems])
+        device = energies.device
+        block = TensorBlock(
+            values=energies.unsqueeze(-1),
             samples=Labels(
-                names=["system"],
-                values=torch.arange(n_sys, dtype=torch.int64).unsqueeze(1),
+                ["system"],
+                torch.arange(len(systems), dtype=torch.int64, device=device).reshape(
+                    -1, 1
+                ),
             ),
             components=[],
             properties=Labels(
-                names=["energy"],
-                values=torch.tensor([[0]], dtype=torch.int64),
+                ["energy"], torch.tensor([[0]], dtype=torch.int64, device=device)
             ),
         )
-        return {"energy": TensorMap(key, [energy_block])}
+        return {
+            "energy": TensorMap(
+                Labels(["_"], torch.tensor([[0]], dtype=torch.int64, device=device)),
+                [block],
+            )
+        }
+
+    def requested_neighbor_lists(self) -> List[NeighborListOptions]:
+        return []
+
+
+class _ConstantEnergyModel(torch.nn.Module):
+    """Minimal model returning an energy independent of positions and cell."""
+
+    def __init__(
+        self,
+        connected: bool = False,
+        connect_first_only: bool = False,
+        value: float = 1.0,
+    ):
+        super().__init__()
+        self.connected = connected
+        self.connect_first_only = connect_first_only
+        self.value = value
+
+    def forward(
+        self,
+        systems: List[System],
+        outputs: Dict[str, ModelOutput],
+        selected_atoms: Optional[Labels] = None,
+    ) -> Dict[str, TensorMap]:
+        energies = []
+        for system_i, system in enumerate(systems):
+            energy = torch.full(
+                (),
+                self.value,
+                dtype=system.positions.dtype,
+                device=system.positions.device,
+            )
+            if self.connected and (not self.connect_first_only or system_i == 0):
+                # Keep a graph connection while remaining independent of values.
+                energy = energy + 0.0 * system.positions.sum()
+            energies.append(energy)
+
+        return {"energy": _system_tensor_map(torch.stack(energies).unsqueeze(-1))}
+
+    def requested_neighbor_lists(self) -> List[NeighborListOptions]:
+        return []
+
+
+class _ParameterOnlyEnergyModel(_ConstantEnergyModel):
+    """Energy with an autograd graph that does not use positions or cell."""
+
+    def __init__(self):
+        super().__init__()
+        self.bias = torch.nn.Parameter(torch.tensor(1.0, dtype=torch.float64))
+
+    def forward(
+        self,
+        systems: List[System],
+        outputs: Dict[str, ModelOutput],
+        selected_atoms: Optional[Labels] = None,
+    ) -> Dict[str, TensorMap]:
+        return {"energy": _system_tensor_map(self.bias.expand(len(systems), 1))}
+
+
+class _ExplicitGradientEnergyModel(torch.nn.Module):
+    """Quadratic energy that attaches an unsolicited positions gradient."""
+
+    def forward(
+        self,
+        systems: List[System],
+        outputs: Dict[str, ModelOutput],
+        selected_atoms: Optional[Labels] = None,
+    ) -> Dict[str, TensorMap]:
+        energies = torch.stack([torch.sum(system.positions**2) for system in systems])
+        device = energies.device
+        properties = Labels(
+            ["energy"], torch.tensor([[0]], dtype=torch.int64, device=device)
+        )
+        block = TensorBlock(
+            values=energies.unsqueeze(-1),
+            samples=Labels(
+                ["system"],
+                torch.arange(len(systems), dtype=torch.int64, device=device).reshape(
+                    -1, 1
+                ),
+            ),
+            components=[],
+            properties=properties,
+        )
+        sample_index = torch.arange(len(systems), dtype=torch.int64, device=device)
+        block.add_gradient(
+            "positions",
+            TensorBlock(
+                values=torch.zeros(
+                    (len(systems), 3, 1), dtype=energies.dtype, device=device
+                ),
+                samples=Labels(
+                    ["sample", "system", "atom"],
+                    torch.stack(
+                        [sample_index, sample_index, torch.zeros_like(sample_index)],
+                        dim=1,
+                    ),
+                ),
+                components=[Labels.range("xyz", 3).to(device=device)],
+                properties=properties,
+            ),
+        )
+        return {
+            "energy": TensorMap(
+                Labels(["_"], torch.tensor([[0]], dtype=torch.int64, device=device)),
+                [block],
+            )
+        }
 
     def requested_neighbor_lists(self) -> List[NeighborListOptions]:
         return []
@@ -364,20 +873,23 @@ class _OffsetAnisotropicEnergyModel(torch.nn.Module):
             1.0e5 + torch.sum(sys.positions**2) + torch.sum(sys.positions[:, 0])
             for sys in systems
         ]
-        block = TensorBlock(
-            values=torch.stack(energies).unsqueeze(-1),
-            samples=Labels(
-                names=["system"],
-                values=torch.arange(len(systems), dtype=torch.int64).unsqueeze(1),
-            ),
-            components=[],
-            properties=Labels(
-                names=["energy"],
-                values=torch.tensor([[0]], dtype=torch.int64),
-            ),
-        )
-        key = Labels(names=["_"], values=torch.tensor([[0]], dtype=torch.int64))
-        return {"energy": TensorMap(key, [block])}
+        return {"energy": _system_tensor_map(torch.stack(energies).unsqueeze(-1))}
+
+    def requested_neighbor_lists(self):
+        return []
+
+
+class _DegreeSevenEnergyModel(torch.nn.Module):
+    """Smooth response whose degree-12 grid variance is materially aliased."""
+
+    def forward(self, systems, outputs, selected_atoms=None):
+        energies = []
+        for system in systems:
+            x, y, z = system.positions[0]
+            fourth_order = 0.625 * (x**4 + y**4 + z**4)
+            mixed = x**2 * y**2 + x**2 * z**2 + y**2 * z**2
+            energies.append(1000.0 * x * y * z * (fourth_order - mixed))
+        return {"energy": _system_tensor_map(torch.stack(energies).unsqueeze(-1))}
 
     def requested_neighbor_lists(self):
         return []
@@ -390,26 +902,13 @@ class _EnergyAndVectorModel(torch.nn.Module):
         outputs: Dict[str, ModelOutput],
         selected_atoms: Optional[Labels] = None,
     ) -> Dict[str, TensorMap]:
-        n_sys = len(systems)
-        key = Labels(names=["_"], values=torch.tensor([[0]], dtype=torch.int64))
         result = {}
 
         if "energy" in outputs:
-            energy_block = TensorBlock(
-                values=torch.stack(
-                    [torch.sum(sys.positions**2) for sys in systems]
-                ).unsqueeze(-1),
-                samples=Labels(
-                    names=["system"],
-                    values=torch.arange(n_sys, dtype=torch.int64).unsqueeze(1),
-                ),
-                components=[],
-                properties=Labels(
-                    names=["energy"],
-                    values=torch.tensor([[0]], dtype=torch.int64),
-                ),
+            energies = torch.stack(
+                [torch.sum(system.positions**2) for system in systems]
             )
-            result["energy"] = TensorMap(key, [energy_block])
+            result["energy"] = _system_tensor_map(energies.unsqueeze(-1))
 
         if "non_conservative_forces" in outputs:
             values = torch.cat([sys.positions.unsqueeze(-1) for sys in systems], dim=0)
@@ -417,8 +916,8 @@ class _EnergyAndVectorModel(torch.nn.Module):
             for i_sys, sys in enumerate(systems):
                 for atom in range(len(sys)):
                     samples.append([i_sys, atom])
-            force_block = TensorBlock(
-                values=values,
+            force_tmap = _single_block_tensor_map(
+                values,
                 samples=Labels(
                     names=["system", "atom"],
                     values=torch.tensor(samples, dtype=torch.int64),
@@ -434,7 +933,6 @@ class _EnergyAndVectorModel(torch.nn.Module):
                     values=torch.tensor([[0]], dtype=torch.int64),
                 ),
             )
-            force_tmap = TensorMap(key, [force_block])
             if selected_atoms is not None:
                 force_tmap = mts.slice(
                     force_tmap,
@@ -446,6 +944,57 @@ class _EnergyAndVectorModel(torch.nn.Module):
         return result
 
     def requested_neighbor_lists(self):
+        return []
+
+
+class _NonLeadingSystemSampleModel(torch.nn.Module):
+    """Return interleaved per-atom rows with ``system`` not in column zero."""
+
+    def forward(self, systems, outputs, selected_atoms=None):
+        values = torch.stack(
+            [
+                torch.sum(system.positions[atom] ** 2)
+                for atom in range(len(systems[0]))
+                for system in systems
+            ]
+        ).unsqueeze(-1)
+        samples = [
+            [atom, system_index]
+            for atom in range(len(systems[0]))
+            for system_index in range(len(systems))
+        ]
+        return {
+            "mtt::feature": _single_block_tensor_map(
+                values,
+                samples=Labels(
+                    ["atom", "system"],
+                    torch.tensor(samples, dtype=torch.int64, device=values.device),
+                ),
+                components=[],
+                properties=Labels.range("feature", 1).to(device=values.device),
+            )
+        }
+
+    def requested_neighbor_lists(self):
+        return []
+
+
+class _CustomUnitInputEnergyModel(torch.nn.Module):
+    """Return the sum of a custom mass input requested in kilograms."""
+
+    def requested_inputs(self) -> Dict[str, ModelOutput]:
+        return {"mass": ModelOutput(unit="kg", sample_kind="atom")}
+
+    def forward(
+        self,
+        systems: List[System],
+        outputs: Dict[str, ModelOutput],
+        selected_atoms: Optional[Labels] = None,
+    ) -> Dict[str, TensorMap]:
+        energies = [system.get_data("mass").block().values.sum() for system in systems]
+        return {"energy": _system_tensor_map(torch.stack(energies).reshape(-1, 1))}
+
+    def requested_neighbor_lists(self) -> List[NeighborListOptions]:
         return []
 
 
@@ -468,20 +1017,7 @@ class _AnisotropicEnergyModel(torch.nn.Module):
             torch.sum(sys.positions**2) + torch.sum(sys.positions[:, 0])
             for sys in systems
         ]
-        block = TensorBlock(
-            values=torch.stack(energies).unsqueeze(-1),
-            samples=Labels(
-                names=["system"],
-                values=torch.arange(len(systems), dtype=torch.int64).unsqueeze(1),
-            ),
-            components=[],
-            properties=Labels(
-                names=["energy"],
-                values=torch.tensor([[0]], dtype=torch.int64),
-            ),
-        )
-        key = Labels(names=["_"], values=torch.tensor([[0]], dtype=torch.int64))
-        return {"energy": TensorMap(key, [block])}
+        return {"energy": _system_tensor_map(torch.stack(energies).unsqueeze(-1))}
 
     def requested_neighbor_lists(self):
         return []
@@ -490,240 +1026,140 @@ class _AnisotropicEnergyModel(torch.nn.Module):
 class TestGradientForces:
     """Test conservative forces from autograd via _evaluate_with_gradients."""
 
-    def test_forces_identity_rotation(self):
-        """With identity rotation, forces should be -2*positions for E=sum(pos^2)."""
-        model = _QuadraticEnergyModel()
-        positions = torch.tensor(
-            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=torch.float64
-        )
-        system = System(
-            types=torch.tensor([1, 1]),
-            positions=positions,
-            cell=torch.zeros(3, 3, dtype=torch.float64),
-            pbc=torch.tensor([False, False, False]),
-        )
-        rotation = torch.eye(3, dtype=torch.float64).unsqueeze(0)  # (1, 3, 3)
-        outputs = {"energy": ModelOutput(sample_kind="system")}
-
-        out = _evaluate_with_gradients(
-            model,
-            system,
-            rotation,
-            outputs,
-            None,
-            device=torch.device("cpu"),
-            dtype=torch.float64,
-        )
-
-        assert "forces" in out
-        forces = out["forces"].block().values.squeeze(-1)  # (n_atoms, 3) for N=1
-        expected = -2.0 * positions
-        assert torch.allclose(forces, expected, atol=1e-12)
-
-    def test_forces_with_rotation(self):
-        """Forces in rotated frame should equal R @ (forces in lab frame).
-        For E=sum(pos^2), forces_lab = -2*pos_lab.
-        In rotated frame: forces_rot = -dE/d(pos_rot) where pos_rot = pos_lab @ R.T.
-        Since E = sum((pos_rot @ R)^2) = sum(pos_rot^2) (R is orthogonal),
-        forces_rot = -2*pos_rot = -2*(pos_lab @ R.T).
-        """
-        model = _QuadraticEnergyModel()
-        positions = torch.tensor(
-            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=torch.float64
-        )
-        system = System(
-            types=torch.tensor([1, 1]),
-            positions=positions,
-            cell=torch.zeros(3, 3, dtype=torch.float64),
-            pbc=torch.tensor([False, False, False]),
-        )
-        # Random rotation
-        rng = np.random.default_rng(42)
-        R_scipy = Rotation.random(random_state=rng)
-        R = torch.tensor(R_scipy.as_matrix(), dtype=torch.float64)
-        outputs = {"energy": ModelOutput(sample_kind="system")}
-
-        out = _evaluate_with_gradients(
-            model,
-            system,
-            R.unsqueeze(0),
-            outputs,
-            None,
-            device=torch.device("cpu"),
-            dtype=torch.float64,
-        )
-
-        forces_rot = out["forces"].block().values.squeeze(-1)
-        expected_rot = -2.0 * (positions @ R.T)
-        assert torch.allclose(forces_rot, expected_rot, atol=1e-12)
-
-    def test_stress_periodic_system(self):
-        """For a periodic system with E=sum(pos^2), check stress via strain trick.
-
-        With strain trick: pos_final = pos_rot @ strain, so
-        E = sum((pos_rot @ strain)^2) = sum_i sum_a (sum_b pos_rot_ib * strain_ba)^2
-        dE/d(strain_cd) = 2 * sum_i sum_a (pos_rot @ strain)_ia * pos_rot_ic * delta_da
-                        = 2 * (pos_rot.T @ (pos_rot @ strain))_{ca}  (at strain=I)
-                        = 2 * pos_rot.T @ pos_rot
-        stress = (1/V) * dE/d(strain) = (2/V) * pos_rot.T @ pos_rot
-        """
-        model = _QuadraticEnergyModel()
+    @staticmethod
+    def _system(*, pbc=(False, False, False)):
         positions = torch.tensor(
             [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]], dtype=torch.float64
         )
-        cell = torch.eye(3, dtype=torch.float64) * 5.0
-        system = System(
+        return System(
             types=torch.tensor([1, 1]),
             positions=positions,
-            cell=cell,
-            pbc=torch.tensor([True, True, True]),
-        )
-        R = torch.eye(3, dtype=torch.float64).unsqueeze(0)
-        outputs = {"energy": ModelOutput(sample_kind="system")}
-
-        out = _evaluate_with_gradients(
-            model,
-            system,
-            R,
-            outputs,
-            None,
-            device=torch.device("cpu"),
-            dtype=torch.float64,
+            cell=5.0 * torch.diag(torch.tensor(pbc, dtype=torch.float64)),
+            pbc=torch.tensor(pbc),
         )
 
-        assert "stress" in out
-        stress = out["stress"].block().values.squeeze(0).squeeze(-1)  # (3, 3)
-        volume = torch.abs(torch.linalg.det(cell))
-        expected_stress = 2.0 * positions.T @ positions / volume
-        assert torch.allclose(stress, expected_stress, atol=1e-12)
+    @pytest.mark.parametrize(
+        "periodic",
+        [False, True],
+    )
+    def test_quadratic_derivatives_for_rotation_batch(self, periodic):
+        """Autograd returns exact rotated-frame forces and periodic stress."""
+        pbc = (periodic,) * 3
+        system = self._system(pbc=pbc)
+        rotations = torch.cat(
+            [
+                torch.eye(3, dtype=torch.float64).unsqueeze(0),
+                torch.tensor(
+                    Rotation.random(2, random_state=7).as_matrix(),
+                    dtype=torch.float64,
+                ),
+            ]
+        )
+        result = _evaluate_gradients(_QuadraticEnergyModel(), system, rotations)
 
-    def test_no_stress_for_nonperiodic(self):
-        """Non-periodic systems should not produce stress output."""
-        model = _QuadraticEnergyModel()
+        n_atoms = len(system)
+        forces = result["forces"].block().values.squeeze(-1)
+        expected_forces = torch.cat(
+            [-2.0 * (system.positions @ rotation.T) for rotation in rotations]
+        )
+        assert torch.allclose(forces, expected_forces, atol=1e-12)
+        assert result["forces"].block().samples.names == ["system", "atom"]
+        assert result["forces"].block().samples.values.tolist() == [
+            [rotation, atom]
+            for rotation in range(len(rotations))
+            for atom in range(n_atoms)
+        ]
+
+        if not periodic:
+            assert "stress" not in result
+            return
+
+        stresses = result["stress"].block().values.squeeze(-1)
+        volume = torch.abs(torch.linalg.det(system.cell))
+        expected_stresses = torch.stack(
+            [
+                2.0
+                * (system.positions @ rotation.T).T
+                @ (system.positions @ rotation.T)
+                / volume
+                for rotation in rotations
+            ]
+        )
+        assert torch.allclose(stresses, expected_stresses, atol=1e-12)
+
+    @pytest.mark.parametrize(
+        ("pbc", "cell"),
+        [
+            ([False, False, False], torch.zeros(3, 3)),
+            ([True, False, False], torch.diag(torch.tensor([5.0, 0.0, 0.0]))),
+            ([True, True, False], torch.diag(torch.tensor([5.0, 5.0, 0.0]))),
+        ],
+    )
+    def test_stress_is_omitted_without_three_periodic_dimensions(self, pbc, cell):
+        positions = torch.tensor([[0.1, 0.2, 0.3]], dtype=torch.float64)
         system = System(
             types=torch.tensor([1]),
-            positions=torch.tensor([[1.0, 2.0, 3.0]], dtype=torch.float64),
-            cell=torch.zeros(3, 3, dtype=torch.float64),
-            pbc=torch.tensor([False, False, False]),
-        )
-        R = torch.eye(3, dtype=torch.float64).unsqueeze(0)
-        outputs = {"energy": ModelOutput(sample_kind="system")}
-
-        out = _evaluate_with_gradients(
-            model,
-            system,
-            R,
-            outputs,
-            None,
-            device=torch.device("cpu"),
-            dtype=torch.float64,
-        )
-
-        assert "forces" in out
-        assert "stress" not in out
-
-    def test_forces_batched_rotations(self):
-        """N>1 rotations should produce per-system forces that match what the same
-        rotations would produce one at a time. Validates the batched-gradient refactor.
-        """
-        model = _QuadraticEnergyModel()
-        positions = torch.tensor(
-            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=torch.float64
-        )
-        system = System(
-            types=torch.tensor([1, 1]),
             positions=positions,
-            cell=torch.zeros(3, 3, dtype=torch.float64),
-            pbc=torch.tensor([False, False, False]),
+            cell=cell.to(dtype=torch.float64),
+            pbc=torch.tensor(pbc),
         )
+        result = _evaluate_gradients(_QuadraticEnergyModel(), system)
 
-        rng = np.random.default_rng(7)
-        rotations = torch.stack(
-            [
-                torch.tensor(
-                    Rotation.random(random_state=rng).as_matrix(),
-                    dtype=torch.float64,
-                )
-                for _ in range(3)
-            ],
-            dim=0,
-        )
-        outputs = {"energy": ModelOutput(sample_kind="system")}
+        assert "stress" not in result
+        forces = result["forces"].block().values.squeeze(-1)
+        assert torch.allclose(forces, -2.0 * positions, atol=1e-12)
 
-        out = _evaluate_with_gradients(
-            model,
-            system,
-            rotations,
-            outputs,
-            None,
-            device=torch.device("cpu"),
-            dtype=torch.float64,
-        )
-
-        forces = out["forces"].block().values.squeeze(-1)  # (3 * n_atoms, 3)
-        n_atoms = positions.shape[0]
-        for i in range(rotations.shape[0]):
-            R = rotations[i]
-            expected = -2.0 * (positions @ R.T)
-            actual = forces[i * n_atoms : (i + 1) * n_atoms]
-            assert torch.allclose(actual, expected, atol=1e-12)
-
-        # also verify sample labels are (system=i, atom=j) in row-major order
-        samples = out["forces"].block().samples
-        sys_col = samples.column("system")
-        atom_col = samples.column("atom")
-        for i in range(rotations.shape[0]):
-            for j in range(n_atoms):
-                row = i * n_atoms + j
-                assert int(sys_col[row]) == i
-                assert int(atom_col[row]) == j
-
-    def test_stress_batched_rotations(self):
-        """Stress under N>1 rotations: rotation-invariant magnitude per system, with
-        rotated principal axes."""
-        model = _QuadraticEnergyModel()
-        positions = torch.tensor(
-            [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]], dtype=torch.float64
-        )
-        cell = torch.eye(3, dtype=torch.float64) * 5.0
+    @pytest.mark.parametrize(
+        "cell",
+        [
+            torch.tensor([[5.0, 0.0, 0.0], [0.0, 5.0, 0.0], [5.0, 5.0, 0.0]]),
+            torch.diag(torch.tensor([float("nan"), 5.0, 5.0])),
+            torch.diag(torch.tensor([float("inf"), 5.0, 5.0])),
+        ],
+    )
+    def test_invalid_fully_periodic_cell_is_rejected(self, cell):
         system = System(
-            types=torch.tensor([1, 1]),
-            positions=positions,
-            cell=cell,
+            types=torch.tensor([1]),
+            positions=torch.tensor([[0.1, 0.2, 0.3]], dtype=torch.float64),
+            cell=cell.to(dtype=torch.float64),
             pbc=torch.tensor([True, True, True]),
         )
 
-        rng = np.random.default_rng(11)
-        rotations = torch.stack(
-            [
-                torch.tensor(
-                    Rotation.random(random_state=rng).as_matrix(),
-                    dtype=torch.float64,
-                )
-                for _ in range(2)
-            ],
-            dim=0,
-        )
-        outputs = {"energy": ModelOutput(sample_kind="system")}
+        with pytest.raises(ValueError, match="singular or non-finite"):
+            _evaluate_gradients(_QuadraticEnergyModel(), system)
 
-        out = _evaluate_with_gradients(
+    @pytest.mark.parametrize(
+        "model",
+        [
+            pytest.param(_ConstantEnergyModel(connected=True), id="connected"),
+            pytest.param(
+                _ConstantEnergyModel(connected=True, connect_first_only=True),
+                id="partly-connected-batch",
+            ),
+            pytest.param(_ParameterOnlyEnergyModel(), id="parameter-only"),
+        ],
+    )
+    def test_coordinate_independent_energy_has_zero_derivatives(self, model):
+        result = _evaluate_gradients(
             model,
-            system,
-            rotations,
-            outputs,
-            None,
-            device=torch.device("cpu"),
-            dtype=torch.float64,
+            self._system(pbc=(True, True, True)),
+            torch.eye(3, dtype=torch.float64).repeat(2, 1, 1),
         )
 
-        assert "stress" in out
-        stress_values = out["stress"].block().values.squeeze(-1)  # (N, 3, 3)
-        volume = torch.abs(torch.linalg.det(cell))
-        for i in range(rotations.shape[0]):
-            R = rotations[i]
-            rotated_pos = positions @ R.T
-            expected = 2.0 * rotated_pos.T @ rotated_pos / volume
-            assert torch.allclose(stress_values[i], expected, atol=1e-12)
+        for name in ("forces", "stress"):
+            values = result[name].block().values
+            assert torch.equal(values, torch.zeros_like(values))
+
+    def test_detached_constant_energy_has_zero_forces(self):
+        model = _symmetrized(_ConstantEnergyModel(), batch_size=2)
+        with pytest.warns(RuntimeWarning, match="detached.*zero derivatives"):
+            out = model(
+                [_two_atom_system()],
+                {"energy": ModelOutput(sample_kind="system")},
+                compute_gradients=True,
+            )
+
+        assert torch.count_nonzero(out["forces_l1_mean"].block().values) == 0
 
 
 class TestSymmetrizedModelForward:
@@ -734,19 +1170,19 @@ class TestSymmetrizedModelForward:
         return _two_atom_system(_POSITIONS_B, dtype=dtype)
 
     def test_scalar_forward_outputs(self):
-        model = SymmetrizedModel(
+        model = _symmetrized(
             _QuadraticEnergyModel(),
             max_o3_lambda_character=1,
             max_o3_lambda_target=0,
             batch_size=2,
-        ).to(dtype=torch.float64)
+        )
 
-        outputs = {"energy": ModelOutput(sample_kind="system")}
-        result = model([self._make_system()], outputs)
+        result = model([self._make_system()], _ENERGY_OUTPUTS)
 
         assert "energy_l0_mean" in result
         assert "energy_l0_var" in result
         assert "energy_l0_norm_squared" in result
+        assert result["energy_l0_mean"].keys.names == ["o3_lambda", "o3_sigma"]
         assert torch.allclose(
             result["energy_l0_mean"].block().values,
             torch.tensor([[[5.0]]], dtype=torch.float64),
@@ -754,17 +1190,17 @@ class TestSymmetrizedModelForward:
         )
 
     def test_forward_character_projections(self):
-        model = SymmetrizedModel(
+        model = _symmetrized(
             _QuadraticEnergyModel(),
             max_o3_lambda_character=1,
             max_o3_lambda_target=0,
+            max_o3_lambda_grid=2,
             batch_size=1,
-        ).to(dtype=torch.float64)
+        )
 
-        outputs = {"energy": ModelOutput(sample_kind="system")}
         result = model(
             [self._make_system()],
-            outputs,
+            _ENERGY_OUTPUTS,
             compute_character_projections=True,
         )
 
@@ -784,50 +1220,24 @@ class TestSymmetrizedModelForward:
 
             def forward(self, systems, outputs, selected_atoms):
                 self.recorded_grad_states.append(torch.is_grad_enabled())
-                # shape (n_systems=1, n_properties=1): no components, so 2D
                 values = torch.tensor(
                     [[1.0]],
                     dtype=systems[0].positions.dtype,
                     device=systems[0].positions.device,
                 )
-                tensor = TensorMap(
-                    Labels(
-                        ["_"],
-                        torch.tensor([[0]], dtype=torch.int64, device=values.device),
-                    ),
-                    [
-                        TensorBlock(
-                            values=values,
-                            samples=Labels(
-                                ["system"],
-                                torch.tensor(
-                                    [[0]], dtype=torch.int64, device=values.device
-                                ),
-                            ),
-                            components=[],
-                            properties=Labels(
-                                ["energy"],
-                                torch.tensor(
-                                    [[0]], dtype=torch.int64, device=values.device
-                                ),
-                            ),
-                        )
-                    ],
-                )
-                return {"energy": tensor}
+                return {"energy": _system_tensor_map(values)}
 
         base_model = _GradStateModel()
-        model = SymmetrizedModel(
+        model = _symmetrized(
             base_model,
             max_o3_lambda_character=1,
             max_o3_lambda_target=0,
             batch_size=1,
-        ).to(dtype=torch.float64)
+        )
 
-        outputs = {"energy": ModelOutput(sample_kind="system")}
         result = model(
             [self._make_system()],
-            outputs,
+            _ENERGY_OUTPUTS,
             compute_character_projections=True,
             compute_gradients=False,
         )
@@ -841,22 +1251,21 @@ class TestSymmetrizedModelForward:
         # Regression: setting storage_device must only move tensors, not
         # change numerical results, in both evaluation modes (outputs are
         # detached before back-rotation, so offloading is safe with gradients)
-        outputs = {"energy": ModelOutput(sample_kind="system")}
         systems = [self._make_system()]
 
         results = {}
         for storage_device in (None, "cpu"):
             base_model = _QuadraticEnergyModel()
-            model = SymmetrizedModel(
+            model = _symmetrized(
                 base_model,
                 max_o3_lambda_character=1,
                 max_o3_lambda_target=1,
                 batch_size=2,
                 storage_device=storage_device,
-            ).to(dtype=torch.float64)
+            )
             results[storage_device] = model(
                 systems,
-                outputs,
+                _ENERGY_OUTPUTS,
                 compute_character_projections=not compute_gradients,
                 compute_gradients=compute_gradients,
             )
@@ -876,36 +1285,120 @@ class TestSymmetrizedModelForward:
                     atol=1e-12,
                 ), f"storage device changed values for '{name}' / key {key}"
 
-    def test_compute_gradients_produces_forces(self):
-        # Regression: with `compute_gradients=True`, _evaluate_with_gradients must
-        # run autograd through the base model and inject "forces" into the output
-        # stream so the symmetrization pipeline produces forces_l1_*. The previous
-        # bug coupled autograd enablement to the output offloading policy and could
-        # silently break this path.
-        outputs = {"energy": ModelOutput(sample_kind="system")}
-        model = SymmetrizedModel(
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+    @pytest.mark.parametrize("compute_gradients", [False, True])
+    def test_cuda_evaluation_can_offload_results_to_cpu(self, compute_gradients):
+        """Exercise the split-device path for values, Wigner work, and gradients."""
+        system = self._make_system().to(device="cuda")
+        results = {}
+        for storage_device in (None, "cpu"):
+            model = _symmetrized(
+                _QuadraticEnergyModel(),
+                max_o3_lambda_character=1,
+                max_o3_lambda_target=1,
+                batch_size=2,
+                storage_device=storage_device,
+            ).to(device="cuda")
+            results[storage_device] = model(
+                [system],
+                _ENERGY_OUTPUTS,
+                compute_character_projections=not compute_gradients,
+                compute_gradients=compute_gradients,
+            )
+
+        assert set(results[None]) == set(results["cpu"])
+        for name, cpu_tensor in results["cpu"].items():
+            cuda_tensor = results[None][name]
+            assert cuda_tensor.keys == cpu_tensor.keys
+            for cuda_block, cpu_block in zip(
+                cuda_tensor.blocks(), cpu_tensor.blocks(), strict=True
+            ):
+                assert cuda_block.values.device.type == "cuda"
+                assert cpu_block.values.device.type == "cpu"
+                assert torch.allclose(
+                    cuda_block.values.cpu(), cpu_block.values, atol=1e-11
+                )
+
+    def test_compute_gradients_produces_exact_forces_and_periodic_stress(self):
+        positions = torch.tensor(
+            [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]], dtype=torch.float64
+        )
+        cell = torch.tensor(
+            [[3.0, 0.0, 0.0], [0.2, 4.0, 0.0], [0.1, 0.3, 5.0]],
+            dtype=torch.float64,
+        )
+        periodic = System(
+            types=torch.tensor([1, 1]),
+            positions=positions,
+            cell=cell,
+            pbc=torch.tensor([True, True, True]),
+        )
+        nonperiodic = self._make_second_system()
+        model = _symmetrized(
             _QuadraticEnergyModel(),
             max_o3_lambda_character=1,
-            max_o3_lambda_target=1,
-            batch_size=1,
-        ).to(dtype=torch.float64)
+            batch_size=2,
+        )
 
-        result = model([self._make_system()], outputs, compute_gradients=True)
+        result = model([periodic, nonperiodic], _ENERGY_OUTPUTS, compute_gradients=True)
+
+        forces = result["forces_l1_mean"].block()
+        expected_forces = torch.cat(
+            [-2.0 * periodic.positions, -2.0 * nonperiodic.positions]
+        ).roll(-1, dims=1)
+        assert torch.equal(
+            forces.samples.values,
+            torch.tensor([[0, 0], [0, 1], [1, 0], [1, 1]]),
+        )
+        assert torch.allclose(forces.values.squeeze(-1), expected_forces, atol=1e-11)
+
+        expected_stress = (
+            2.0 * positions.T @ positions / torch.abs(torch.linalg.det(cell))
+        )
+        expected_stress = expected_stress.reshape(1, 3, 3, 1)
+        stress_l0 = result["stress_l0_mean"].block()
+        stress_l2 = result["stress_l2_mean"].block()
+        assert torch.equal(stress_l0.samples.values, torch.tensor([[0]]))
+        assert torch.equal(stress_l2.samples.values, torch.tensor([[0]]))
+        assert torch.allclose(
+            stress_l0.values,
+            _l0_components_from_matrices(expected_stress),
+            atol=1e-11,
+        )
+        assert torch.allclose(
+            stress_l2.values,
+            _l2_components_from_matrices(expected_stress),
+            atol=1e-11,
+        )
+
+        for name in ("forces_l1_var", "stress_l0_var", "stress_l2_var"):
+            assert torch.max(torch.abs(result[name].block().values)) < 1e-11
+
+    def test_compute_gradients_omits_3d_stress_for_partial_pbc(self):
+        system = System(
+            types=torch.tensor([1]),
+            positions=torch.tensor([[0.1, 0.2, 0.3]], dtype=torch.float64),
+            cell=torch.diag(torch.tensor([5.0, 5.0, 0.0], dtype=torch.float64)),
+            pbc=torch.tensor([True, True, False]),
+        )
+        model = _symmetrized(_QuadraticEnergyModel())
+
+        result = model(
+            [system],
+            _ENERGY_OUTPUTS,
+            compute_gradients=True,
+        )
 
         assert "forces_l1_mean" in result
-        forces = result["forces_l1_mean"].block().values
-        # Forces for E=sum(pos^2) at positions [[1,0,0],[0,2,0]] have magnitudes
-        # [2, 4]; back-rotated/averaged forces retain non-trivial values for at
-        # least one atom (averaging is over O(3), not over atoms).
-        assert torch.any(forces.abs() > 0.5)
+        assert torch.all(torch.isfinite(result["forces_l1_mean"].block().values))
+        assert all(not name.startswith("stress_") for name in result)
 
     def test_vector_like_forward_outputs(self):
-        model = SymmetrizedModel(
+        model = _symmetrized(
             _EnergyAndVectorModel(),
             max_o3_lambda_character=1,
-            max_o3_lambda_target=1,
             batch_size=2,
-        ).to(dtype=torch.float64)
+        )
 
         outputs = {
             "energy": ModelOutput(sample_kind="system"),
@@ -919,12 +1412,11 @@ class TestSymmetrizedModelForward:
 
     def test_selected_atoms_are_mapped_per_outer_system(self):
         systems = [self._make_system(), self._make_second_system()]
-        model = SymmetrizedModel(
+        model = _symmetrized(
             _EnergyAndVectorModel(),
             max_o3_lambda_character=1,
-            max_o3_lambda_target=1,
             batch_size=5,
-        ).to(dtype=torch.float64)
+        )
 
         outputs = {
             "energy": ModelOutput(sample_kind="system"),
@@ -955,12 +1447,11 @@ class TestSymmetrizedModelForward:
 
     def test_selected_atoms_can_be_empty_for_some_systems(self):
         systems = [self._make_system(), self._make_second_system()]
-        model = SymmetrizedModel(
+        model = _symmetrized(
             _EnergyAndVectorModel(),
             max_o3_lambda_character=1,
-            max_o3_lambda_target=1,
             batch_size=5,
-        ).to(dtype=torch.float64)
+        )
 
         outputs = {
             "non_conservative_forces": ModelOutput(sample_kind="atom"),
@@ -988,15 +1479,13 @@ class TestCharacterProjectionValidation:
     def test_equivariance_only_without_character_lambda(self):
         # the common use case: max_o3_lambda_character can be omitted entirely,
         # and the default grid then follows the target angular momentum
-        model = SymmetrizedModel(
+        model = _symmetrized(
             _QuadraticEnergyModel(),
             max_o3_lambda_target=0,
-            batch_size=4,
-        ).to(dtype=torch.float64)
+        )
         assert model.max_o3_lambda_grid == 1  # 2 * max_o3_lambda_target + 1
 
-        outputs = {"energy": ModelOutput(sample_kind="system")}
-        result = model([self._make_system()], outputs)
+        result = model([self._make_system()], _ENERGY_OUTPUTS)
         assert set(result.keys()) == {
             "energy_l0_mean",
             "energy_l0_var",
@@ -1004,32 +1493,268 @@ class TestCharacterProjectionValidation:
         }
 
     def test_character_projections_require_character_lambda(self):
-        model = SymmetrizedModel(
+        model = _symmetrized(
             _QuadraticEnergyModel(),
             max_o3_lambda_target=0,
-        ).to(dtype=torch.float64)
+        )
 
-        outputs = {"energy": ModelOutput(sample_kind="system")}
         with pytest.raises(ValueError, match="max_o3_lambda_character must be set"):
-            model([self._make_system()], outputs, compute_character_projections=True)
+            model(
+                [self._make_system()],
+                _ENERGY_OUTPUTS,
+                compute_character_projections=True,
+            )
 
     def test_character_projections_insufficient_grid_raises(self):
         # a grid unable to integrate the projections exactly produces silently
         # wrong results (isotypical fractions far above 1), so it must be
         # rejected when projections are requested, and only then
-        model = SymmetrizedModel(
+        model = _symmetrized(
             _QuadraticEnergyModel(),
             max_o3_lambda_target=0,
-            max_o3_lambda_character=2,
-            max_o3_lambda_grid=1,  # Lebedev order 3 < 2 * 2
-        ).to(dtype=torch.float64)
+            max_o3_lambda_character=1,
+            max_o3_lambda_grid=1,  # K=2 gamma points, but products require 3
+        )
 
-        outputs = {"energy": ModelOutput(sample_kind="system")}
         with pytest.raises(ValueError, match="too coarse for character projections"):
-            model([self._make_system()], outputs, compute_character_projections=True)
+            model(
+                [self._make_system()],
+                _ENERGY_OUTPUTS,
+                compute_character_projections=True,
+            )
 
-        result = model([self._make_system()], outputs)
+        result = model([self._make_system()], _ENERGY_OUTPUTS)
         assert "energy_l0_mean" in result
+
+
+class TestExplicitGradientRejection:
+    @pytest.mark.parametrize("compute_gradients", [False, True])
+    def test_requested_explicit_gradient_is_rejected_before_evaluation(
+        self, compute_gradients
+    ):
+        class _CountingModel(_QuadraticEnergyModel):
+            def __init__(self):
+                super().__init__()
+                self.call_count = 0
+
+            def forward(self, systems, outputs, selected_atoms=None):
+                self.call_count += 1
+                return super().forward(systems, outputs, selected_atoms)
+
+        base_model = _CountingModel()
+        model = SymmetrizedModel(base_model, max_o3_lambda_target=1)
+        outputs = {
+            "energy": ModelOutput(
+                sample_kind="system", explicit_gradients=["positions"]
+            )
+        }
+
+        with pytest.raises(ValueError, match="does not support explicit gradients"):
+            model(
+                [_two_atom_system()],
+                outputs,
+                compute_gradients=compute_gradients,
+            )
+        assert base_model.call_count == 0
+
+    @pytest.mark.parametrize("compute_gradients", [False, True])
+    def test_unsolicited_attached_gradient_is_rejected(self, compute_gradients):
+        model = SymmetrizedModel(_ExplicitGradientEnergyModel(), max_o3_lambda_target=1)
+        with pytest.raises(
+            ValueError,
+            match="output 'energy' contains explicit gradient 'positions'",
+        ):
+            model(
+                [_two_atom_system()],
+                {"energy": ModelOutput(sample_kind="system")},
+                compute_gradients=compute_gradients,
+            )
+
+
+class TestBaseOutputValidation:
+    @pytest.mark.parametrize("batch_size", [1, 3])
+    def test_non_leading_system_sample_column(self, batch_size):
+        model = _symmetrized(
+            _NonLeadingSystemSampleModel(),
+            max_o3_lambda_target=0,
+            batch_size=batch_size,
+        )
+        result = model(
+            [_two_atom_system()],
+            {"mtt::feature": ModelOutput(sample_kind="atom")},
+        )
+
+        block = result["mtt::feature_mean"].block()
+        assert block.samples.names == ["system", "atom"]
+        assert block.samples.values.tolist() == [[0, 0], [0, 1]]
+
+    @pytest.mark.parametrize("compute_gradients", [False, True])
+    def test_missing_requested_output_is_rejected(self, compute_gradients):
+        model = SymmetrizedModel(
+            _QuadraticEnergyModel(), max_o3_lambda_target=1, batch_size=4
+        )
+        with pytest.raises(
+            ValueError,
+            match="did not return requested output.*mtt::missing",
+        ):
+            model(
+                [_two_atom_system()],
+                {
+                    "energy": ModelOutput(sample_kind="system"),
+                    "mtt::missing": ModelOutput(sample_kind="system"),
+                },
+                compute_gradients=compute_gradients,
+            )
+
+    @pytest.mark.parametrize(
+        ("colliding_name", "compute_gradients"),
+        [("energy_l0", False), ("forces_l1", True)],
+    )
+    def test_decomposed_output_name_collisions_are_rejected(
+        self, colliding_name, compute_gradients
+    ):
+        model = _symmetrized(_ConstantEnergyModel(), batch_size=4)
+        outputs = {
+            "energy": ModelOutput(sample_kind="system"),
+            colliding_name: ModelOutput(sample_kind="system"),
+        }
+
+        with pytest.raises(ValueError, match=f"both produce '{colliding_name}'"):
+            model(
+                [_two_atom_system()],
+                outputs,
+                compute_gradients=compute_gradients,
+            )
+
+
+class TestConstructorValidation:
+    @pytest.mark.parametrize(
+        ("name", "value"),
+        [
+            ("max_o3_lambda_target", 1.0),
+            ("max_o3_lambda_target", True),
+            ("max_o3_lambda_character", 1.0),
+            ("max_o3_lambda_character", True),
+            ("max_o3_lambda_grid", 1.0),
+            ("max_o3_lambda_grid", True),
+            ("batch_size", 1.0),
+            ("batch_size", True),
+            ("wigner_cache_max_bytes", 1.0),
+            ("wigner_cache_max_bytes", True),
+        ],
+    )
+    def test_rejects_non_integer_values(self, name, value):
+        arguments = {"max_o3_lambda_target": 0, name: value}
+        with pytest.raises(TypeError, match=f"{name} must be an integer"):
+            SymmetrizedModel(_QuadraticEnergyModel(), **arguments)
+
+    @pytest.mark.parametrize(
+        ("name", "value"),
+        [
+            ("max_o3_lambda_target", -1),
+            ("max_o3_lambda_character", -1),
+            ("max_o3_lambda_grid", -1),
+            ("batch_size", 0),
+            ("batch_size", -1),
+            ("wigner_cache_max_bytes", -1),
+        ],
+    )
+    def test_rejects_out_of_range_values(self, name, value):
+        arguments = {"max_o3_lambda_target": 0, name: value}
+        with pytest.raises(ValueError, match=name):
+            SymmetrizedModel(_QuadraticEnergyModel(), **arguments)
+
+    def test_accepts_numpy_integer_values(self):
+        model = SymmetrizedModel(
+            _QuadraticEnergyModel(),
+            max_o3_lambda_target=np.int64(0),
+            max_o3_lambda_character=np.int64(1),
+            max_o3_lambda_grid=np.int64(3),
+            batch_size=np.int64(2),
+            wigner_cache_max_bytes=np.int64(1024),
+        )
+        assert model.max_o3_lambda_target == 0
+        assert model.max_o3_lambda_character == 1
+        assert model.max_o3_lambda_grid == 3
+        assert model.batch_size == 2
+        assert model.wigner_cache_max_bytes == 1024
+
+
+class TestMPSPolicy:
+    def test_storage_device_rejects_before_quadrature(self, monkeypatch):
+        def quadrature_must_not_run(*args, **kwargs):
+            raise AssertionError("quadrature construction was reached")
+
+        monkeypatch.setattr(
+            symmetrized_model_module,
+            "_choose_quadrature",
+            quadrature_must_not_run,
+        )
+        with pytest.raises(ValueError, match="does not support MPS"):
+            SymmetrizedModel(
+                _ConstantEnergyModel(),
+                max_o3_lambda_target=0,
+                storage_device="mps",
+            )
+
+    def test_to_mps_rejects_before_cache_or_subtree_mutation(self):
+        model = SymmetrizedModel(
+            _ConstantEnergyModel(),
+            max_o3_lambda_target=0,
+            max_o3_lambda_character=1,
+            batch_size=4,
+        ).to(dtype=torch.float64)
+        model(
+            [_two_atom_system()],
+            {"energy": ModelOutput(sample_kind="system")},
+            compute_character_projections=True,
+        )
+        before_rotations = model.so3_rotations.clone()
+        before_cache = model._wigner_cache
+
+        with pytest.raises(ValueError, match="does not support MPS"):
+            model.to("mps")
+
+        assert torch.equal(model.so3_rotations, before_rotations)
+        assert model._wigner_cache is before_cache
+
+    @pytest.mark.skipif(not can_use_mps_backend(), reason="MPS is not available")
+    def test_mixed_base_state_rejects_before_quadrature(self, monkeypatch):
+        class MixedStateModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.cpu_parameter = torch.nn.Parameter(torch.ones(1))
+                self.register_buffer("mps_buffer", torch.ones(1, device="mps"))
+
+        def quadrature_must_not_run(*args, **kwargs):
+            raise AssertionError("quadrature construction was reached")
+
+        monkeypatch.setattr(
+            symmetrized_model_module,
+            "_choose_quadrature",
+            quadrature_must_not_run,
+        )
+        with pytest.raises(ValueError, match="does not support MPS"):
+            SymmetrizedModel(MixedStateModel(), max_o3_lambda_target=0)
+
+    @pytest.mark.skipif(not can_use_mps_backend(), reason="MPS is not available")
+    def test_mps_system_rejects_before_model_call(self):
+        class CountingModel(_ConstantEnergyModel):
+            def __init__(self):
+                super().__init__()
+                self.calls = 0
+
+            def forward(self, *args, **kwargs):
+                self.calls += 1
+                return super().forward(*args, **kwargs)
+
+        base = CountingModel()
+        model = SymmetrizedModel(base, max_o3_lambda_target=0)
+        system = _two_atom_system(dtype=torch.float32).to(device="mps")
+
+        with pytest.raises(ValueError, match="does not support MPS"):
+            model([system], {"energy": ModelOutput(sample_kind="system")})
+        assert base.calls == 0
 
 
 class TestPerSystemHelpers:
@@ -1040,16 +1765,15 @@ class TestPerSystemHelpers:
         # the energy of _AnisotropicEnergyModel has content only at lambda=0 and
         # lambda=1 (both in the proper chi_sigma=+1 sector), so with a sufficient
         # grid the fractions must sum to 1 and vanish everywhere else
-        model = SymmetrizedModel(
+        model = _symmetrized(
             _AnisotropicEnergyModel(),
             max_o3_lambda_target=0,
             max_o3_lambda_character=3,
             batch_size=64,
-        ).to(dtype=torch.float64)
+        )
 
-        outputs = {"energy": ModelOutput(sample_kind="system")}
         result = model(
-            self._make_systems(), outputs, compute_character_projections=True
+            self._make_systems(), _ENERGY_OUTPUTS, compute_character_projections=True
         )
 
         proper, improper, lambdas = per_system_character_fractions(result, "energy_l0")
@@ -1061,14 +1785,105 @@ class TestPerSystemHelpers:
         assert torch.all(improper.abs() < 1e-8)
         assert torch.all(proper[:, 2:].abs() < 1e-8)
 
+    def test_negative_manual_diagnostics_are_rejected(self):
+        samples = Labels("system", torch.tensor([[0]]))
+        properties = Labels.range("p", 1)
+
+        def single(value, keys=None):
+            return _single_block_tensor_map(
+                torch.tensor([[value]], dtype=torch.float64),
+                samples=samples,
+                components=[],
+                properties=properties,
+                keys=keys,
+            )
+
+        character_keys = Labels(["chi_lambda", "chi_sigma"], torch.tensor([[0, 1]]))
+        with pytest.raises(ValueError, match="squared norm"):
+            per_system_character_fractions(
+                {
+                    "x_character_projection": single(1.0, character_keys),
+                    "x_norm_squared": single(-1.0),
+                },
+                "x",
+            )
+        with pytest.raises(ValueError, match="character-projection"):
+            per_system_character_fractions(
+                {
+                    "x_character_projection": single(-1.0, character_keys),
+                    "x_norm_squared": single(1.0),
+                },
+                "x",
+            )
+        with pytest.raises(ValueError, match="zero squared norm"):
+            per_system_character_fractions(
+                {
+                    "x_character_projection": single(1.0, character_keys),
+                    "x_norm_squared": single(0.0),
+                },
+                "x",
+            )
+        cancelling_norm = _single_block_tensor_map(
+            torch.tensor([[-1.0, 2.0]], dtype=torch.float64),
+            samples=samples,
+            components=[],
+            properties=Labels.range("p", 2),
+        )
+        cancelling_projection = _single_block_tensor_map(
+            torch.tensor([[1.0, 0.0]], dtype=torch.float64),
+            samples=samples,
+            components=[],
+            properties=Labels.range("p", 2),
+            keys=character_keys,
+        )
+        with pytest.raises(ValueError, match="squared norm"):
+            per_system_character_fractions(
+                {
+                    "x_character_projection": cancelling_projection,
+                    "x_norm_squared": cancelling_norm,
+                },
+                "x",
+            )
+        with pytest.raises(ValueError, match="variance values"):
+            per_system_equivariance_rmse(
+                {"x_var": single(-1.0), "x_mean": single(0.0)}, "x"
+            )
+
+    def test_character_fractions_support_empty_samples(self):
+        samples = Labels("system", torch.empty((0, 1), dtype=torch.int64))
+        properties = Labels.range("p", 1)
+        character_keys = Labels(["chi_lambda", "chi_sigma"], torch.tensor([[0, 1]]))
+        outputs = {
+            "x_norm_squared": _single_block_tensor_map(
+                torch.empty((0, 1), dtype=torch.float64),
+                samples=samples,
+                components=[],
+                properties=properties,
+            ),
+            "x_character_projection": _single_block_tensor_map(
+                torch.empty((0, 3, 1), dtype=torch.float64),
+                samples=samples,
+                components=[Labels.range("o3_mu", 3)],
+                properties=properties,
+                keys=character_keys,
+            ),
+        }
+
+        proper, improper, lambdas = per_system_character_fractions(
+            outputs, "x", n_systems=2
+        )
+
+        assert lambdas.tolist() == [0]
+        assert proper.shape == improper.shape == (2, 1)
+        assert torch.count_nonzero(proper) == torch.count_nonzero(improper) == 0
+
     def test_equivariance_rmse_vanishes_for_equivariant_output(self):
         # forces of _EnergyAndVectorModel are the (rotated) positions, which
         # back-rotate exactly: the equivariance RMSE must be zero per system
-        model = SymmetrizedModel(
+        model = _symmetrized(
             _EnergyAndVectorModel(),
-            max_o3_lambda_target=1,
             batch_size=8,
-        ).to(dtype=torch.float64)
+        )
 
         outputs = {"non_conservative_forces": ModelOutput(sample_kind="atom")}
         result = model(self._make_systems(), outputs)
@@ -1089,32 +1904,24 @@ class TestPerSystemHelpers:
             torch.tensor([[0, 0], [0, 1], [1, 0]], dtype=torch.int64),
         )
         properties = Labels(["p"], torch.tensor([[0]], dtype=torch.int64))
-        variance = TensorMap(
-            keys,
-            [
-                TensorBlock(
-                    values=torch.tensor([[6.0], [15.0], [24.0]], dtype=torch.float64),
-                    samples=samples,
-                    components=[],
-                    properties=properties,
-                )
-            ],
+        variance = _single_block_tensor_map(
+            torch.tensor([[6.0], [15.0], [24.0]], dtype=torch.float64),
+            samples=samples,
+            components=[],
+            properties=properties,
+            keys=keys,
         )
-        mean = TensorMap(
-            keys,
-            [
-                TensorBlock(
-                    values=torch.zeros((3, 3, 1), dtype=torch.float64),
-                    samples=samples,
-                    components=[
-                        Labels(
-                            ["o3_mu"],
-                            torch.tensor([[-1], [0], [1]], dtype=torch.int64),
-                        )
-                    ],
-                    properties=properties,
+        mean = _single_block_tensor_map(
+            torch.zeros((3, 3, 1), dtype=torch.float64),
+            samples=samples,
+            components=[
+                Labels(
+                    ["o3_mu"],
+                    torch.tensor([[-1], [0], [1]], dtype=torch.int64),
                 )
             ],
+            properties=properties,
+            keys=keys,
         )
 
         rmse = per_system_equivariance_rmse(
@@ -1220,11 +2027,10 @@ class TestEquivarianceErrorMethod:
     def test_equivariant_output_has_zero_error(self):
         # forces of _EnergyAndVectorModel back-rotate exactly, so the reported
         # equivariance error must vanish; this is the invariant the metric is for
-        model = SymmetrizedModel(
+        model = _symmetrized(
             _EnergyAndVectorModel(),
-            max_o3_lambda_target=1,
             batch_size=8,
-        ).to(dtype=torch.float64)
+        )
         systems = self._make_systems()
 
         errors = model.equivariance_error(
@@ -1246,16 +2052,15 @@ class TestEquivarianceErrorMethod:
     def test_non_equivariant_output_matches_helper(self):
         # a non-invariant energy must give a strictly positive error, equal to
         # the per_system_equivariance_rmse reduction of the raw forward outputs
-        model = SymmetrizedModel(
+        model = _symmetrized(
             _AnisotropicEnergyModel(),
             max_o3_lambda_target=0,
             batch_size=8,
-        ).to(dtype=torch.float64)
+        )
         systems = self._make_systems()
-        outputs = {"energy": ModelOutput(sample_kind="system")}
 
-        errors = model.equivariance_error(systems, outputs)
-        raw = model(systems, outputs)
+        errors = model.equivariance_error(systems, _ENERGY_OUTPUTS)
+        raw = model(systems, _ENERGY_OUTPUTS)
         expected = per_system_equivariance_rmse(raw, "energy_l0", n_systems=2)
 
         values = errors["energy_l0"].block().values
@@ -1265,6 +2070,51 @@ class TestEquivarianceErrorMethod:
 
 class TestFloat64Accumulation:
     """Statistics are accumulated in float64 regardless of the model dtype."""
+
+    def test_underresolved_signed_grid_is_rejected(self):
+        position = torch.tensor(
+            [[-1.12984253e-2, 3.64940445e-4, -9.99936104e-1]],
+            dtype=torch.float64,
+        )
+        position = position / torch.linalg.norm(position)
+        system = System(
+            types=torch.tensor([1]),
+            positions=position,
+            cell=torch.zeros((3, 3), dtype=torch.float64),
+            pbc=torch.tensor([False, False, False]),
+        )
+        underresolved = SymmetrizedModel(
+            _DegreeSevenEnergyModel(),
+            max_o3_lambda_target=0,
+            max_o3_lambda_grid=12,
+            batch_size=64,
+        )
+        with pytest.raises(ValueError, match="materially negative.*Increase"):
+            underresolved([system], _ENERGY_OUTPUTS)
+
+        resolved = SymmetrizedModel(
+            _DegreeSevenEnergyModel(),
+            max_o3_lambda_target=0,
+            max_o3_lambda_character=7,
+            max_o3_lambda_grid=14,
+            batch_size=64,
+        )
+        result = resolved([system], _ENERGY_OUTPUTS, compute_character_projections=True)
+        expected = 1.0e6 * 17.0 / 137280.0
+        assert result["energy_l0_mean"].block().values.item() == pytest.approx(
+            0.0, abs=1e-12
+        )
+        assert result["energy_l0_var"].block().values.item() == pytest.approx(
+            expected, rel=1e-12
+        )
+        assert result["energy_l0_norm_squared"].block().values.item() == pytest.approx(
+            expected, rel=1e-12
+        )
+        sigma_plus, sigma_minus, _ = per_system_character_fractions(result, "energy_l0")
+        assert torch.sum(sigma_plus + sigma_minus).item() == pytest.approx(
+            1.0, abs=1e-12
+        )
+        assert torch.max(torch.abs(sigma_minus)).item() < 1e-12
 
     def test_float32_model_with_large_energy_offset(self):
         # positions sum to v = (1, 2, 0), so the exact O(3) variance of the
@@ -1285,7 +2135,7 @@ class TestFloat64Accumulation:
             batch_size=8,
         ).to(dtype=torch.float32)
 
-        results = model([system], {"energy": ModelOutput(sample_kind="system")})
+        results = model([system], _ENERGY_OUTPUTS)
 
         variance = results["energy_l0_var"].block().values
         assert variance.dtype == torch.float64
@@ -1293,6 +2143,20 @@ class TestFloat64Accumulation:
         # the residual error is the float32 round-off of the model outputs
         # themselves (~1e5 * 1e-7), far below the 5% tolerance
         assert abs(variance.item() - expected) < 0.05 * expected
+
+    @pytest.mark.parametrize("batch_size", [1, 2, 4, 64])
+    def test_large_invariant_offset_is_batch_independent(self, batch_size):
+        model = _symmetrized(
+            _ConstantEnergyModel(value=1.0e12),
+            max_o3_lambda_target=0,
+            batch_size=batch_size,
+        )
+
+        result = model([_two_atom_system()], _ENERGY_OUTPUTS)
+
+        assert result["energy_l0_mean"].block().values.item() == 1.0e12
+        assert result["energy_l0_var"].block().values.item() == 0.0
+        assert result["energy_l0_norm_squared"].block().values.item() == 1.0e24
 
 
 class TestCustomEnergyName:
@@ -1304,16 +2168,12 @@ class TestCustomEnergyName:
     def test_gradients_with_custom_energy_name(self):
         systems = [self._make_system()]
 
-        reference = SymmetrizedModel(
-            _QuadraticEnergyModel(), max_o3_lambda_target=1, batch_size=4
-        ).to(dtype=torch.float64)
-        renamed = SymmetrizedModel(
-            _RenamedEnergyModel(), max_o3_lambda_target=1, batch_size=4
-        ).to(dtype=torch.float64)
+        reference = _symmetrized(_QuadraticEnergyModel())
+        renamed = _symmetrized(_RenamedEnergyModel())
 
         reference_results = reference(
             systems,
-            {"energy": ModelOutput(sample_kind="system")},
+            _ENERGY_OUTPUTS,
             compute_gradients=True,
         )
         renamed_results = renamed(
@@ -1338,9 +2198,7 @@ class TestCustomEnergyName:
             )
 
     def test_missing_energy_name_raises(self):
-        model = SymmetrizedModel(
-            _RenamedEnergyModel(), max_o3_lambda_target=1, batch_size=4
-        ).to(dtype=torch.float64)
+        model = _symmetrized(_RenamedEnergyModel())
 
         with pytest.raises(ValueError, match="requires 'energy' in outputs"):
             model(
@@ -1350,9 +2208,7 @@ class TestCustomEnergyName:
             )
 
     def test_equivariance_error_with_custom_energy_name(self):
-        model = SymmetrizedModel(
-            _RenamedEnergyModel(), max_o3_lambda_target=1, batch_size=4
-        ).to(dtype=torch.float64)
+        model = _symmetrized(_RenamedEnergyModel())
 
         errors = model.equivariance_error(
             [self._make_system()],
@@ -1373,14 +2229,21 @@ class TestAtomisticBaseModel:
     def _make_system(self):
         return _two_atom_system()
 
-    def _export(self):
+    def _export(self, module=None, explicit_gradients=None):
+        if module is None:
+            module = _QuadraticEnergyModel()
+        if explicit_gradients is None:
+            explicit_gradients = []
         return AtomisticModel(
-            _QuadraticEnergyModel().eval(),
+            module.eval(),
             ModelMetadata(),
             ModelCapabilities(
                 outputs={
                     "energy": ModelOutput(
-                        sample_kind="system", unit="eV", description="energy"
+                        sample_kind="system",
+                        unit="eV",
+                        description="energy",
+                        explicit_gradients=explicit_gradients,
                     )
                 },
                 atomic_types=[1],
@@ -1392,11 +2255,7 @@ class TestAtomisticBaseModel:
         )
 
     def _symmetrize(self, base_model):
-        return SymmetrizedModel(
-            base_model,
-            max_o3_lambda_target=1,
-            batch_size=4,
-        ).to(dtype=torch.float64)
+        return _symmetrized(base_model)
 
     def _assert_same_results(self, reference, results):
         assert set(results.keys()) == set(reference.keys())
@@ -1412,6 +2271,25 @@ class TestAtomisticBaseModel:
 
         self._assert_same_results(reference, results)
 
+    def test_custom_input_unit_metadata_survives_rotation(self):
+        system = self._make_system()
+        masses = _single_block_tensor_map(
+            torch.tensor([[1.0], [2.0]], dtype=torch.float64),
+            samples=Labels(["system", "atom"], torch.tensor([[0, 0], [0, 1]])),
+            components=[],
+            properties=Labels(["mass"], torch.tensor([[0]])),
+        )
+        masses.set_info("unit", "u")
+        system.add_data("mass", masses)
+
+        model = self._symmetrize(self._export(_CustomUnitInputEnergyModel()))
+        result = model([system], {"energy": ModelOutput(sample_kind="system")})
+
+        expected = 3.0 * unit_conversion_factor("u", "kg")
+        assert result["energy_l0_mean"].block().values.item() == pytest.approx(
+            expected, rel=1e-12
+        )
+
     def test_gradients_through_exported_model(self):
         outputs = {"energy": ModelOutput(sample_kind="system")}
         systems = [self._make_system()]
@@ -1425,6 +2303,24 @@ class TestAtomisticBaseModel:
 
         assert "forces_l1_mean" in results
         self._assert_same_results(reference, results)
+
+    @pytest.mark.parametrize("compute_gradients", [False, True])
+    def test_exported_model_unsolicited_gradient_is_rejected(self, compute_gradients):
+        exported = self._export(
+            module=_ExplicitGradientEnergyModel(),
+            explicit_gradients=["positions"],
+        )
+        model = self._symmetrize(exported)
+
+        with pytest.raises(
+            ValueError,
+            match="output 'energy' contains explicit gradient 'positions'",
+        ):
+            model(
+                [self._make_system()],
+                {"energy": ModelOutput(sample_kind="system")},
+                compute_gradients=compute_gradients,
+            )
 
     def test_exported_model_converts_requested_units(self):
         # requested outputs are forwarded unchanged, so each base-model kind
@@ -1537,7 +2433,7 @@ class TestGradientPathIntegrity:
                 atol=1e-14,
             )
 
-    def test_custom_data_is_rotated(self):
+    def test_custom_data_is_rotated(self, monkeypatch):
         # energy = sum(pos^2) + field . sum(pos) is invariant when the stored
         # field rotates with the system: the forces equivariance error must
         # vanish (and the run must not crash on the data-carrying system)
@@ -1555,17 +2451,9 @@ class TestGradientPathIntegrity:
                         torch.sum(sys.positions**2)
                         + torch.dot(field, sys.positions.sum(dim=0))
                     )
-                block = TensorBlock(
-                    values=torch.stack(energies).unsqueeze(-1),
-                    samples=Labels(
-                        ["system"],
-                        torch.arange(len(systems), dtype=torch.int64).unsqueeze(1),
-                    ),
-                    components=[],
-                    properties=Labels(["energy"], torch.tensor([[0]])),
-                )
-                key = Labels(["_"], torch.tensor([[0]]))
-                return {"energy": TensorMap(key, [block])}
+                return {
+                    "energy": _system_tensor_map(torch.stack(energies).unsqueeze(-1))
+                }
 
             def requested_neighbor_lists(self):
                 return []
@@ -1578,44 +2466,42 @@ class TestGradientPathIntegrity:
             cell=torch.zeros((3, 3), dtype=torch.float64),
             pbc=torch.tensor([False, False, False]),
         )
-        field = TensorMap(
-            Labels(["_"], torch.tensor([[0]])),
-            [
-                TensorBlock(
-                    values=torch.tensor([[[0.3], [0.7], [-0.2]]], dtype=torch.float64),
-                    samples=Labels(["system"], torch.tensor([[0]])),
-                    components=[Labels.range("xyz", 3)],
-                    properties=Labels.range("field", 1),
-                )
-            ],
+        field = _single_block_tensor_map(
+            torch.tensor([[[0.3], [0.7], [-0.2]]], dtype=torch.float64),
+            samples=Labels(["system"], torch.tensor([[0]])),
+            components=[Labels.range("xyz", 3)],
+            properties=Labels.range("field", 1),
         )
         system.add_data("mtt::field", field)
 
-        model = SymmetrizedModel(
-            _FieldModel(), max_o3_lambda_target=1, batch_size=8
-        ).to(dtype=torch.float64)
+        checked_constructor_calls = 0
+        original_init = O3Transformation.__init__
+
+        def counted_init(self, *args, **kwargs):
+            nonlocal checked_constructor_calls
+            checked_constructor_calls += 1
+            original_init(self, *args, **kwargs)
+
+        monkeypatch.setattr(O3Transformation, "__init__", counted_init)
+
+        model = _symmetrized(_FieldModel(), batch_size=8)
         errors = model.equivariance_error(
             [system],
-            {"energy": ModelOutput(sample_kind="system")},
+            _ENERGY_OUTPUTS,
             compute_gradients=True,
         )
 
         assert torch.all(errors["forces_l1"].block().values.abs() < 1e-7)
+        # All matrices in this path come from the wrapper's fixed quadrature;
+        # none should repeat the public constructor's synchronization-heavy
+        # orthogonality and determinant validation.
+        assert checked_constructor_calls == 0
 
     def test_reserved_output_names_raise(self):
-        model = SymmetrizedModel(
-            _QuadraticEnergyModel(), max_o3_lambda_target=1, batch_size=8
-        ).to(dtype=torch.float64)
+        model = _symmetrized(_QuadraticEnergyModel(), batch_size=8)
         with pytest.raises(ValueError, match="reserved for the autograd-derived"):
             model(
-                [
-                    System(
-                        types=torch.tensor([1], dtype=torch.int32),
-                        positions=torch.tensor([[1.0, 0.0, 0.0]], dtype=torch.float64),
-                        cell=torch.zeros((3, 3), dtype=torch.float64),
-                        pbc=torch.tensor([False, False, False]),
-                    )
-                ],
+                [_two_atom_system()],
                 {
                     "energy": ModelOutput(sample_kind="system"),
                     "forces": ModelOutput(sample_kind="atom"),
@@ -1626,20 +2512,10 @@ class TestGradientPathIntegrity:
     def test_results_carry_no_autograd_graph(self):
         # regression test: the accumulators used to keep every rotated copy's
         # forward graph alive across the whole grid in compute_gradients mode
-        system = System(
-            types=torch.tensor([1, 1], dtype=torch.int32),
-            positions=torch.tensor(
-                [[1.0, 0.0, 0.0], [0.0, 2.0, 0.0]], dtype=torch.float64
-            ),
-            cell=torch.zeros((3, 3), dtype=torch.float64),
-            pbc=torch.tensor([False, False, False]),
-        )
-        model = SymmetrizedModel(
-            _QuadraticEnergyModel(), max_o3_lambda_target=1, batch_size=4
-        ).to(dtype=torch.float64)
+        model = _symmetrized(_QuadraticEnergyModel())
         results = model(
-            [system],
-            {"energy": ModelOutput(sample_kind="system")},
+            [_two_atom_system()],
+            _ENERGY_OUTPUTS,
             compute_gradients=True,
         )
         for name in ("energy_l0_mean", "energy_l0_var", "forces_l1_mean"):
@@ -1647,42 +2523,50 @@ class TestGradientPathIntegrity:
 
 
 class TestLambdaValidation:
-    """Spherical components beyond the declared max_o3_lambda_target fail with
-    a clear error instead of an opaque Wigner-cache miss."""
+    """Input data uses its actual rank; outputs obey max_o3_lambda_target."""
 
     def _spherical_map(self, ell):
-        return TensorMap(
-            Labels(["o3_lambda", "o3_sigma"], torch.tensor([[ell, 1]])),
-            [
-                TensorBlock(
-                    values=torch.rand(1, 2 * ell + 1, 1, dtype=torch.float64),
-                    samples=Labels(["system"], torch.tensor([[0]])),
-                    components=[
-                        Labels(
-                            ["o3_mu"],
-                            torch.arange(-ell, ell + 1, dtype=torch.int64).reshape(
-                                -1, 1
-                            ),
-                        )
-                    ],
-                    properties=Labels.range("p", 1),
-                )
-            ],
+        return _system_tensor_map(
+            torch.rand(1, 2 * ell + 1, 1, dtype=torch.float64),
+            property_name="p",
+            ell=ell,
         )
 
     def _make_system(self):
         return _two_atom_system()
 
-    def test_system_data_beyond_target_raises(self):
+    def test_system_data_rank_is_independent_of_output_target(self):
         system = self._make_system()
-        system.add_data("mtt::spherical_field", self._spherical_map(3))
+        spherical_field = self._spherical_map(3)
+        expected = torch.sum(spherical_field.block().values ** 2)
+        system.add_data("mtt::spherical_field", spherical_field)
 
-        model = SymmetrizedModel(
-            _QuadraticEnergyModel(), max_o3_lambda_target=1, batch_size=8
-        ).to(dtype=torch.float64)
+        class _SphericalNormModel(torch.nn.Module):
+            def forward(self, systems, outputs, selected_atoms=None):
+                energies = torch.stack(
+                    [
+                        torch.sum(
+                            item.get_data("mtt::spherical_field").block().values ** 2
+                        )
+                        for item in systems
+                    ]
+                )
+                return {"energy": _system_tensor_map(energies.unsqueeze(-1))}
 
-        with pytest.raises(ValueError, match="larger than max_o3_lambda_target=1"):
-            model([system], {"energy": ModelOutput(sample_kind="system")})
+            def requested_neighbor_lists(self):
+                return []
+
+        model = _symmetrized(
+            _SphericalNormModel(), max_o3_lambda_target=0, batch_size=8
+        )
+        result = model([system], _ENERGY_OUTPUTS)
+
+        assert torch.allclose(
+            result["energy_l0_mean"].block().values.squeeze(),
+            expected,
+            atol=1e-10,
+        )
+        assert torch.all(result["energy_l0_var"].block().values.abs() < 1e-10)
 
     def test_output_beyond_target_raises(self):
         spherical_map = self._spherical_map(2)
@@ -1694,9 +2578,7 @@ class TestLambdaValidation:
             def requested_neighbor_lists(self):
                 return []
 
-        model = SymmetrizedModel(
-            _SphericalOutputModel(), max_o3_lambda_target=1, batch_size=8
-        ).to(dtype=torch.float64)
+        model = _symmetrized(_SphericalOutputModel(), batch_size=8)
 
         with pytest.raises(ValueError, match="larger than max_o3_lambda_target=1"):
             model(
@@ -1704,34 +2586,330 @@ class TestLambdaValidation:
                 {"mtt::spherical": ModelOutput(sample_kind="system")},
             )
 
+    @pytest.mark.parametrize("spherical_first", [False, True])
+    @pytest.mark.parametrize("compute_character_projections", [False, True])
+    def test_wigner_work_uses_actual_output_and_character_ranks(
+        self, monkeypatch, spherical_first, compute_character_projections
+    ):
+        class _ScalarAndSphericalModel(torch.nn.Module):
+            def forward(self, systems, outputs, selected_atoms=None):
+                device = systems[0].positions.device
+                dtype = systems[0].positions.dtype
+                scalar = _system_tensor_map(
+                    torch.ones(len(systems), 1, dtype=dtype, device=device)
+                )
+                spherical = _system_tensor_map(
+                    torch.ones(len(systems), 5, 1, dtype=dtype, device=device),
+                    property_name="p",
+                    ell=2,
+                )
+                available = {"energy": scalar, "mtt::spherical": spherical}
+                return {name: available[name] for name in outputs}
+
+            def requested_neighbor_lists(self):
+                return []
+
+        built_ranks = []
+        original_build = transformation_module.build_wigner_D_cache
+
+        def tracked_build(ell_max, *args, **kwargs):
+            built_ranks.append(ell_max)
+            return original_build(ell_max, *args, **kwargs)
+
+        monkeypatch.setattr(
+            transformation_module, "build_wigner_D_cache", tracked_build
+        )
+
+        names = ["energy", "mtt::spherical"]
+        if spherical_first:
+            names.reverse()
+        outputs = {
+            name: ModelOutput(sample_kind="system" if name == "energy" else "atom")
+            for name in names
+        }
+        model = _symmetrized(
+            _ScalarAndSphericalModel(),
+            max_o3_lambda_target=4,
+            max_o3_lambda_character=0,
+            batch_size=64,
+        )
+
+        result = model(
+            [self._make_system()],
+            outputs,
+            compute_character_projections=compute_character_projections,
+        )
+
+        assert built_ranks and set(built_ranks) == {2}
+        assert len(built_ranks) == model.so3_rotations.shape[0]
+        assert (
+            "energy_l0_character_projection" in result
+        ) is compute_character_projections
+
+
+class TestPersistentWignerCache:
+    """User-visible cache contracts: bounded, optional, reusable, and derived."""
+
+    @staticmethod
+    def _model(cache_max_bytes=64 * 1024**2):
+        return _symmetrized(
+            _ConstantEnergyModel(),
+            max_o3_lambda_target=0,
+            max_o3_lambda_character=2,
+            max_o3_lambda_grid=5,
+            batch_size=32,
+            wigner_cache_max_bytes=cache_max_bytes,
+        )
+
+    @staticmethod
+    def _run(model, *, dtype=torch.float64):
+        return model(
+            [_two_atom_system(dtype=dtype)],
+            _ENERGY_OUTPUTS,
+            compute_character_projections=True,
+        )
+
+    @staticmethod
+    def _assert_same(first, second):
+        assert set(first) == set(second)
+        for name in first:
+            assert mts.equal(first[name], second[name])
+
+    def test_budget_controls_cache_without_changing_results(self):
+        cached = self._model()
+        uncached = self._model(cache_max_bytes=0)
+
+        expected = self._run(cached)
+        self._assert_same(expected, self._run(uncached))
+        retained_bytes = sum(
+            tensor.numel() * tensor.element_size()
+            for tensor in cached._wigner_cache.values()
+        )
+        assert 0 < retained_bytes <= cached.wigner_cache_max_bytes
+        assert uncached._wigner_cache == {}
+
+        # A lower-rank request must not retain a higher-rank cache that no
+        # longer fits a reduced public budget.
+        cached.wigner_cache_max_bytes = retained_bytes // 2
+        lower_rank = cached._persistent_wigner_stacks(
+            1, device=torch.device("cpu"), dtype=torch.float64
+        )
+        assert lower_rank is not None and set(lower_rank) == {0, 1}
+
+        # Changing the public budget at runtime releases a warm cache while
+        # preserving numerical results through the bounded fallback path.
+        cached.wigner_cache_max_bytes = 0
+        self._assert_same(expected, self._run(cached))
+        assert cached._wigner_cache == {}
+
+    def test_one_build_is_reused_across_original_systems(self, monkeypatch):
+        model = self._model()
+        build_calls = 0
+        original_build = transformation_module.build_wigner_D_cache
+
+        def counted_build(*args, **kwargs):
+            nonlocal build_calls
+            build_calls += 1
+            return original_build(*args, **kwargs)
+
+        monkeypatch.setattr(
+            transformation_module, "build_wigner_D_cache", counted_build
+        )
+        model(
+            [_two_atom_system(), _two_atom_system(_POSITIONS_B)],
+            {"energy": ModelOutput(sample_kind="system")},
+            compute_character_projections=True,
+        )
+
+        # Systems are still evaluated separately, but the second one reuses
+        # the fixed grid representation built while processing the first.
+        assert build_calls == model.so3_rotations.shape[0]
+
+    def test_warm_cache_to_dtype_matches_fresh_model(self):
+        model = self._model()
+        self._run(model)
+
+        model.to(dtype=torch.float32)
+        assert model._wigner_cache == {}
+
+        fresh = self._model().to(dtype=torch.float32)
+        expected = self._run(fresh, dtype=torch.float32)
+        actual = self._run(model, dtype=torch.float32)
+        self._assert_same(expected, actual)
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+    def test_cuda_cached_and_uncached_results_match(self, monkeypatch):
+        build_devices = []
+        original_build = transformation_module.build_wigner_D_cache
+
+        def record_build_device(*args, **kwargs):
+            build_devices.append(args[1].device.type)
+            return original_build(*args, **kwargs)
+
+        monkeypatch.setattr(
+            transformation_module,
+            "build_wigner_D_cache",
+            record_build_device,
+        )
+        cached = self._model().to(device="cuda")
+        uncached = self._model(cache_max_bytes=0).to(device="cuda")
+        system = _two_atom_system().to(device="cuda")
+
+        expected = cached(
+            [system],
+            _ENERGY_OUTPUTS,
+            compute_character_projections=True,
+        )
+        actual = uncached(
+            [system],
+            _ENERGY_OUTPUTS,
+            compute_character_projections=True,
+        )
+
+        self._assert_same(expected, actual)
+        assert cached._wigner_cache
+        assert uncached._wigner_cache == {}
+        assert len(build_devices) == 2 * cached.so3_rotations.shape[0]
+        assert set(build_devices) == {"cpu"}
+
+    def test_cache_is_rebuilt_after_serialization(self):
+        model = self._model()
+        expected = self._run(model)
+        assert model._wigner_cache
+        state = model.state_dict()
+        assert "so3_rotations" in state
+        assert all("wigner_cache" not in name for name in state)
+
+        payload = io.BytesIO()
+        torch.save(model, payload)
+        payload.seek(0)
+        loaded = torch.load(payload, weights_only=False)
+
+        assert loaded._wigner_cache == {}
+        actual = self._run(loaded)
+        self._assert_same(expected, actual)
+
 
 class TestDecomposeOutputNames:
     """All spellings of the force/stress output names decompose to spherical
     blocks; unknown names pass through."""
 
     def _vector_map(self):
-        return TensorMap(
-            Labels(["_"], torch.tensor([[0]])),
-            [
-                TensorBlock(
-                    values=torch.rand(2, 3, 1, dtype=torch.float64),
-                    samples=Labels(["system", "atom"], torch.tensor([[0, 0], [0, 1]])),
-                    components=[Labels.range("xyz", 3)],
-                    properties=Labels.range("p", 1),
-                )
-            ],
+        return _single_block_tensor_map(
+            torch.rand(2, 3, 1, dtype=torch.float64),
+            samples=Labels(["system", "atom"], torch.tensor([[0, 0], [0, 1]])),
+            components=[Labels.range("xyz", 3)],
+            properties=Labels.range("p", 1),
         )
 
-    def test_canonical_singular_name_is_decomposed(self):
-        result = _decompose_output("non_conservative_force", self._vector_map())
-        assert set(result.keys()) == {"non_conservative_force_l1"}
-        assert result["non_conservative_force_l1"].block().components[0].names == [
-            "o3_mu"
-        ]
+    def _scalar_map(self, keys=None):
+        return _single_block_tensor_map(
+            torch.rand(1, 2, dtype=torch.float64),
+            samples=Labels(["system"], torch.tensor([[0]])),
+            components=[],
+            properties=Labels.range("p", 2),
+            keys=keys,
+        )
 
-    def test_deprecated_plural_name_is_decomposed(self):
-        result = _decompose_output("non_conservative_forces", self._vector_map())
-        assert set(result.keys()) == {"non_conservative_forces_l1"}
+    def _stress_map(self):
+        return _single_block_tensor_map(
+            torch.rand(1, 3, 3, 1, dtype=torch.float64),
+            samples=Labels(["system"], torch.tensor([[0]])),
+            components=[Labels.range("xyz_1", 3), Labels.range("xyz_2", 3)],
+            properties=Labels.range("p", 1),
+        )
+
+    @staticmethod
+    def _assert_irrep_keys(tensor, ell):
+        assert tensor.keys.names == ["o3_lambda", "o3_sigma"]
+        assert tensor.keys.values.tolist() == [[ell, 1]]
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "non_conservative_force",
+            "non_conservative_forces",
+            "non_conservative_force/direct",
+        ],
+    )
+    def test_vector_names_are_decomposed(self, name):
+        output_name = name + "_l1"
+        result = _decompose_output(name, self._vector_map())
+        assert set(result) == {output_name}
+        assert result[output_name].block().components[0].names == ["o3_mu"]
+        self._assert_irrep_keys(result[output_name], 1)
+
+    @pytest.mark.parametrize(
+        "name",
+        ["energy/pbe", "energy_ensemble/member", "energy_uncertainty/direct"],
+    )
+    def test_energy_variants_are_decomposed(self, name):
+        result = _decompose_output(name, self._scalar_map())
+        assert set(result) == {name + "_l0"}
+        self._assert_irrep_keys(result[name + "_l0"], 0)
+
+    def test_stress_variant_is_decomposed(self):
+        name = "non_conservative_stress/direct"
+        result = _decompose_output(name, self._stress_map())
+        assert set(result) == {name + "_l0", name + "_l2"}
+        self._assert_irrep_keys(result[name + "_l0"], 0)
+        self._assert_irrep_keys(result[name + "_l2"], 2)
+
+    def test_semantic_keys_are_preserved_and_placeholder_is_validated(self):
+        tensor = self._scalar_map(Labels(["channel"], torch.tensor([[7]])))
+        result = _decompose_output("energy", tensor)["energy_l0"]
+        assert result.keys.names == ["channel", "o3_lambda", "o3_sigma"]
+        assert result.keys.values.tolist() == [[7, 0, 1]]
+
+        with pytest.raises(ValueError, match="canonical.*placeholder"):
+            _decompose_output(
+                "energy", self._scalar_map(Labels(["_"], torch.tensor([[1]])))
+            )
+        with pytest.raises(ValueError, match="existing 'o3_lambda'.*inconsistent"):
+            _decompose_output(
+                "energy",
+                self._scalar_map(
+                    Labels(
+                        ["channel", "o3_lambda"],
+                        torch.tensor([[7, 1]]),
+                    )
+                ),
+            )
+
+    @pytest.mark.parametrize("inversion", [1.0, -1.0])
+    @pytest.mark.parametrize(
+        ("name", "tensor_factory"),
+        [
+            ("non_conservative_force", "_vector_map"),
+            ("non_conservative_stress", "_stress_map"),
+        ],
+    )
+    def test_decomposition_commutes_with_o3_transform(
+        self, name, tensor_factory, inversion
+    ):
+        tensor = getattr(self, tensor_factory)()
+        matrix = inversion * torch.tensor(
+            Rotation.from_rotvec([0.2, -0.4, 0.3]).as_matrix(),
+            dtype=torch.float64,
+        )
+        transformation = O3Transformation(matrix, max_angular_momentum=2)
+        system = _two_atom_system()
+
+        decomposed_first = _decompose_output(name, tensor)
+        transformed_first = {
+            output_name: transform_tensor(output, [system], [transformation])
+            for output_name, output in decomposed_first.items()
+        }
+        transformed_cartesian = transform_tensor(tensor, [system], [transformation])
+        decomposed_second = _decompose_output(name, transformed_cartesian)
+
+        assert set(transformed_first) == set(decomposed_second)
+        for output_name in transformed_first:
+            assert mts.allclose(
+                transformed_first[output_name],
+                decomposed_second[output_name],
+                atol=1e-12,
+            )
 
     def test_unknown_name_passes_through(self):
         tensor = self._vector_map()

--- a/python/metatomic_torch/tests/symmetrized_model.py
+++ b/python/metatomic_torch/tests/symmetrized_model.py
@@ -2737,6 +2737,29 @@ class TestPersistentWignerCache:
         actual = self._run(model, dtype=torch.float32)
         self._assert_same(expected, actual)
 
+    def test_grid_mutation_invalidates_and_preserves_cache_values(self):
+        model = self._model()
+        self._run(model)
+        old_key = model._wigner_cache_key
+        old_stack = model._wigner_cache[2]
+
+        # Read-only forwards must leave the persistent matrices unchanged.
+        expected_cache = {
+            ell: tensor.clone() for ell, tensor in model._wigner_cache.items()
+        }
+        self._run(model)
+        for ell, expected in expected_cache.items():
+            assert torch.equal(model._wigner_cache[ell], expected)
+
+        # An in-place grid mutation increments Tensor._version and must rebuild
+        # the Wigner matrices derived from the canonical grid.
+        with torch.no_grad():
+            model.so3_rotations[0].copy_(model.so3_rotations[1])
+        self._run(model)
+        assert model._wigner_cache_key != old_key
+        assert model._wigner_cache[2] is not old_stack
+        assert torch.equal(model._wigner_cache[2][0], model._wigner_cache[2][1])
+
     @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
     def test_cuda_cached_and_uncached_results_match(self, monkeypatch):
         build_devices = []

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ testing_deps =
 metatomic_deps =
     metatensor-torch >=0.10.0,<0.11
     metatensor-operations >=0.5.0,<0.6
-    wigners
+    wigners >=0.4.0
 
 
 ################################################################################


### PR DESCRIPTION
This is a stacked follow-up to #119. It intentionally targets the
`token_rotations` branch at `31cc945`, so this pull request contains only the
four follow-up commits rather than repeating the complete parent PR.

## Scope

The changes are limited to:

- `metatomic.torch.SymmetrizedModel`;
- the O(3) transformation utilities directly required by that wrapper; and
- the existing ASE `SymmetrizedCalculator`, including the requested-input and
  space-group paths needed to construct its symmetry orbit.

No metatrain model, training procedure, loss, dataset, optimizer, or base-model
architecture is modified.

## Motivation

The implementation in #119 establishes the main feature, but several
mathematical, numerical, API, and scalability contracts required additional
work before the feature could be considered internally consistent and suitable
for larger grids and datasets.

The follow-up therefore:

- applies one proper/improper O(3) convention across every public path;
- makes multi-System routing and spherical metadata validation explicit;
- uses pole-safe Wigner construction;
- resolves the Wigner-product space actually integrated by the finite grid;
- accumulates centered moments to avoid catastrophic cancellation;
- defines explicit derivative and three-dimensional stress behavior;
- preserves requested ASE inputs and complete closed space-group actions; and
- removes repeated representation work and full-grid prediction retention.

## Intentional behavioral corrections

Some results intentionally differ from the original #119 implementation:

- generated spherical outputs use canonical `o3_lambda` and `o3_sigma` keys;
- centered accumulation replaces the unstable difference of large moments;
- attached TensorMap gradients are rejected rather than silently discarded;
- conservative forces and eligible fully periodic stress are derived through
  autograd when requested;
- partial or nonperiodic Systems omit undefined volume-based 3D stress;
- singular or non-finite fully periodic cells raise before stress division;
- detached energies warn and produce exact-zero derivatives as constant
  energies;
- unsupported MPS execution is rejected before evaluation without changing
  CPU or CUDA behavior; and
- ASE space-group projection retains complete actions, including
  translation-distinct atom permutations.

These cases are tested against analytical, structural, or API targets.

## Performance and scalability

The optimization are limited to:

- direct and lazy real Wigner construction;
- Wigner work sized from the actual returned rank;
- a bounded persistent Wigner cache with an exact uncached fallback;
- batched core-System transformations;
- canonical storage of forward rotations without a duplicate inverse grid;
- streamed ASE moment reduction whose retained state is independent of the
  number of quadrature operations; and
- indexed periodic-site candidate matching with Cartesian minimum-image
  verification and an exact bounded fallback.

Controlled benchmarks showed material improvements on the affected paths.

## Change composition

Relative to #119, this series changes 20 files:

- production-source paths: +1,564 net lines, including reviewer-facing docstrings;
- tests: +2,471 net lines;
- public documentation, changelogs, and configuration: +436 net lines.

The total increase relative to #119 is 4,471 net lines. Tests account for
55.3% of this increase. Compared with the previous draft, the runtime
implementation is unchanged while repetitive tests and documentation were
consolidated, reducing the series by 221 net lines.

## Validation

Validation on the exact four-commit tip:

- complete local Torch suite: 372 passed, 7 skipped;
- complete local ASE suite: 140 passed, 2 skipped;
- CUDA O(3)/SymmetrizedModel suite: 267 passed, 2 MPS-only skips;
- CUDA ASE symmetrization suite: 94 passed;
- Torch coverage before and after compression: unchanged at 96% statements
  and 94% including branches;
- ASE symmetrization coverage: unchanged at 90% including branches;
- Ruff lint and formatting: passed;
- `git diff --check`: passed;
- Sphinx documentation build with warnings treated as errors: passed.

The three commits were also tested independently to preserve bisectability.

## Review structure

The commits are intentionally divided into four review units:

1. O(3) transformation correctness and Wigner construction;
2. `SymmetrizedModel` numerical, derivative, schema, cache, and performance contracts;
3. ASE requested-state preservation, streaming reduction, and space-group projection;
4. reviewer-facing mathematical/API documentation and the direct Wigner-cache
   mutation regression.
   
   I have refreshed the draft series after a reviewability pass. The runtime implementation is unchanged from the previous draft. Repetitive tests were consolidated, non-obvious mathematical and API contracts were documented, and a direct quadrature-grid mutation regression was restored.