### PR TITLE
Improve O(3) transformations and Wigner-D evaluation

### DIFF
--- a/docs/src/torch/reference/o3.rst
+++ b/docs/src/torch/reference/o3.rst
@@ -33,10 +33,8 @@ At most ten component axes are supported in one value or gradient block. Other
 component-axis names are rejected. These metadata requirements also apply to
 blocks without samples.
 
-An :py:class:`O3Transformation` stores a copy of its input matrix, and its
-:py:attr:`~metatomic.torch.o3.O3Transformation.matrix` property returns a copy.
-Modifying either tensor therefore cannot make the stored matrix disagree with its
-proper/improper classification or cached Wigner-D matrices.
+An :py:class:`O3Transformation` stores a copy of its input matrix. Modifying the
+original tensor therefore does not change the transformation.
 The :py:attr:`~metatomic.torch.o3.O3Transformation.is_improper` property is true
 exactly when the matrix has negative determinant.
 
@@ -46,9 +44,6 @@ Wigner-D matrices
 Wigner-D matrices are computed when first requested by an
 :py:class:`O3Transformation` and then reused. Cartesian-only operations do not build
 them.
-
-:py:meth:`~metatomic.torch.o3.O3Transformation.wigner_D_matrix` returns a copy.
-Modifying the returned tensor therefore does not affect later transformations.
 
 Complex Wigner-D matrices are computed by the `wigners <https://github.com/luthaf/wigners>`_
 package, using the convention

--- a/docs/src/torch/reference/o3.rst
+++ b/docs/src/torch/reference/o3.rst
@@ -11,24 +11,44 @@ augmentation.
 Conventions
 -----------
 
-To transform a :py:class:`~metatensor.torch.TensorBlock`, :py:func:`transform_block`
-and :py:func:`transform_tensor` need to know, for each component axis, whether it
-carries a Cartesian or a spherical tensor. This is inferred from the axis name:
+To transform a :py:class:`~metatensor.torch.TensorBlock`,
+:py:func:`transform_block` and :py:func:`transform_tensor` inspect its component
+axes. Blocks without component axes are scalar; Cartesian and spherical axes are
+identified by name:
 
-- Cartesian axes are named ``xyz``, or ``xyz_1``, ``xyz_2``, ... for blocks with
-  several Cartesian axes (e.g. rank-2 Cartesian tensors). These are rotated directly
-  with the (3, 3) transformation matrix :math:`R` passed to
-  :py:class:`O3Transformation`, following the usual column-vector convention
-  :math:`v' = R v` (equivalently, since values are stored as rows,
-  ``values_transformed = values @ R.T``).
-- Spherical axes are named ``o3_mu``, or ``o3_mu_1``, ``o3_mu_2``, ... They are rotated
-  with the real Wigner-D matrix for the angular momentum ``o3_lambda`` (respectively
-  ``o3_lambda_1``, ``o3_lambda_2``, ...) found in the block's key. Real, rather than
-  complex, spherical harmonics are used throughout, matching the convention used
-  elsewhere in metatomic and metatensor for spherical targets.
+- Cartesian axes are named ``xyz`` or ``xyz_1`` through ``xyz_9``. They are
+  transformed directly with the (3, 3) matrix :math:`R` passed to
+  :py:class:`O3Transformation`, following the column-vector convention
+  :math:`v' = Rv` (equivalently, ``values_transformed = values @ R.T`` because
+  values are stored as rows). Their component labels must be ``[0, 1, 2]`` in
+  :math:`x, y, z` order.
+- Spherical axes are named ``o3_mu`` or ``o3_mu_1`` through ``o3_mu_9``. Their
+  :math:`\ell` and :math:`\sigma` values are read from the correspondingly
+  suffixed ``o3_lambda`` and ``o3_sigma`` dimensions in the block key. For
+  angular momentum :math:`\ell`, component labels must run from :math:`-\ell`
+  through :math:`+\ell` in ascending order. These axes use the real Wigner-D
+  convention described below.
+
+At most ten component axes are supported in one value or gradient block. Other
+component-axis names are rejected. These metadata requirements also apply to
+blocks without samples.
+
+An :py:class:`O3Transformation` stores a copy of its input matrix, and its
+:py:attr:`~metatomic.torch.o3.O3Transformation.matrix` property returns a copy.
+Modifying either tensor therefore cannot make the stored matrix disagree with its
+proper/improper classification or cached Wigner-D matrices.
+The :py:attr:`~metatomic.torch.o3.O3Transformation.is_improper` property is true
+exactly when the matrix has negative determinant.
 
 Wigner-D matrices
 ~~~~~~~~~~~~~~~~~
+
+Wigner-D matrices are computed when first requested by an
+:py:class:`O3Transformation` and then reused. Cartesian-only operations do not build
+them.
+
+:py:meth:`~metatomic.torch.o3.O3Transformation.wigner_D_matrix` returns a copy.
+Modifying the returned tensor therefore does not affect later transformations.
 
 Complex Wigner-D matrices are computed by the `wigners <https://github.com/luthaf/wigners>`_
 package, using the convention
@@ -61,16 +81,26 @@ so that the real Wigner-D matrix is :math:`D^{\ell}_{\text{real}} = T^{*} D^{\el
 
 For an improper rotation (a rotation composed with an inversion), Cartesian axes are
 flipped as part of the transformation matrix itself, while spherical axes pick up an
-extra parity factor :math:`(-1)^{\ell} \sigma`, where :math:`\ell` is ``o3_lambda``
-and :math:`\sigma` is the block's ``o3_sigma`` (its behavior under inversion, +1 or
--1), also read from the key.
+extra parity factor :math:`(-1)^{\ell} \sigma`. Here :math:`\ell` and
+:math:`\sigma` are the matching ``o3_lambda`` and ``o3_sigma`` labels from the
+block key. Only :math:`\sigma=+1` (a proper representation) and
+:math:`\sigma=-1` (a pseudo representation) are accepted.
 
-A :py:class:`~metatensor.torch.TensorBlock` in general contains values associated with
-several systems. This information is contained in the ``"system"`` samples dimension;
-each row is rotated with the transformation of the system it belongs to. Gradient blocks
-are routed the same way, via their parent block's ``"system"`` column. When only one
-system is being transformed, the ``"system"`` column is optional and, if present, is
-ignored: every row is rotated with the (single) given transformation.
+Multiple systems
+~~~~~~~~~~~~~~~~
+
+When several systems are transformed, list order determines the pairing:
+``transformations[i]`` is used for ``systems[i]``. The integer ``system_ids[i]``
+identifies that system in a block's ``"system"`` sample column. For example, if
+``system_ids = [92, 38]``, samples labelled ``92`` use ``transformations[0]`` and
+samples labelled ``38`` use ``transformations[1]``.
+
+Each identifier must be unique. A block may contain samples for only some of the
+systems, but every ``"system"`` label present in the block must appear in
+``system_ids``. A gradient sample points to its parent value sample through its
+``"sample"`` label and uses the same transformation as its parent. When only one
+system is supplied, all samples use its transformation; the ``"system"`` column is
+optional and, if present, ignored.
 
 Reference
 ---------

--- a/docs/src/torch/reference/o3.rst
+++ b/docs/src/torch/reference/o3.rst
@@ -11,39 +11,24 @@ augmentation.
 Conventions
 -----------
 
-To transform a :py:class:`~metatensor.torch.TensorBlock`,
-:py:func:`transform_block` and :py:func:`transform_tensor` inspect its component
-axes. Blocks without component axes are scalar; Cartesian and spherical axes are
-identified by name:
+To transform a :py:class:`~metatensor.torch.TensorBlock`, :py:func:`transform_block`
+and :py:func:`transform_tensor` need to know, for each component axis, whether it
+carries a Cartesian or a spherical tensor. This is inferred from the axis name:
 
-- Cartesian axes are named ``xyz`` or ``xyz_1`` through ``xyz_9``. They are
-  transformed directly with the (3, 3) matrix :math:`R` passed to
-  :py:class:`O3Transformation`, following the column-vector convention
-  :math:`v' = Rv` (equivalently, ``values_transformed = values @ R.T`` because
-  values are stored as rows). Their component labels must be ``[0, 1, 2]`` in
-  :math:`x, y, z` order.
-- Spherical axes are named ``o3_mu`` or ``o3_mu_1`` through ``o3_mu_9``. Their
-  :math:`\ell` and :math:`\sigma` values are read from the correspondingly
-  suffixed ``o3_lambda`` and ``o3_sigma`` dimensions in the block key. For
-  angular momentum :math:`\ell`, component labels must run from :math:`-\ell`
-  through :math:`+\ell` in ascending order. These axes use the real Wigner-D
-  convention described below.
-
-At most ten component axes are supported in one value or gradient block. Other
-component-axis names are rejected. These metadata requirements also apply to
-blocks without samples.
-
-An :py:class:`O3Transformation` stores a copy of its input matrix. Modifying the
-original tensor therefore does not change the transformation.
-The :py:attr:`~metatomic.torch.o3.O3Transformation.is_improper` property is true
-exactly when the matrix has negative determinant.
+- Cartesian axes are named ``xyz``, or ``xyz_1``, ``xyz_2``, ... for blocks with
+  several Cartesian axes (e.g. rank-2 Cartesian tensors). These are rotated directly
+  with the (3, 3) transformation matrix :math:`R` passed to
+  :py:class:`O3Transformation`, following the usual column-vector convention
+  :math:`v' = R v` (equivalently, since values are stored as rows,
+  ``values_transformed = values @ R.T``).
+- Spherical axes are named ``o3_mu``, or ``o3_mu_1``, ``o3_mu_2``, ... They are rotated
+  with the real Wigner-D matrix for the angular momentum ``o3_lambda`` (respectively
+  ``o3_lambda_1``, ``o3_lambda_2``, ...) found in the block's key. Real, rather than
+  complex, spherical harmonics are used throughout, matching the convention used
+  elsewhere in metatomic and metatensor for spherical targets.
 
 Wigner-D matrices
 ~~~~~~~~~~~~~~~~~
-
-Wigner-D matrices are computed when first requested by an
-:py:class:`O3Transformation` and then reused. Cartesian-only operations do not build
-them.
 
 Complex Wigner-D matrices are computed by the `wigners <https://github.com/luthaf/wigners>`_
 package, using the convention
@@ -73,29 +58,22 @@ change of basis :math:`T` mapping complex spherical harmonics
     \end{cases}
 
 so that the real Wigner-D matrix is :math:`D^{\ell}_{\text{real}} = T^{*} D^{\ell} T^{T}`.
+Spherical components follow the same column-vector convention as Cartesian ones,
+:math:`f' = D^{\ell}_{\text{real}} f` (equivalently, since values are stored as
+rows, ``values_transformed = values @ D.T``).
 
 For an improper rotation (a rotation composed with an inversion), Cartesian axes are
 flipped as part of the transformation matrix itself, while spherical axes pick up an
-extra parity factor :math:`(-1)^{\ell} \sigma`. Here :math:`\ell` and
-:math:`\sigma` are the matching ``o3_lambda`` and ``o3_sigma`` labels from the
-block key. Only :math:`\sigma=+1` (a proper representation) and
-:math:`\sigma=-1` (a pseudo representation) are accepted.
+extra parity factor :math:`(-1)^{\ell} \sigma`, where :math:`\ell` is ``o3_lambda``
+and :math:`\sigma` is the block's ``o3_sigma`` (its behavior under inversion, +1 or
+-1), also read from the key.
 
-Multiple systems
-~~~~~~~~~~~~~~~~
-
-When several systems are transformed, list order determines the pairing:
-``transformations[i]`` is used for ``systems[i]``. The integer ``system_ids[i]``
-identifies that system in a block's ``"system"`` sample column. For example, if
-``system_ids = [92, 38]``, samples labelled ``92`` use ``transformations[0]`` and
-samples labelled ``38`` use ``transformations[1]``.
-
-Each identifier must be unique. A block may contain samples for only some of the
-systems, but every ``"system"`` label present in the block must appear in
-``system_ids``. A gradient sample points to its parent value sample through its
-``"sample"`` label and uses the same transformation as its parent. When only one
-system is supplied, all samples use its transformation; the ``"system"`` column is
-optional and, if present, ignored.
+A :py:class:`~metatensor.torch.TensorBlock` in general contains values associated with
+several systems. This information is contained in the ``"system"`` samples dimension;
+each row is rotated with the transformation of the system it belongs to. Gradient blocks
+are routed the same way, via their parent block's ``"system"`` column. When only one
+system is being transformed, the ``"system"`` column is optional and, if present, is
+ignored: every row is rotated with the (single) given transformation.
 
 Reference
 ---------

--- a/metatomic-torch/CHANGELOG.md
+++ b/metatomic-torch/CHANGELOG.md
@@ -6,15 +6,22 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 
 ## [Unreleased](https://github.com/metatensor/metatomic/)
 
-<!-- Possible sections:
-### Added
+### Changed
+
+- Renamed `O3Transformation.is_inverted` to `is_improper`.
+- `O3Transformation` now stores its own matrix, returns copies from `matrix` and
+  `wigner_D_matrix`, and computes Wigner-D matrices on first use.
+- O(3) TensorMap transformations now validate component metadata, system
+  identifiers, and transformation dtype/device consistently.
+- `random_transformations` now accepts only `torch.float32` and `torch.float64`
+  and validates its count and angular-momentum limit before sampling.
 
 ### Fixed
 
-### Changed
-
-### Removed
--->
+- Corrected spherical parity under proper and improper transformations and made
+  Wigner-D evaluation stable near ZYZ Euler-angle poles.
+- O(3) transformations now retain TensorMap information, preserve registered
+  neighbor-list autograd, and support all ten recognized component axes.
 
 ## [Version 0.1.16](https://github.com/metatensor/metatomic/releases/tag/metatomic-torch-v0.1.16) - 2026-07-13
 

--- a/metatomic-torch/CHANGELOG.md
+++ b/metatomic-torch/CHANGELOG.md
@@ -6,22 +6,24 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 
 ## [Unreleased](https://github.com/metatensor/metatomic/)
 
+<!-- Possible sections:
+### Added
+
+### Fixed
+
+### Changed
+
+### Removed
+-->
+
 ### Changed
 
 - Renamed `O3Transformation.is_inverted` to `is_improper`.
-- `O3Transformation` now stores its own matrix, returns copies from `matrix` and
-  `wigner_D_matrix`, and computes Wigner-D matrices on first use.
-- O(3) TensorMap transformations now validate component metadata, system
-  identifiers, and transformation dtype/device consistently.
-- `random_transformations` now accepts only `torch.float32` and `torch.float64`
-  and validates its count and angular-momentum limit before sampling.
 
 ### Fixed
 
 - Corrected spherical parity under proper and improper transformations and made
   Wigner-D evaluation stable near ZYZ Euler-angle poles.
-- O(3) transformations now retain TensorMap information, preserve registered
-  neighbor-list autograd, and support all ten recognized component axes.
 
 ## [Version 0.1.16](https://github.com/metatensor/metatomic/releases/tag/metatomic-torch-v0.1.16) - 2026-07-13
 

--- a/metatomic-torch/CHANGELOG.md
+++ b/metatomic-torch/CHANGELOG.md
@@ -19,11 +19,14 @@ a changelog](https://keepachangelog.com/en/1.1.0/) format. This project follows
 ### Changed
 
 - Renamed `O3Transformation.is_inverted` to `is_improper`.
+- `wigners >= 0.4.0` is now required.
 
 ### Fixed
 
-- Corrected spherical parity under proper and improper transformations and made
-  Wigner-D evaluation stable near ZYZ Euler-angle poles.
+- `O3Transformation.transform_spherical` no longer applies the `(-1)^ell`
+  parity factor for proper transformations with `sigma = -1`.
+- Wigner-D evaluation is now stable near the ZYZ Euler-angle poles.
+- `transform_system` now preserves autograd for registered neighbor lists.
 
 ## [Version 0.1.16](https://github.com/metatensor/metatomic/releases/tag/metatomic-torch-v0.1.16) - 2026-07-13
 

--- a/python/metatomic_torch/metatomic/torch/o3/_tranformations.py
+++ b/python/metatomic_torch/metatomic/torch/o3/_tranformations.py
@@ -140,7 +140,7 @@ class O3Transformation:
     A single O(3) transformation, represented by a (3, 3) rotation or improper-rotation
     matrix.
 
-    The constructor stores a copy of ``matrix``, and :attr:`matrix` returns a copy.
+    The constructor stores a copy of ``matrix``.
     """
 
     def __init__(self, matrix: torch.Tensor, max_angular_momentum: int):
@@ -180,7 +180,13 @@ class O3Transformation:
         *,
         is_improper: bool,
     ) -> "O3Transformation":
-        """Create a transformation from an internally generated matrix."""
+        """Create a transformation after validation in ``random_transformations``.
+
+        The random factory validates its arguments and matrices before calling this
+        method. This avoids repeating the public constructor's checks, matrix copy,
+        and determinant calculation for every matrix. ``is_improper`` must match
+        ``matrix``.
+        """
         transformation = cls.__new__(cls)
         transformation._matrix = matrix
         transformation._max_angular_momentum = max_angular_momentum
@@ -212,8 +218,8 @@ class O3Transformation:
 
     @property
     def matrix(self) -> torch.Tensor:
-        """A copy of the (3, 3) rotation or improper-rotation matrix."""
-        return self._matrix.clone()
+        """The (3, 3) rotation or improper-rotation matrix."""
+        return self._matrix
 
     @property
     def dtype(self) -> torch.dtype:
@@ -276,7 +282,7 @@ class O3Transformation:
         return transformed
 
     def wigner_D_matrix(self, ell: int):
-        """Return a copy of the proper-part Wigner-D matrix for ``ell``.
+        """Return the proper-part Wigner-D matrix for ``ell``.
 
         For an improper transformation, :meth:`transform_spherical` applies the
         inversion-parity factor separately.
@@ -284,7 +290,7 @@ class O3Transformation:
         :param ell: angular momentum in ``[0, max_angular_momentum]``
         :return: (2*ell+1, 2*ell+1) Wigner-D matrix
         """
-        return self._wigner_D_cache_entry(ell).clone()
+        return self._wigner_D_cache_entry(ell)
 
 
 def random_transformations(

--- a/python/metatomic_torch/metatomic/torch/o3/_tranformations.py
+++ b/python/metatomic_torch/metatomic/torch/o3/_tranformations.py
@@ -3,6 +3,8 @@ Rotate systems and tensor maps under O(3) transformations, routing rows of
 multi-system tensors by their ``"system"`` sample label.
 """
 
+from numbers import Integral
+
 import torch
 from metatensor.torch import Labels, LabelsEntry, TensorBlock, TensorMap
 
@@ -15,21 +17,142 @@ _SUFFIXES = [""] + [f"_{i}" for i in range(1, 10)]
 _CARTESIAN_AXES = frozenset({f"xyz{s}" for s in _SUFFIXES})
 _SPHERICAL_AXIS_TO_LAMBDA = {f"o3_mu{s}": f"o3_lambda{s}" for s in _SUFFIXES}
 _SPHERICAL_AXIS_TO_SIGMA = {f"o3_mu{s}": f"o3_sigma{s}" for s in _SUFFIXES}
+_INTEGER_DTYPES = (torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64)
+
+
+def _validate_nonnegative_integer(name: str, value: int) -> int:
+    """Validate a non-negative integer and return it as a Python int."""
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise TypeError(f"{name} must be a non-negative integer.")
+
+    integer_value = int(value)
+    if integer_value < 0:
+        raise ValueError(f"{name} must be a non-negative integer, got {integer_value}.")
+
+    return integer_value
+
+
+def _spherical_parity_factor(
+    ell: int,
+    sigma: int,
+    is_improper: bool,
+) -> int:
+    """Return ``sigma * (-1) ** ell`` for an improper transformation, else ``1``."""
+    if isinstance(sigma, bool) or not isinstance(sigma, Integral):
+        raise TypeError("sigma must be either -1 or +1.")
+
+    sigma = int(sigma)
+    if sigma not in (-1, 1):
+        raise ValueError(f"sigma must be either -1 or +1, got {sigma}.")
+
+    if is_improper:
+        return sigma * ((-1) ** ell)
+
+    return 1
+
+
+def _validate_system_ids(
+    systems: list[System],
+    transformations: list["O3Transformation"],
+    system_ids: list[int] | torch.Tensor | None,
+    *,
+    expected_device: torch.device | None,
+) -> torch.Tensor:
+    """Return one distinct ``torch.long`` sample label per
+    system-transformation pair.
+    """
+    n_systems = len(systems)
+    n_transformations = len(transformations)
+    if n_systems != n_transformations:
+        raise ValueError(
+            "Expected one transformation per system, but got "
+            f"len(systems)={n_systems} and "
+            f"len(transformations)={n_transformations}."
+        )
+
+    if system_ids is None:
+        return torch.arange(n_systems, dtype=torch.long, device=expected_device)
+
+    if isinstance(system_ids, torch.Tensor):
+        if system_ids.ndim != 1:
+            raise ValueError(
+                "system_ids must be one-dimensional, but got a tensor with shape "
+                f"{tuple(system_ids.shape)}."
+            )
+        if system_ids.dtype not in _INTEGER_DTYPES:
+            raise ValueError(
+                "system_ids must contain integers, but got a tensor with dtype "
+                f"{system_ids.dtype}."
+            )
+        if expected_device is not None and system_ids.device != expected_device:
+            raise ValueError(
+                f"system_ids are on device {system_ids.device}, but the values to "
+                f"transform are on device {expected_device}."
+            )
+        validated_ids = system_ids.to(dtype=torch.long)
+    else:
+        python_ids: list[int] = []
+        for system_id in system_ids:
+            if isinstance(system_id, bool) or not isinstance(system_id, Integral):
+                raise ValueError("system_ids must contain integers.")
+            python_ids.append(int(system_id))
+        validated_ids = torch.tensor(
+            python_ids,
+            dtype=torch.long,
+            device=expected_device,
+        )
+
+    if len(validated_ids) != n_systems:
+        raise ValueError(
+            "system_ids must contain exactly one entry per system, but got "
+            f"len(system_ids)={len(validated_ids)} and len(systems)={n_systems}."
+        )
+    if torch.unique(validated_ids).numel() != n_systems:
+        raise ValueError(
+            "system_ids must contain one distinct entry per system, but got "
+            f"{validated_ids.tolist()}."
+        )
+
+    return validated_ids
+
+
+def _validate_transformations_dtype_device(
+    transformations: list["O3Transformation"],
+    *,
+    expected_dtype: torch.dtype,
+    expected_device: torch.device,
+) -> None:
+    """Check that every transformation has the expected dtype and device."""
+    for index, transformation in enumerate(transformations):
+        if (
+            transformation.dtype != expected_dtype
+            or transformation.device != expected_device
+        ):
+            raise ValueError(
+                f"Transformation at index {index} has dtype/device "
+                f"({transformation.dtype}, {transformation.device}), differing from "
+                f"the values to transform ({expected_dtype}, {expected_device})."
+            )
 
 
 class O3Transformation:
     """
     A single O(3) transformation, represented by a (3, 3) rotation or improper-rotation
     matrix.
+
+    The constructor stores a copy of ``matrix``, and :attr:`matrix` returns a copy.
     """
 
     def __init__(self, matrix: torch.Tensor, max_angular_momentum: int):
         """
         :param matrix: (3, 3) rotation or improper-rotation matrix
-        :param max_angular_momentum: maximum angular momentum of any spherical
-            representation to be transformed by this transformation; Wigner-D matrices
-            will be precomputed for all ``ell <= max_angular_momentum``
+        :param max_angular_momentum: non-negative maximum angular momentum for
+            Wigner-D matrices, which are computed and cached on first use
         """
+        max_angular_momentum = _validate_nonnegative_integer(
+            "max_angular_momentum", max_angular_momentum
+        )
+
         if matrix.shape != (3, 3):
             raise ValueError(
                 f"Transformation has shape {tuple(matrix.shape)}; expected (3, 3)."
@@ -41,21 +164,56 @@ class O3Transformation:
                 "Transformation is not orthogonal (R @ R.T deviates from I)."
             )
 
-        self._matrix = matrix
+        # Keep an independent copy so modifying the input tensor later cannot make
+        # the matrix disagree with the cached parity and Wigner-D matrices.
+        self._matrix = matrix.clone()
         self._max_angular_momentum = max_angular_momentum
-        self._is_inverted = bool(torch.det(matrix) < 0)
+        self._is_improper = bool(torch.det(self._matrix) < 0)
 
-        self._wigner_D_cache = build_wigner_D_cache(
-            max_angular_momentum,
-            matrix,
-            device=matrix.device,
-            dtype=matrix.dtype,
-        )
+        self._wigner_D_cache: dict[int, torch.Tensor] | None = None
+
+    @classmethod
+    def _create_from_internal_matrix(
+        cls,
+        matrix: torch.Tensor,
+        max_angular_momentum: int,
+        *,
+        is_improper: bool,
+    ) -> "O3Transformation":
+        """Create a transformation from an internally generated matrix."""
+        transformation = cls.__new__(cls)
+        transformation._matrix = matrix
+        transformation._max_angular_momentum = max_angular_momentum
+        transformation._is_improper = is_improper
+        transformation._wigner_D_cache = None
+        return transformation
+
+    def _ensure_wigner_D_cache(self) -> dict[int, torch.Tensor]:
+        """Ensure that the Wigner-D cache has been built and return it."""
+        if self._wigner_D_cache is None:
+            self._wigner_D_cache = build_wigner_D_cache(
+                self._max_angular_momentum,
+                self._matrix,
+                device=self._matrix.device,
+                dtype=self._matrix.dtype,
+            )
+
+        return self._wigner_D_cache
+
+    def _wigner_D_cache_entry(self, ell: int) -> torch.Tensor:
+        """Return the internal cache entry for ``ell`` without copying it."""
+        ell = self._validate_ell_range(ell)
+
+        D = self._ensure_wigner_D_cache().get(ell)
+        if D is None:
+            raise ValueError(f"Wigner-D matrix for ell={ell} not found in cache.")
+
+        return D
 
     @property
     def matrix(self) -> torch.Tensor:
-        """The (3, 3) rotation or improper-rotation matrix."""
-        return self._matrix
+        """A copy of the (3, 3) rotation or improper-rotation matrix."""
+        return self._matrix.clone()
 
     @property
     def dtype(self) -> torch.dtype:
@@ -68,9 +226,9 @@ class O3Transformation:
         return self._matrix.device
 
     @property
-    def is_inverted(self) -> bool:
-        """Whether this transformation is an improper rotation (det < 0)."""
-        return self._is_inverted
+    def is_improper(self) -> bool:
+        """Whether this transformation is improper, with negative determinant."""
+        return self._is_improper
 
     def transform_cartesian(self, vectors: torch.Tensor) -> torch.Tensor:
         """Apply the transformation to Cartesian vectors.
@@ -80,34 +238,53 @@ class O3Transformation:
         """
         return vectors @ self._matrix.T
 
+    def _validate_ell_range(self, ell: int) -> int:
+        """Check that ``ell`` is an integer in ``[0, max_angular_momentum]``."""
+        ell = _validate_nonnegative_integer("ell", ell)
+
+        if ell > self._max_angular_momentum:
+            raise ValueError(
+                f"ell={ell} exceeds max_angular_momentum={self._max_angular_momentum}."
+            )
+
+        return ell
+
     def transform_spherical(
         self, values: torch.Tensor, ell: int, sigma: int
     ) -> torch.Tensor:
         """Apply the transformation to spherical values.
 
         :param values: (..., 2*ell+1) tensor of spherical values
-        :param ell: angular momentum of the spherical representation
-        :param sigma: inversion parity of the spherical representation
+        :param ell: angular momentum in ``[0, max_angular_momentum]``
+        :param sigma: ``+1`` for a proper spherical representation or ``-1`` for
+            a pseudo one. Under an improper transformation, the representation
+            acquires the factor ``sigma * (-1) ** ell``.
         :return: (..., 2*ell+1) tensor of transformed spherical values
         """
-        D = self._wigner_D_cache.get(ell)
-        if D is None:
-            raise ValueError(f"Wigner-D matrix for ell={ell} not found in cache.")
+        ell = self._validate_ell_range(ell)
+        parity_factor = _spherical_parity_factor(
+            ell,
+            sigma,
+            is_improper=self.is_improper,
+        )
+
+        D = self._wigner_D_cache_entry(ell)
         transformed = values @ D.T
-        if sigma == -1:
-            transformed = transformed * ((-1) ** ell)
+        if parity_factor != 1:
+            transformed = transformed * parity_factor
+
         return transformed
 
     def wigner_D_matrix(self, ell: int):
-        """Return the Wigner-D matrix for this transformation and angular momentum ell.
+        """Return a copy of the proper-part Wigner-D matrix for ``ell``.
 
-        :param ell: angular momentum of the spherical representation
+        For an improper transformation, :meth:`transform_spherical` applies the
+        inversion-parity factor separately.
+
+        :param ell: angular momentum in ``[0, max_angular_momentum]``
         :return: (2*ell+1, 2*ell+1) Wigner-D matrix
         """
-        D = self._wigner_D_cache.get(ell)
-        if D is None:
-            raise ValueError(f"Wigner-D matrix for ell={ell} not found in cache.")
-        return D
+        return self._wigner_D_cache_entry(ell).clone()
 
 
 def random_transformations(
@@ -119,21 +296,32 @@ def random_transformations(
     include_inversions: bool = False,
     generator: torch.Generator | None = None,
 ) -> list[O3Transformation]:
-    """Sample ``n`` uniformly distributed O(3) transformations.
+    """Sample ``n`` transformations uniformly from SO(3), or from O(3) when
+    inversions are included.
 
     Rotations are sampled from the Haar measure on SO(3) via random unit quaternions.
     When ``include_inversions`` is ``True``, each matrix is independently negated with
     probability 0.5, giving a uniform distribution over the full O(3) group.
 
-    :param n: number of transformations to generate
-    :param max_angular_momentum: maximum angular momentum for Wigner-D matrices
+    :param n: non-negative number of transformations to generate
+    :param max_angular_momentum: non-negative maximum angular momentum for
+        Wigner-D matrices
     :param device: target device for the output tensors
-    :param dtype: target dtype for the output tensors
+    :param dtype: target dtype for the output tensors; must be
+        :attr:`torch.float32` or :attr:`torch.float64`
     :param include_inversions: if ``True``, sample from O(3) instead of SO(3)
     :param generator: optional :class:`torch.Generator` for reproducible sampling; when
         ``None`` the global RNG is used
-    :return: list of ``n`` orthogonal (3, 3) tensors
+    :return: list of ``n`` :class:`O3Transformation` objects
     """
+    n = _validate_nonnegative_integer("n", n)
+    max_angular_momentum = _validate_nonnegative_integer(
+        "max_angular_momentum", max_angular_momentum
+    )
+
+    if dtype not in (torch.float32, torch.float64):
+        raise ValueError(f"dtype must be torch.float32 or torch.float64, got {dtype}.")
+
     q = torch.randn(n, 4, device=device, dtype=dtype, generator=generator)
     q = q / q.norm(dim=1, keepdim=True)
     w, x, y, z = q.unbind(1)
@@ -153,33 +341,45 @@ def random_transformations(
         dim=1,
     ).reshape(n, 3, 3)
 
+    matrices_are_improper = [False] * n
+
     if include_inversions:
         signs = torch.randint(0, 2, (n,), device=device, generator=generator) * 2 - 1
         R = R * signs.to(dtype=dtype).reshape(n, 1, 1)
+        matrices_are_improper = (signs < 0).tolist()
 
-    return [O3Transformation(r, max_angular_momentum) for r in R.unbind(0)]
+    identity = torch.eye(
+        3,
+        device=R.device,
+        dtype=R.dtype,
+    ).expand(n, 3, 3)
+    if not torch.allclose(
+        R @ R.transpose(-1, -2),
+        identity,
+        atol=1e-5,
+    ):
+        raise ValueError("Generated transformations are not orthogonal.")
+
+    return [
+        O3Transformation._create_from_internal_matrix(
+            matrix,
+            max_angular_momentum,
+            is_improper=is_improper,
+        )
+        for matrix, is_improper in zip(
+            R.unbind(0),
+            matrices_are_improper,
+            strict=True,
+        )
+    ]
 
 
-def _block_row_indices_by_system(
+def _value_row_indices_by_system(
     block: TensorBlock,
     system_ids: torch.Tensor,
 ) -> list[torch.Tensor]:
-    """Return row-index tensors into ``block.values``, one per system.
-
-    With a single system every row belongs to it (any ``"system"`` label is ignored).
-
-    With several systems the ``"system"`` column is required and each row is routed by
-    matching its ``"system"`` label against ``system_ids``.
-
-    :param block: block whose ``samples`` may contain a ``"system"`` column
-    :param system_ids: one value per system; ``system_ids[i]`` is the value of the
-        ``"system"`` column identifying the rows belonging to the i-th entry in the
-        ``systems`` list passed to ``transform_tensor`` or ``transform_block``
-    :return: list of length ``len(system_ids)``; entry ``i`` selects the rows of system
-        ``i``
-    """
-    n_systems = len(system_ids)
-    if n_systems == 1:
+    """Return value-row indices in ``system_ids`` order, or all rows for one system."""
+    if len(system_ids) == 1:
         return [torch.arange(block.values.shape[0], device=block.values.device)]
 
     if "system" not in block.samples.names:
@@ -187,19 +387,19 @@ def _block_row_indices_by_system(
             "Rotational augmentation expects output samples to include a 'system' "
             "dimension when transforming multiple systems."
         )
-    system_column = block.samples.column("system").to(dtype=torch.long)
-    distinct = torch.unique(system_column)
-    covered = torch.isin(distinct, system_ids)
-    if not covered.all():
-        uncovered = distinct[~covered]
+    system_labels = block.samples.column("system").to(dtype=torch.long)
+    unique_labels = torch.unique(system_labels)
+    labels_are_known = torch.isin(unique_labels, system_ids)
+    if not labels_are_known.all():
+        unknown_labels = unique_labels[~labels_are_known]
         raise ValueError(
-            f"Block samples contain system labels {uncovered.tolist()} that are "
+            f"Block samples contain system labels {unknown_labels.tolist()} that are "
             f"not in system_ids={system_ids.tolist()}. Every sample must be "
             f"assigned to a system in the transformation."
         )
     return [
-        torch.nonzero(system_column == label, as_tuple=False).reshape(-1)
-        for label in system_ids
+        torch.nonzero(system_labels == system_id, as_tuple=False).reshape(-1)
+        for system_id in system_ids
     ]
 
 
@@ -208,47 +408,41 @@ def _gradient_row_indices_by_system(
     parent_block: TensorBlock,
     system_ids: torch.Tensor,
 ) -> list[torch.Tensor]:
-    """Return row-index tensors into a gradient block, one per system.
-
-    Gradient samples carry a ``"sample"`` column indexing into the parent block rather
-    than their own ``"system"`` column, so the system of each gradient row is read from
-    the parent block's ``"system"`` column.
-
-    :param grad_block: gradient block to route
-    :param parent_block: the value block this gradient is attached to
-    :param system_ids: one value per system; ``system_ids[i]`` is the value of the
-        ``"system"`` column identifying the rows belonging to the i-th entry in the
-        ``systems`` list passed to ``transform_tensor`` or ``transform_block``
-    :return: list of length ``len(system_ids)``; entry ``i`` selects the gradient
-        rows of system ``i``
-    """
-    n_systems = len(system_ids)
-    if n_systems == 1:
+    """Group gradient rows by the system of their referenced value row."""
+    if len(system_ids) == 1:
         return [
             torch.arange(grad_block.values.shape[0], device=grad_block.values.device)
         ]
+
     if "system" not in parent_block.samples.names:
         raise ValueError(
             "Rotational augmentation expects the values samples to include a 'system' "
             "dimension when transforming gradients of multiple systems."
         )
-    parent_system = parent_block.samples.column("system").to(dtype=torch.long)
-    sample_index = grad_block.samples.column("sample").to(dtype=torch.long)
-    grad_system = parent_system[sample_index]
+
+    parent_system_labels = parent_block.samples.column("system").to(dtype=torch.long)
+    parent_value_rows = grad_block.samples.column("sample").to(dtype=torch.long)
+    gradient_system_labels = parent_system_labels[parent_value_rows]
+
     return [
-        torch.nonzero(grad_system == label, as_tuple=False).reshape(-1)
-        for label in system_ids
+        torch.nonzero(
+            gradient_system_labels == system_id,
+            as_tuple=False,
+        ).reshape(-1)
+        for system_id in system_ids
     ]
 
 
 def transform_system(system: System, transformation: O3Transformation) -> System:
     """Apply an O(3) transformation to a single System.
 
-    This function will transform positions, cell vectors, neighbor-list displacement
-    vectors, and any custom data.
+    Positions, cell vectors, neighbor-list displacements, and custom data following
+    :ref:`o3-conventions` are transformed. Atomic types and periodic-boundary flags
+    are preserved.
 
     :param system: input system
-    :param transformation: O(3) transformation to apply
+    :param transformation: O(3) transformation to apply, matching
+        ``system.positions`` in dtype and device
     :return: new System with transformed geometry
     """
     if (
@@ -278,7 +472,8 @@ def transform_system(system: System, transformation: O3Transformation) -> System
     for options in system.known_neighbor_lists():
         neighbors = system.get_neighbor_list(options)
         # neighbor vectors are stored as (N, 3, 1); squeeze/unsqueeze around the matmul
-        neighbors_values = neighbors.values.squeeze(-1)
+        # Detach the input graph before registering the rotated values below.
+        neighbors_values = neighbors.values.detach().squeeze(-1)
         new_values = transformation.transform_cartesian(neighbors_values)
         rotated_neighbors = TensorBlock(
             values=new_values.unsqueeze(-1),
@@ -306,14 +501,15 @@ def _contract_component_axes(
     :param matrices: one rotation matrix per component axis (empty for scalars)
     :return: rotated values, same shape as the input
     """
-    # einsum index letters for the per-axis component contraction (input lower, output
-    # upper). Six axes is far more than any realistic block (value + gradient) needs.
-    _EINSUM_IN = "abcdef"
-    _EINSUM_OUT = "ABCDEF"
+    # Reserve einsum indices for all ten component axes supported by Metatomic.
+    _EINSUM_IN = "abcdefghjk"
+    _EINSUM_OUT = "ABCDEFGHIJ"
 
     if len(matrices) == 0:
         return values
     n_axes = len(matrices)
+    if n_axes > len(_EINSUM_IN):
+        raise ValueError(f"can not transform a tensor with {n_axes} component axes")
     in_subscript = "i" + _EINSUM_IN[:n_axes] + "p"
     out_subscript = "i" + _EINSUM_OUT[:n_axes] + "p"
     matrix_subscripts = [_EINSUM_OUT[j] + _EINSUM_IN[j] for j in range(n_axes)]
@@ -321,43 +517,83 @@ def _contract_component_axes(
     return torch.einsum(equation, *matrices, values)
 
 
-def _axis_matrices_and_parity(
+def _validate_component_axis_metadata(
     components: list[Labels],
     key: LabelsEntry,
-    transformation: O3Transformation,
-) -> tuple[list[torch.Tensor], int]:
-    """Pick the rotation matrix for each component axis and the O(3) inversion parity.
+) -> list[tuple[str, int, int]]:
+    """Validate component axes and return ``(axis_name, ell, sigma)`` for each one.
 
-    Cartesian axes (``xyz``/``xyz_1``/``xyz_2``/...) use the rotation directly, so
-    improper rotations flip vectors automatically. Spherical axes
-    (``o3_mu``/``o3_mu_1``/ ``o3_mu_2``) use the proper-rotation Wigner-D matrix of the
-    matching ``o3_lambda`` plus a ``(-1)^ell * sigma`` parity factor accumulated
-    whenever ``transformation`` is improper.
-
-    :param name: TensorMap name, used only in error messages
-    :param components: component :class:`Labels` of the block (or gradient block)
-    :param key: the parent block's key, supplying ``o3_lambda``/``o3_sigma`` values
-    :param transformation: this system's O3 transformation
-    :return: ``(matrices, parity)`` with one matrix per component axis
+    ``ell`` and ``sigma`` come from the block key and apply only to spherical axes.
     """
-    matrices: list[torch.Tensor] = []
-    parity = 1
+    if len(components) > len(_SUFFIXES):
+        raise ValueError(
+            f"can not transform a tensor with {len(components)} component axes; "
+            f"at most {len(_SUFFIXES)} are supported"
+        )
+
+    metadata: list[tuple[str, int, int]] = []
     for component in components:
         axis_name = component.names[0]
         if axis_name in _CARTESIAN_AXES:
-            matrices.append(transformation.matrix)
+            expected_labels = torch.arange(
+                3,
+                device=component.values.device,
+                dtype=component.values.dtype,
+            )
+            if not torch.equal(component.values[:, 0], expected_labels):
+                raise ValueError(
+                    f"Cartesian component axis '{axis_name}' must use labels "
+                    "[0, 1, 2] in x, y, z order."
+                )
+            metadata.append((axis_name, 0, 1))
         elif axis_name in _SPHERICAL_AXIS_TO_LAMBDA:
-            ell = int(key[_SPHERICAL_AXIS_TO_LAMBDA[axis_name]])
-            matrices.append(transformation.wigner_D_matrix(ell))
-            if transformation.is_inverted:
-                sigma = int(key[_SPHERICAL_AXIS_TO_SIGMA[axis_name]])
-                parity *= ((-1) ** ell) * sigma
+            ell = _validate_nonnegative_integer(
+                "ell",
+                int(key[_SPHERICAL_AXIS_TO_LAMBDA[axis_name]]),
+            )
+            sigma = int(key[_SPHERICAL_AXIS_TO_SIGMA[axis_name]])
+            _spherical_parity_factor(ell, sigma, is_improper=False)
+
+            expected_labels = torch.arange(
+                -ell,
+                ell + 1,
+                device=component.values.device,
+                dtype=component.values.dtype,
+            )
+            if not torch.equal(component.values[:, 0], expected_labels):
+                raise ValueError(
+                    f"Spherical component axis '{axis_name}' for ell={ell} must use "
+                    f"labels from {-ell} through {ell} in ascending order."
+                )
+            metadata.append((axis_name, ell, sigma))
         else:
             raise ValueError(
                 f"Found a component axis '{axis_name}', which is neither a Cartesian "
                 "('xyz'/'xyz_1'/'xyz_2'/...) nor spherical ('o3_mu'/'o3_mu_1'/...) "
                 "axis; it can not be transformed."
             )
+
+    return metadata
+
+
+def _axis_matrices_and_parity(
+    metadata: list[tuple[str, int, int]],
+    transformation: O3Transformation,
+) -> tuple[list[torch.Tensor], int]:
+    """Return the axis matrices and their combined spherical parity factor."""
+    matrices: list[torch.Tensor] = []
+    parity = 1
+    for axis_name, ell, sigma in metadata:
+        if axis_name in _CARTESIAN_AXES:
+            matrices.append(transformation._matrix)
+        else:
+            matrices.append(transformation._wigner_D_cache_entry(ell))
+            parity *= _spherical_parity_factor(
+                ell,
+                sigma,
+                transformation.is_improper,
+            )
+
     return matrices, parity
 
 
@@ -368,23 +604,15 @@ def _transform_component_values(
     row_indices: list[torch.Tensor],
     transformations: list[O3Transformation],
 ) -> torch.Tensor:
-    """Rotate the values of a single value or gradient block, per system.
-
-    :param name: TensorMap name, used only in error messages
-    :param values: the block's values tensor
-    :param components: the block's component :class:`Labels`
-    :param key: the parent block's key (for spherical ``o3_lambda``/``o3_sigma``)
-    :param row_indices: per-system row indices into ``values``
-    :param transformations: per-system (3, 3) transformation matrices
-    :param wigner_D_matrices: ``{ell: [D_0, ..., D_{N-1}]}`` real Wigner-D matrices
-    :return: new values tensor with each system's rows rotated
-    """
+    """Rotate value or gradient rows with their assigned transformation."""
+    metadata = _validate_component_axis_metadata(components, key)
     new_values = values.clone()
     for system_index, rows in enumerate(row_indices):
         if len(rows) == 0:
             continue
         matrices, parity = _axis_matrices_and_parity(
-            components, key, transformations[system_index]
+            metadata,
+            transformations[system_index],
         )
         rotated = _contract_component_axes(values[rows], matrices)
         if parity != 1:
@@ -400,80 +628,78 @@ def transform_block(
     transformations: list[O3Transformation],
     system_ids: list[int] | torch.Tensor | None = None,
 ) -> TensorBlock:
-    """Rotate one block and all of its gradients.
+    """Apply per-system O(3) transformations to a block and its gradients.
 
-    :param key: the block's key, containing ``o3_lambda``/``o3_sigma`` values for
-        spherical blocks
-    :param block: the block to rotate
-    :param systems: list of systems, one per transformation
-    :param transformations: per-system O(3) transformation matrices
-    :param system_ids: index of the ``systems`` used in the samples of ``block``;
-        defaults to ``list(range(len(systems)))``
-    :return: new block with rotated values and gradients
+    :param key: parent block key, supplying the O(3) labels required by spherical
+        component axes
+    :param block: block to transform
+    :param systems: systems corresponding positionally to ``transformations``
+    :param transformations: one O(3) transformation per system, matching
+        ``block.values`` in dtype and device
+    :param system_ids: one distinct integer ``"system"`` sample label per system;
+        entry ``i`` is paired with ``transformations[i]``. A tensor argument must
+        be one-dimensional and use the same device as ``block.values``. Defaults
+        to ``range(len(systems))``
+    :return: block with transformed values and gradients and unchanged labels; when
+        ``systems`` is empty, the block is unchanged
     """
-    assert len(systems) == len(transformations)
+    system_ids = _validate_system_ids(
+        systems,
+        transformations,
+        system_ids,
+        expected_device=block.values.device,
+    )
     if len(systems) == 0:
         return block
 
-    if system_ids is None:
-        system_ids = list(range(len(systems)))
+    _validate_transformations_dtype_device(
+        transformations,
+        expected_dtype=block.values.dtype,
+        expected_device=block.values.device,
+    )
 
-    if not isinstance(system_ids, torch.Tensor):
-        system_ids = torch.tensor(
-            system_ids, dtype=torch.int32, device=block.values.device
-        )
-
-    if (
-        block.values.dtype != transformations[0].dtype
-        or block.values.device != transformations[0].device
-    ):
-        raise ValueError(
-            f"TensorMap has values with dtype/device "
-            f"({block.values.dtype}, {block.values.device}) differing "
-            f"from the transformations ({transformations[0].dtype}, "
-            f"{transformations[0].device})."
-        )
-
-    return _transform_block_impl(key, block, systems, transformations, system_ids)
+    return _transform_block_impl(key, block, transformations, system_ids)
 
 
 def _transform_block_impl(
     key: LabelsEntry,
     block: TensorBlock,
-    systems: list[System],
     transformations: list[O3Transformation],
     system_ids: torch.Tensor,
 ) -> TensorBlock:
-    """Implementation of ``transform_block`` without the initial checks"""
-    row_indices = _block_row_indices_by_system(block, system_ids)
+    """Transform block values and gradients using validated system assignments."""
+    value_sample_indices = _value_row_indices_by_system(block, system_ids)
     new_block = TensorBlock(
         values=_transform_component_values(
             block.values,
             block.components,
             key,
-            row_indices,
+            value_sample_indices,
             transformations,
         ),
         samples=block.samples,
         components=block.components,
         properties=block.properties,
     )
-    for gradient_name in block.gradients_list():
-        grad_block = block.gradient(gradient_name)
-        grad_rows = _gradient_row_indices_by_system(grad_block, block, system_ids)
+    for gradient_name, gradient in block.gradients():
+        gradient_sample_indices = _gradient_row_indices_by_system(
+            gradient,
+            block,
+            system_ids,
+        )
         new_block.add_gradient(
             gradient_name,
             TensorBlock(
                 values=_transform_component_values(
-                    grad_block.values,
-                    grad_block.components,
+                    gradient.values,
+                    gradient.components,
                     key,
-                    grad_rows,
+                    gradient_sample_indices,
                     transformations,
                 ),
-                samples=grad_block.samples,
-                components=grad_block.components,
-                properties=grad_block.properties,
+                samples=gradient.samples,
+                components=gradient.components,
+                properties=gradient.properties,
             ),
         )
     return new_block
@@ -485,49 +711,56 @@ def transform_tensor(
     transformations: list[O3Transformation],
     system_ids: list[int] | torch.Tensor | None = None,
 ) -> TensorMap:
-    """Rotate every block (and its gradients) of a TensorMap.
+    """Apply per-system O(3) transformations to a TensorMap and its gradients.
 
-    The tensor character of each component axis is inferred from its name, so a single
-    :py:class:`TensorMap` may freely mix scalar, Cartesian and spherical blocks, and
-    blocks may carry gradients.
+    Blocks without component axes are scalar. Cartesian and spherical component
+    axes are identified by name, so one :py:class:`TensorMap` may contain all three
+    kinds of data.
 
-    One of the samples dimensions must be ``"system"``, which is used to route each row
-    to the correct system and transformation.
+    With multiple systems, the ``"system"`` sample label assigns each value sample
+    to a transformation. With one system, this label is optional and ignored.
 
-    :param tensor: TensorMap to rotate
-    :param systems: input systems
-    :param transformations: per-system O(3) transformation matrices
-    :param system_ids: index of the ``systems`` used in the samples of ``tensor``;
-        defaults to ``list(range(len(systems)))``
-    :return: new TensorMap with rotated values and gradients
+    :param tensor: TensorMap to transform
+    :param systems: systems corresponding positionally to ``transformations``
+    :param transformations: one O(3) transformation per system, matching the tensor
+        values in dtype and device when present
+    :param system_ids: one distinct integer ``"system"`` sample label per system;
+        entry ``i`` is paired with ``transformations[i]``. A tensor argument must
+        be one-dimensional and use the transformations' device. Defaults to
+        ``range(len(systems))``
+    :return: transformed TensorMap with the same keys and global information; when
+        ``systems`` is empty, the tensor is unchanged
     """
-    assert len(systems) == len(transformations)
+    if len(tensor) != 0:
+        system_ids_device = tensor.block(0).values.device
+    elif len(transformations) != 0:
+        system_ids_device = transformations[0].device
+    else:
+        system_ids_device = None
+
+    system_ids = _validate_system_ids(
+        systems,
+        transformations,
+        system_ids,
+        expected_device=system_ids_device,
+    )
     if len(systems) == 0:
         return tensor
 
-    if system_ids is None:
-        system_ids = list(range(len(systems)))
-
-    if not isinstance(system_ids, torch.Tensor):
-        system_ids = torch.tensor(
-            system_ids, dtype=torch.int32, device=transformations[0].device
+    if len(tensor) != 0:
+        values = tensor.block(0).values
+        _validate_transformations_dtype_device(
+            transformations,
+            expected_dtype=values.dtype,
+            expected_device=values.device,
         )
 
-    if len(tensor) != 0:
-        block = tensor.block(0)
-        if (
-            block.values.dtype != transformations[0].dtype
-            or block.values.device != transformations[0].device
-        ):
-            raise ValueError(
-                f"TensorMap has values with dtype/device "
-                f"({block.values.dtype}, {block.values.device}) differing "
-                f"from the transformations ({transformations[0].dtype}, "
-                f"{transformations[0].device})."
-            )
-
     new_blocks = [
-        _transform_block_impl(key, block, systems, transformations, system_ids)
+        _transform_block_impl(key, block, transformations, system_ids)
         for key, block in tensor.items()
     ]
-    return TensorMap(keys=tensor.keys, blocks=new_blocks)
+    transformed = TensorMap(keys=tensor.keys, blocks=new_blocks)
+    for info_key, info_value in tensor.info().items():
+        transformed.set_info(info_key, info_value)
+
+    return transformed

--- a/python/metatomic_torch/metatomic/torch/o3/_tranformations.py
+++ b/python/metatomic_torch/metatomic/torch/o3/_tranformations.py
@@ -12,20 +12,17 @@ from .. import System, register_autograd_neighbors
 from ._wigner import build_wigner_D_cache
 
 
-# Component-axis names recognised by the augmentation machinery.
-_SUFFIXES = [""] + [f"_{i}" for i in range(1, 10)]
-_CARTESIAN_AXES = frozenset({f"xyz{s}" for s in _SUFFIXES})
-_SPHERICAL_AXIS_TO_LAMBDA = {f"o3_mu{s}": f"o3_lambda{s}" for s in _SUFFIXES}
-_SPHERICAL_AXIS_TO_SIGMA = {f"o3_mu{s}": f"o3_sigma{s}" for s in _SUFFIXES}
 _INTEGER_DTYPES = (torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64)
 
 
 def _validate_nonnegative_integer(name: str, value: int) -> int:
     """Validate a non-negative integer and return it as a Python int."""
-    if isinstance(value, bool) or not isinstance(value, Integral):
-        raise TypeError(f"{name} must be a non-negative integer.")
-
-    integer_value = int(value)
+    if torch.jit.is_scripting():
+        integer_value = value
+    else:
+        if isinstance(value, bool) or not isinstance(value, Integral):
+            raise TypeError(f"{name} must be a non-negative integer.")
+        integer_value = int(value)
     if integer_value < 0:
         raise ValueError(f"{name} must be a non-negative integer, got {integer_value}.")
 
@@ -38,15 +35,17 @@ def _spherical_parity_factor(
     is_improper: bool,
 ) -> int:
     """Return ``sigma * (-1) ** ell`` for an improper transformation, else ``1``."""
-    if isinstance(sigma, bool) or not isinstance(sigma, Integral):
-        raise TypeError("sigma must be either -1 or +1.")
-
-    sigma = int(sigma)
-    if sigma not in (-1, 1):
-        raise ValueError(f"sigma must be either -1 or +1, got {sigma}.")
+    if torch.jit.is_scripting():
+        integer_sigma = sigma
+    else:
+        if isinstance(sigma, bool) or not isinstance(sigma, Integral):
+            raise TypeError("sigma must be either -1 or +1.")
+        integer_sigma = int(sigma)
+    if integer_sigma not in (-1, 1):
+        raise ValueError(f"sigma must be either -1 or +1, got {integer_sigma}.")
 
     if is_improper:
-        return sigma * ((-1) ** ell)
+        return integer_sigma * int((-1) ** ell)
 
     return 1
 
@@ -523,24 +522,32 @@ def _contract_component_axes(
     return torch.einsum(equation, *matrices, values)
 
 
+def _component_axis_suffix(axis_name: str, prefix: str) -> tuple[bool, str]:
+    """Match a component-axis name and return its supported suffix."""
+    suffixes = ["", "_1", "_2", "_3", "_4", "_5", "_6", "_7", "_8", "_9"]
+    for suffix in suffixes:
+        if axis_name == prefix + suffix:
+            return True, suffix
+    return False, ""
+
+
 def _validate_component_axis_metadata(
     components: list[Labels],
     key: LabelsEntry,
-) -> list[tuple[str, int, int]]:
-    """Validate component axes and return ``(axis_name, ell, sigma)`` for each one.
-
-    ``ell`` and ``sigma`` come from the block key and apply only to spherical axes.
-    """
-    if len(components) > len(_SUFFIXES):
+) -> list[tuple[bool, int, int]]:
+    """Validate component axes and return ``(is_spherical, ell, sigma)`` metadata."""
+    if len(components) > 10:
         raise ValueError(
             f"can not transform a tensor with {len(components)} component axes; "
-            f"at most {len(_SUFFIXES)} are supported"
+            "at most 10 are supported"
         )
 
-    metadata: list[tuple[str, int, int]] = []
+    metadata: list[tuple[bool, int, int]] = []
     for component in components:
         axis_name = component.names[0]
-        if axis_name in _CARTESIAN_AXES:
+        is_cartesian, _ = _component_axis_suffix(axis_name, "xyz")
+        is_spherical, suffix = _component_axis_suffix(axis_name, "o3_mu")
+        if is_cartesian:
             expected_labels = torch.arange(
                 3,
                 device=component.values.device,
@@ -551,13 +558,13 @@ def _validate_component_axis_metadata(
                     f"Cartesian component axis '{axis_name}' must use labels "
                     "[0, 1, 2] in x, y, z order."
                 )
-            metadata.append((axis_name, 0, 1))
-        elif axis_name in _SPHERICAL_AXIS_TO_LAMBDA:
+            metadata.append((False, 0, 1))
+        elif is_spherical:
             ell = _validate_nonnegative_integer(
                 "ell",
-                int(key[_SPHERICAL_AXIS_TO_LAMBDA[axis_name]]),
+                int(key["o3_lambda" + suffix]),
             )
-            sigma = int(key[_SPHERICAL_AXIS_TO_SIGMA[axis_name]])
+            sigma = int(key["o3_sigma" + suffix])
             _spherical_parity_factor(ell, sigma, is_improper=False)
 
             expected_labels = torch.arange(
@@ -571,7 +578,7 @@ def _validate_component_axis_metadata(
                     f"Spherical component axis '{axis_name}' for ell={ell} must use "
                     f"labels from {-ell} through {ell} in ascending order."
                 )
-            metadata.append((axis_name, ell, sigma))
+            metadata.append((True, ell, sigma))
         else:
             raise ValueError(
                 f"Found a component axis '{axis_name}', which is neither a Cartesian "
@@ -582,23 +589,47 @@ def _validate_component_axis_metadata(
     return metadata
 
 
+def _max_o3_lambda_in_tensor(tensor: TensorMap) -> int:
+    """Return the largest spherical rank in block values or attached gradients.
+
+    A TensorMap containing only scalar or Cartesian component axes returns ``-1``.
+    """
+    max_o3_lambda = -1
+    for key, block in tensor.items():
+        metadata = _validate_component_axis_metadata(block.components, key)
+        for is_spherical, ell, _sigma in metadata:
+            if is_spherical and ell > max_o3_lambda:
+                max_o3_lambda = ell
+
+        for _gradient_name, gradient in block.gradients():
+            gradient_metadata = _validate_component_axis_metadata(
+                gradient.components,
+                key,
+            )
+            for is_spherical, ell, _sigma in gradient_metadata:
+                if is_spherical and ell > max_o3_lambda:
+                    max_o3_lambda = ell
+
+    return max_o3_lambda
+
+
 def _axis_matrices_and_parity(
-    metadata: list[tuple[str, int, int]],
+    metadata: list[tuple[bool, int, int]],
     transformation: O3Transformation,
 ) -> tuple[list[torch.Tensor], int]:
     """Return the axis matrices and their combined spherical parity factor."""
     matrices: list[torch.Tensor] = []
     parity = 1
-    for axis_name, ell, sigma in metadata:
-        if axis_name in _CARTESIAN_AXES:
-            matrices.append(transformation._matrix)
-        else:
+    for is_spherical, ell, sigma in metadata:
+        if is_spherical:
             matrices.append(transformation._wigner_D_cache_entry(ell))
             parity *= _spherical_parity_factor(
                 ell,
                 sigma,
                 transformation.is_improper,
             )
+        else:
+            matrices.append(transformation._matrix)
 
     return matrices, parity
 
@@ -769,4 +800,155 @@ def transform_tensor(
     for info_key, info_value in tensor.info().items():
         transformed.set_info(info_key, info_value)
 
+    return transformed
+
+
+def _transformation_indices(
+    samples: Labels,
+    n_transformations: int,
+) -> torch.Tensor:
+    """Map sample rows to local transformation indices."""
+    if n_transformations <= 0:
+        raise ValueError("n_transformations must be positive")
+    if n_transformations == 1:
+        return torch.zeros(
+            len(samples),
+            dtype=torch.long,
+            device=samples.device,
+        )
+    if "system" not in samples.names:
+        raise ValueError("multiple transformations require a 'system' sample dimension")
+
+    indices = samples.column("system").to(dtype=torch.long)
+    if bool(torch.any((indices < 0) | (indices >= n_transformations)).item()):
+        raise ValueError("sample system indices exceed the transformation batch")
+    return indices
+
+
+def _transform_component_values_with_precomputed_matrices(
+    values: torch.Tensor,
+    components: list[Labels],
+    key: LabelsEntry,
+    transformation_indices: torch.Tensor,
+    matrices: torch.Tensor,
+    wigner_matrices: list[torch.Tensor],
+    is_improper: bool,
+) -> torch.Tensor:
+    """Transform component axes with precomputed O(3) matrices."""
+    metadata = _validate_component_axis_metadata(components, key)
+    if len(metadata) == 0:
+        return values.clone()
+
+    transformed = values
+    parity = 1
+    for component_index, (is_spherical, ell, sigma) in enumerate(metadata):
+        if is_spherical:
+            if ell >= len(wigner_matrices):
+                raise ValueError("spherical rank exceeds the Wigner-D storage")
+            axis_matrices = wigner_matrices[ell]
+            parity *= _spherical_parity_factor(ell, sigma, is_improper)
+        else:
+            axis_matrices = matrices
+
+        component_axis = component_index + 1
+        moved = torch.movedim(transformed, component_axis, -1)
+        moved_shape = moved.shape
+        flattened = moved.flatten(start_dim=1, end_dim=-2)
+        matrices_for_rows = axis_matrices.index_select(
+            0,
+            transformation_indices,
+        )
+        transformed = torch.bmm(
+            flattened,
+            matrices_for_rows.transpose(1, 2),
+        )
+        transformed = transformed.reshape(moved_shape)
+        transformed = torch.movedim(transformed, -1, component_axis)
+
+    if parity != 1:
+        transformed = transformed * parity
+    return transformed
+
+
+def _transform_tensor_with_precomputed_matrices(
+    tensor: TensorMap,
+    matrices: torch.Tensor,
+    wigner_matrices: list[torch.Tensor],
+    is_improper: bool,
+) -> TensorMap:
+    """Transform a TensorMap using precomputed matrices from one O(3) coset.
+
+    ``matrices[i]`` is the actual Cartesian operation for local system ``i``,
+    while ``wigner_matrices[ell][i]`` is the Wigner-D matrix for its proper
+    rotational part. Every operation in the batch must be either proper or
+    improper, as selected by ``is_improper``.
+
+    With multiple operations, ``"system"`` sample labels are local indices into
+    the matrix batch. A singleton batch does not require this sample dimension.
+    The caller chooses the transformation direction by supplying either the
+    forward matrices or their inverses.
+    """
+    if (
+        matrices.dim() != 3
+        or matrices.size(0) == 0
+        or matrices.size(1) != 3
+        or matrices.size(2) != 3
+    ):
+        raise ValueError("matrices must have shape (N, 3, 3) with N > 0")
+    if matrices.dtype != torch.float32 and matrices.dtype != torch.float64:
+        raise TypeError("matrices must use float32 or float64")
+    if len(tensor) != 0:
+        reference_values = tensor.block(0).values
+        if (
+            matrices.dtype != reference_values.dtype
+            or matrices.device != reference_values.device
+        ):
+            raise ValueError("tensor and matrices must have the same dtype and device")
+
+    blocks: list[TensorBlock] = []
+    for key, block in tensor.items():
+        value_indices = _transformation_indices(
+            block.samples,
+            matrices.size(0),
+        )
+        new_block = TensorBlock(
+            values=_transform_component_values_with_precomputed_matrices(
+                block.values,
+                block.components,
+                key,
+                value_indices,
+                matrices,
+                wigner_matrices,
+                is_improper,
+            ),
+            samples=block.samples,
+            components=block.components,
+            properties=block.properties,
+        )
+
+        for gradient_name, gradient in block.gradients():
+            parent_rows = gradient.samples.column("sample").to(dtype=torch.long)
+            gradient_indices = value_indices.index_select(0, parent_rows)
+            new_block.add_gradient(
+                gradient_name,
+                TensorBlock(
+                    values=_transform_component_values_with_precomputed_matrices(
+                        gradient.values,
+                        gradient.components,
+                        key,
+                        gradient_indices,
+                        matrices,
+                        wigner_matrices,
+                        is_improper,
+                    ),
+                    samples=gradient.samples,
+                    components=gradient.components,
+                    properties=gradient.properties,
+                ),
+            )
+        blocks.append(new_block)
+
+    transformed = TensorMap(tensor.keys, blocks)
+    for info_name, info_value in tensor.info().items():
+        transformed.set_info(info_name, info_value)
     return transformed

--- a/python/metatomic_torch/metatomic/torch/o3/_tranformations.py
+++ b/python/metatomic_torch/metatomic/torch/o3/_tranformations.py
@@ -21,7 +21,9 @@ def _validate_nonnegative_integer(name: str, value: int) -> int:
         integer_value = value
     else:
         if isinstance(value, bool) or not isinstance(value, Integral):
-            raise TypeError(f"{name} must be a non-negative integer.")
+            raise TypeError(
+                f"{name} must be a non-negative integer, got {type(value).__name__}."
+            )
         integer_value = int(value)
     if integer_value < 0:
         raise ValueError(f"{name} must be a non-negative integer, got {integer_value}.")
@@ -39,7 +41,7 @@ def _spherical_parity_factor(
         integer_sigma = sigma
     else:
         if isinstance(sigma, bool) or not isinstance(sigma, Integral):
-            raise TypeError("sigma must be either -1 or +1.")
+            raise TypeError(f"sigma must be an integer, got {type(sigma).__name__}.")
         integer_sigma = int(sigma)
     if integer_sigma not in (-1, 1):
         raise ValueError(f"sigma must be either -1 or +1, got {integer_sigma}.")
@@ -57,8 +59,13 @@ def _validate_system_ids(
     *,
     expected_device: torch.device | None,
 ) -> torch.Tensor:
-    """Return one distinct ``torch.long`` sample label per
-    system-transformation pair.
+    """Check and normalize the ``system_ids`` argument of ``transform_tensor``.
+
+    ``system_ids[i]`` is the value in a block's ``"system"`` sample column that
+    selects ``transformations[i]``. This checks that systems and transformations
+    pair up one-to-one and that there is one distinct integer id per system,
+    returning the ids as a ``torch.long`` tensor (``0..n_systems - 1`` when
+    ``system_ids`` is ``None``).
     """
     n_systems = len(systems)
     n_transformations = len(transformations)
@@ -146,7 +153,7 @@ class O3Transformation:
         """
         :param matrix: (3, 3) rotation or improper-rotation matrix
         :param max_angular_momentum: non-negative maximum angular momentum for
-            Wigner-D matrices, which are computed and cached on first use
+            which Wigner-D matrices are available
         """
         max_angular_momentum = _validate_nonnegative_integer(
             "max_angular_momentum", max_angular_momentum
@@ -172,7 +179,7 @@ class O3Transformation:
         self._wigner_D_cache: dict[int, torch.Tensor] | None = None
 
     @classmethod
-    def _create_from_internal_matrix(
+    def _create_no_checks(
         cls,
         matrix: torch.Tensor,
         max_angular_momentum: int,
@@ -280,7 +287,7 @@ class O3Transformation:
 
         return transformed
 
-    def wigner_D_matrix(self, ell: int):
+    def wigner_D_matrix(self, ell: int) -> torch.Tensor:
         """Return the proper-part Wigner-D matrix for ``ell``.
 
         For an improper transformation, :meth:`transform_spherical` applies the
@@ -366,7 +373,7 @@ def random_transformations(
         raise ValueError("Generated transformations are not orthogonal.")
 
     return [
-        O3Transformation._create_from_internal_matrix(
+        O3Transformation._create_no_checks(
             matrix,
             max_angular_momentum,
             is_improper=is_improper,
@@ -667,6 +674,9 @@ def transform_block(
 ) -> TensorBlock:
     """Apply per-system O(3) transformations to a block and its gradients.
 
+    With one system, the ``"system"`` sample label is optional and ignored, as in
+    :py:func:`transform_tensor`.
+
     :param key: parent block key, supplying the O(3) labels required by spherical
         component axes
     :param block: block to transform
@@ -750,12 +760,18 @@ def transform_tensor(
 ) -> TensorMap:
     """Apply per-system O(3) transformations to a TensorMap and its gradients.
 
-    Blocks without component axes are scalar. Cartesian and spherical component
-    axes are identified by name, so one :py:class:`TensorMap` may contain all three
-    kinds of data.
+    Scalar, Cartesian, and spherical data are identified by their component-axis
+    names, following :ref:`o3-conventions`; one :py:class:`TensorMap` may contain
+    all three kinds of data. At most ten component axes are supported in one
+    value or gradient block.
 
     With multiple systems, the ``"system"`` sample label assigns each value sample
-    to a transformation. With one system, this label is optional and ignored.
+    to a transformation: samples labelled ``system_ids[i]`` use
+    ``transformations[i]``. A block may contain samples for only some of the
+    systems, but every ``"system"`` label present in the block must appear in
+    ``system_ids``. A gradient sample uses the same transformation as the parent
+    value sample referenced by its ``"sample"`` label. With one system, the
+    ``"system"`` label is optional and ignored.
 
     :param tensor: TensorMap to transform
     :param systems: systems corresponding positionally to ``transformations``
@@ -763,8 +779,8 @@ def transform_tensor(
         values in dtype and device when present
     :param system_ids: one distinct integer ``"system"`` sample label per system;
         entry ``i`` is paired with ``transformations[i]``. A tensor argument must
-        be one-dimensional and use the transformations' device. Defaults to
-        ``range(len(systems))``
+        be one-dimensional and use the same device as the tensor values. Defaults
+        to ``range(len(systems))``
     :return: transformed TensorMap with the same keys and global information; when
         ``systems`` is empty, the tensor is unchanged
     """

--- a/python/metatomic_torch/metatomic/torch/o3/_tranformations.py
+++ b/python/metatomic_torch/metatomic/torch/o3/_tranformations.py
@@ -12,7 +12,16 @@ from .. import System, register_autograd_neighbors
 from ._wigner import build_wigner_D_cache
 
 
-_INTEGER_DTYPES = (torch.uint8, torch.int8, torch.int16, torch.int32, torch.int64)
+_INTEGER_DTYPES = (
+    torch.uint8,
+    torch.uint16,
+    torch.uint32,
+    torch.uint64,
+    torch.int8,
+    torch.int16,
+    torch.int32,
+    torch.int64,
+)
 
 
 def _validate_nonnegative_integer(name: str, value: int) -> int:

--- a/python/metatomic_torch/metatomic/torch/o3/_wigner.py
+++ b/python/metatomic_torch/metatomic/torch/o3/_wigner.py
@@ -1,9 +1,7 @@
 """Private helpers to build real Wigner-D matrices for augmentation.
 
 Complex Wigner-D matrices are delegated to :func:`wigners.wigner_D_array` using
-ZYZ Euler angles. This module then reshapes/indexes these matrices into the flat
-layout expected by the augmentation code and applies the complex-to-real
-change-of-basis.
+ZYZ Euler angles and then converted to the real spherical-harmonic basis.
 
 The indexing convention used here matches ``wigners``:
 ``D[mp + ell, m + ell] == D^ell_{mp,m}``.
@@ -16,118 +14,26 @@ import torch
 from wigners import wigner_D_array
 
 
-def _wigner_d_size(ell_min: int, mp_max: int, ell_max: int) -> int:
-    if mp_max >= ell_max:
-        return (
-            ell_max * (ell_max * (4 * ell_max + 12) + 11)
-            + ell_min * (1 - 4 * ell_min**2)
-            + 3
-        ) // 3
-    if mp_max > ell_min:
-        return (
-            3 * ell_max * (ell_max + 2)
-            + ell_min * (1 - 4 * ell_min**2)
-            + mp_max
-            * (3 * ell_max * (2 * ell_max + 4) + mp_max * (-2 * mp_max - 3) + 5)
-            + 3
-        ) // 3
-
-    return (ell_max * (ell_max + 2) - ell_min**2) * (1 + 2 * mp_max) + 2 * mp_max + 1
-
-
-def _wigner_d_index(ell: int, mp: int, m: int, ell_min: int, mp_max: int) -> int:
-    idx = 0
-    for ell_prev in range(ell_min, ell):
-        local_mp_max = mp_max if mp_max < ell_prev else ell_prev
-        idx += (2 * local_mp_max + 1) * (2 * ell_prev + 1)
-
-    local_mp_max = mp_max if mp_max < ell else ell
-    idx += (mp + local_mp_max) * (2 * ell + 1)
-    idx += m + ell
-    return idx
-
-
-def _compute_wigner_d_complex(
-    ell_max: int, alpha: float, beta: float, gamma: float
-) -> np.ndarray:
-    """Compute complex Wigner-D matrix elements for all ell in ``[0, ell_max]``.
-
-    Calls :func:`wigners.wigner_D_array` for each input angle triplet, then packs
-    values into a flat output array indexed by :func:`_wigner_d_index`.
-
-    :param ell_max: maximum angular-momentum order
-    :param alpha: ZYZ first rotation angle, arbitrary shape
-    :param beta: ZYZ second rotation angle, same shape as ``alpha``
-    :param gamma: ZYZ third rotation angle, same shape as ``alpha``
-    :return: complex array of shape ``(*alpha.shape, dsize)``
-    """
-
-    mp_max = ell_max
-    dsize = _wigner_d_size(0, mp_max, ell_max)
-    result = np.zeros(dsize, dtype=np.complex128)
-
-    _wigner_D_array = wigner_D_array(ell_max, alpha, beta, gamma)
-
-    for ell in range(0, ell_max + 1):
-        for mp in range(-ell, ell + 1):
-            i_d = _wigner_d_index(ell, mp, -ell, 0, mp_max)
-            for m in range(-ell, ell + 1):
-                result[i_d] = _wigner_D_array[ell][mp + ell, m + ell]
-                i_d += 1
-
-    return result
-
-
-def _compute_complex_wigner_d_matrices(
-    ell_max: int,
-    angles: tuple[float, float, float],
-) -> dict[int, np.ndarray]:
-    """Return complex Wigner-D matrices for ell in ``[0, ell_max]`` at the given ZYZ
-    angles.
-
-    The returned matrices follow the standard ``wigners`` indexing convention:
-    ``matrix[..., mp + ell, m + ell] == D^ell_{mp,m}``.
-
-    :param ell_max: maximum angular-momentum order
-    :param angles: ``(alpha, beta, gamma)`` ZYZ Euler-angles
-    :return: ``{ell: array of shape (2*ell+1, 2*ell+1)}``
-    """
-    alpha, beta, gamma = angles
-    raw = _compute_wigner_d_complex(ell_max, alpha, beta, gamma)
-    matrices: dict[int, np.ndarray] = {}
-    for ell in range(ell_max + 1):
-        block = np.zeros((2 * ell + 1, 2 * ell + 1), dtype=np.complex128)
-        for mp in range(-ell, ell + 1):
-            for m in range(-ell, ell + 1):
-                block[mp + ell, m + ell] = raw[_wigner_d_index(ell, mp, m, 0, ell_max)]
-        matrices[ell] = block
-    return matrices
-
-
 def _compute_real_wigner_d_matrices(
     ell_max: int,
     angles: tuple[float, float, float],
     complex_to_real: dict[int, np.ndarray],
 ) -> dict[int, torch.Tensor]:
-    """Convert complex Wigner-D matrices to real ones using the provided
-    change-of-basis.
+    """Compute real Wigner-D matrices using the provided change of basis.
 
     :param ell_max: maximum angular-momentum order
     :param angles: ``(alpha, beta, gamma)`` ZYZ Euler-angles
     :param complex_to_real: ``{ell: (2*ell+1, 2*ell+1)}`` unitary transform from complex
         to real spherical harmonics
-    :return: ``{ell: real tensor of shape (*angles[0].shape, 2*ell+1, 2*ell+1)}``
+    :return: ``{ell: real tensor of shape (2*ell+1, 2*ell+1)}``
     """
-    complex_matrices = _compute_complex_wigner_d_matrices(ell_max, angles)
+    alpha, beta, gamma = angles
     real_matrices: dict[int, torch.Tensor] = {}
-    for ell, matrix in complex_matrices.items():
+    for ell, matrix in enumerate(wigner_D_array(ell_max, alpha, beta, gamma)):
         transform = complex_to_real[ell]
         matrix = np.einsum("ij,...jk,kl->...il", transform.conj(), matrix, transform.T)
-        # The complex-to-real basis change can leave tiny imaginary residuals;
-        # scale the tolerance by matrix magnitude instead of using a fixed atol.
-        scale = float(np.max(np.abs(matrix.real))) if matrix.size else 1.0
-        atol = max(1e-9, scale * 1e-10)
-        if not np.allclose(matrix.imag, 0.0, atol=atol):
+        # The basis change should be real up to numerical roundoff.
+        if not np.allclose(matrix.imag, 0.0, rtol=0.0, atol=1e-9):
             raise ValueError("real Wigner matrix conversion produced complex values")
         real_matrices[ell] = torch.from_numpy(matrix.real)
     return real_matrices
@@ -135,9 +41,9 @@ def _compute_real_wigner_d_matrices(
 
 @functools.lru_cache(maxsize=None)
 def _complex_to_real_spherical_harmonics_transform(ell: int) -> np.ndarray:
-    """Return the complex-to-real spherical-harmonics transform for one ``ell``.
+    """Return the unitary transform ``T`` with ``Y_real = T @ Y_complex``.
 
-    The returned matrix has shape ``(2*ell+1, 2*ell+1)``.
+    Both axes are ordered from ``m=-ell`` through ``m=ell``.
     """
     if ell < 0 or not isinstance(ell, int):
         raise ValueError("ell must be a non-negative integer.")
@@ -171,12 +77,12 @@ def _rotation_to_angles(
     """
 
     rotation = rotation if torch.det(rotation) > 0 else -rotation
-    # R = Rz(alpha) Ry(beta) Rz(gamma): element [2,2] = cos(beta)
+    # Recover beta from both sine and cosine to remain stable at the poles.
     cos_beta = rotation[2, 2].clamp(-1.0, 1.0)
-    beta = torch.arccos(cos_beta)
-    sin_beta = torch.sin(beta)
-    beta = float(beta)
-    if abs(sin_beta) < 1e-10:
+    sin_beta = torch.sqrt(rotation[0, 2] ** 2 + rotation[1, 2] ** 2)
+    beta = float(torch.atan2(sin_beta, cos_beta))
+    pole_tolerance = 8.0 * torch.finfo(rotation.dtype).eps
+    if float(sin_beta) <= pole_tolerance:
         # Gimbal lock: only alpha +/- gamma is defined; fix gamma=0
         if cos_beta > 0:
             alpha = float(torch.atan2(rotation[1, 0], rotation[0, 0]))
@@ -198,10 +104,12 @@ def build_wigner_D_cache(
     device: torch.device,
     dtype: torch.dtype,
 ) -> dict[int, torch.Tensor]:
-    """
-    Build the cache of real Wigner-D matrices for ``ell = 0..o3_lambda_max`` at the ZYZ
-    Euler angles corresponding to the given rotation matrix, using cached
-    complex-to-real transform per ell.
+    """Return real Wigner-D matrices for ``ell = 0, ..., o3_lambda_max``.
+
+    If ``matrix`` has negative determinant, ``-matrix`` is a proper rotation.
+    Build the Wigner-D matrices for this proper rotation; the caller restores
+    the inversion action on spherical values with ``sigma * (-1) ** ell``.
+    Every returned tensor uses ``device`` and ``dtype``.
     """
     angles = _rotation_to_angles(matrix)
     complex_to_real = {

--- a/python/metatomic_torch/setup.py
+++ b/python/metatomic_torch/setup.py
@@ -320,7 +320,7 @@ if __name__ == "__main__":
         f"torch {torch_version}",
         "metatensor-torch >=0.10.0,<0.11",
         "metatensor-operations >=0.5.0,<0.6",
-        "wigners",
+        "wigners >=0.4.0",
     ]
 
     # when packaging a sdist for release, we should never use local dependencies

--- a/python/metatomic_torch/tests/o3.py
+++ b/python/metatomic_torch/tests/o3.py
@@ -20,7 +20,6 @@ from metatomic.torch.o3 import (
 from metatomic.torch.o3._tranformations import _validate_system_ids
 from metatomic.torch.o3._wigner import (
     _complex_to_real_spherical_harmonics_transform,
-    _compute_real_wigner_d_matrices,
     _rotation_to_angles,
     build_wigner_D_cache,
 )
@@ -650,54 +649,6 @@ def test_complex_to_real_spherical_harmonics_transform_is_unitary():
             rtol=0.0,
             atol=1e-15,
             err_msg=f"ell={ell}",
-        )
-
-
-def test_real_wigner_D_matrices_are_orthogonal_and_compose():
-    """Real Wigner-D matrices through ell=8 must be orthogonal.
-
-    Combining two rotations must give the product of their Wigner-D matrices.
-    """
-    ell_max = 8
-    first_rotation = torch.tensor(
-        _axis_angle([1.0, 2.0, 3.0], 0.7),
-        dtype=torch.float64,
-    )
-    second_rotation = torch.tensor(
-        _axis_angle([-2.0, 1.0, 0.5], 2.4),
-        dtype=torch.float64,
-    )
-    complex_to_real = {
-        ell: _complex_to_real_spherical_harmonics_transform(ell)
-        for ell in range(ell_max + 1)
-    }
-
-    def real_wigner_D_matrices(rotation):
-        return _compute_real_wigner_d_matrices(
-            ell_max,
-            _rotation_to_angles(rotation),
-            complex_to_real,
-        )
-
-    first = real_wigner_D_matrices(first_rotation)
-    second = real_wigner_D_matrices(second_rotation)
-    composed = real_wigner_D_matrices(first_rotation @ second_rotation)
-
-    for ell in range(ell_max + 1):
-        identity = torch.eye(2 * ell + 1, dtype=torch.float64)
-        for matrix in (first[ell], second[ell], composed[ell]):
-            torch.testing.assert_close(
-                matrix.T @ matrix,
-                identity,
-                rtol=0.0,
-                atol=1e-12,
-            )
-
-        torch.testing.assert_close(
-            composed[ell],
-            first[ell] @ second[ell],
-            rtol=0.0,
-            atol=1e-12,
         )
 
 

--- a/python/metatomic_torch/tests/o3.py
+++ b/python/metatomic_torch/tests/o3.py
@@ -8,12 +8,21 @@ from metatensor.torch import Labels, TensorBlock, TensorMap
 from metatomic.torch import (
     NeighborListOptions,
     System,
+    register_autograd_neighbors,
 )
 from metatomic.torch.o3 import (
     O3Transformation,
     random_transformations,
+    transform_block,
     transform_system,
     transform_tensor,
+)
+from metatomic.torch.o3._tranformations import _validate_system_ids
+from metatomic.torch.o3._wigner import (
+    _complex_to_real_spherical_harmonics_transform,
+    _compute_real_wigner_d_matrices,
+    _rotation_to_angles,
+    build_wigner_D_cache,
 )
 
 from ._tests_utils import can_use_mps_backend
@@ -57,8 +66,51 @@ def _make_system(
     )
 
 
+def _rotation_90_degrees_around_z():
+    """Return the exact matrix for a 90-degree rotation around z."""
+    return torch.tensor(
+        [
+            [0.0, -1.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ],
+        dtype=torch.float64,
+    )
+
+
+def _single_block_tensor_map(
+    *,
+    values,
+    samples,
+    components,
+    keys=None,
+    properties=None,
+):
+    """Return a TensorMap containing one TensorBlock."""
+    if keys is None:
+        keys = Labels(["_"], torch.tensor([[0]], device=values.device))
+    if properties is None:
+        properties = Labels(["p"], torch.tensor([[0]], device=values.device))
+
+    return TensorMap(
+        keys,
+        [
+            TensorBlock(
+                values=values,
+                samples=samples,
+                components=components,
+                properties=properties,
+            )
+        ],
+    )
+
+
 @pytest.mark.parametrize("device,dtype", ALL_DEVICE_DTYPE)
-def test_transform_system(device, dtype):
+def test_transform_system_rotates_geometry_neighbor_lists_and_custom_data(
+    device,
+    dtype,
+):
+    """Geometry, neighbor vectors, and custom TensorMaps receive one transformation."""
     dtype = getattr(torch, dtype)
     atol = 1e-6 if dtype == torch.float32 else 1e-12
 
@@ -116,6 +168,8 @@ def test_transform_system(device, dtype):
             ),
         ],
     )
+    scalar.set_info("unit", "eV")
+    scalar.set_info("custom", "preserved by transformation")
 
     # xyz vector per-atom data: must rotate by R on the component axis
     vector_values = torch.tensor(
@@ -123,23 +177,14 @@ def test_transform_system(device, dtype):
         dtype=dtype,
         device=device,
     )
-    vector = TensorMap(
-        keys=Labels(["_"], torch.tensor([[0]], device=device)),
-        blocks=[
-            TensorBlock(
-                values=vector_values.clone(),
-                samples=samples,
-                components=[
-                    Labels(["xyz"], torch.arange(3, device=device).reshape(-1, 1))
-                ],
-                properties=Labels(["p"], torch.tensor([[0]], device=device)),
-            )
-        ],
+    vector = _single_block_tensor_map(
+        values=vector_values.clone(),
+        samples=samples,
+        components=[Labels(["xyz"], torch.arange(3, device=device).reshape(-1, 1))],
     )
     system.add_data("custom::scalar", scalar)
     system.add_data("custom::vector", vector)
 
-    # Apply a transformation to it
     matrix = torch.tensor(
         [
             [np.cos(np.pi / 3), -np.sin(np.pi / 3), 0.0],
@@ -165,6 +210,8 @@ def test_transform_system(device, dtype):
     assert torch.allclose(new_neighbors, expected, atol=atol)
 
     new_scalar = rotated.get_data("custom::scalar")
+    assert new_scalar.keys == scalar.keys
+    assert new_scalar.info() == scalar.info()
     for block_id in range(len(scalar.keys)):
         assert torch.allclose(
             new_scalar.block_by_id(block_id).values,
@@ -176,31 +223,412 @@ def test_transform_system(device, dtype):
     assert torch.allclose(new_vector, expected_vector, atol=atol)
 
 
-def test_random_rotations_are_orthogonal():
-    transformations = random_transformations(
-        20, device=torch.device("cpu"), dtype=torch.float64
+def test_transform_system_preserves_neighbor_gradients():
+    """Transformed registered neighbor lists remain differentiable from positions."""
+    positions = torch.tensor(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+        ],
+        dtype=torch.float64,
+        requires_grad=True,
     )
-    assert len(transformations) == 20
-    identity = torch.eye(3, dtype=torch.float64)
-    for transformation in transformations:
-        assert transformation.matrix.shape == (3, 3)
-        assert torch.allclose(
-            transformation.matrix @ transformation.matrix.T, identity, atol=1e-10
+    system = _make_system([1, 1], positions=positions)
+
+    options = NeighborListOptions(
+        cutoff=2.0,
+        full_list=True,
+        strict=False,
+    )
+    neighbors = TensorBlock(
+        values=torch.tensor(
+            [[[1.0], [0.0], [0.0]]],
+            dtype=torch.float64,
+        ),
+        samples=Labels(
+            [
+                "first_atom",
+                "second_atom",
+                "cell_shift_a",
+                "cell_shift_b",
+                "cell_shift_c",
+            ],
+            torch.tensor([[0, 1, 0, 0, 0]]),
+        ),
+        components=[Labels.range("xyz", 3)],
+        properties=Labels.range("distance", 1),
+    )
+
+    register_autograd_neighbors(system, neighbors)
+    system.add_neighbor_list(options, neighbors)
+
+    rotation = _rotation_90_degrees_around_z()
+    transformed = transform_system(
+        system,
+        O3Transformation(rotation, max_angular_momentum=0),
+    )
+
+    loss = torch.sum(transformed.get_neighbor_list(options).values ** 2)
+    gradient = torch.autograd.grad(loss, positions)[0]
+
+    expected = torch.tensor(
+        [
+            [-2.0, 0.0, 0.0],
+            [2.0, 0.0, 0.0],
+        ],
+        dtype=torch.float64,
+    )
+    assert torch.allclose(gradient, expected, atol=1e-12)
+
+
+def test_transform_system_rejects_dtype_mismatch():
+    """System positions and transformation matrix must have the same dtype."""
+    system = _make_system([1], dtype=torch.float64)
+    transformation = O3Transformation(
+        torch.eye(3, dtype=torch.float32),
+        max_angular_momentum=0,
+    )
+
+    with pytest.raises(ValueError, match="differing from the transformations"):
+        transform_system(system, transformation)
+
+
+@pytest.mark.parametrize("device,dtype", ALL_DEVICE_DTYPE)
+def test_random_rotations_are_orthogonal(device, dtype):
+    dtype = getattr(torch, dtype)
+    atol = 1e-5 if dtype == torch.float32 else 1e-10
+
+    assert (
+        random_transformations(
+            0,
+            device=torch.device(device),
+            dtype=dtype,
         )
-        assert abs(float(torch.det(transformation.matrix)) - 1.0) < 1e-10
+        == []
+    )
 
-
-def test_random_rotations_include_inversions():
-    # With n=100 the probability that all determinants have the same sign is 2^{-99}.
     transformations = random_transformations(
+        20,
+        device=torch.device(device),
+        dtype=dtype,
+    )
+
+    assert len(transformations) == 20
+    identity = torch.eye(3, device=device, dtype=dtype)
+
+    for transformation in transformations:
+        matrix = transformation.matrix
+
+        assert transformation.device == identity.device
+        assert transformation.dtype == dtype
+        assert matrix.shape == (3, 3)
+        assert torch.allclose(
+            matrix @ matrix.T,
+            identity,
+            atol=atol,
+        )
+        assert abs(float(torch.det(matrix)) - 1.0) < atol
+
+
+def test_random_transformations_include_inversions_and_are_reproducible():
+    default_generated = random_transformations(
         100,
         device="cpu",
         dtype=torch.float64,
         include_inversions=True,
     )
-    dets = torch.stack([torch.det(T.matrix) for T in transformations])
-    assert torch.allclose(dets.abs(), torch.ones(100, dtype=torch.float64), atol=1e-10)
-    assert (dets > 0).any() and (dets < 0).any()
+    first = random_transformations(
+        100,
+        device="cpu",
+        dtype=torch.float64,
+        include_inversions=True,
+        generator=torch.Generator().manual_seed(20260718),
+    )
+    second = random_transformations(
+        100,
+        device="cpu",
+        dtype=torch.float64,
+        include_inversions=True,
+        generator=torch.Generator().manual_seed(20260718),
+    )
+
+    determinants = torch.stack(
+        [torch.det(transformation.matrix) for transformation in default_generated]
+    )
+    assert torch.allclose(
+        determinants.abs(),
+        torch.ones(100, dtype=torch.float64),
+        atol=1e-10,
+    )
+    assert (determinants > 0).any() and (determinants < 0).any()
+
+    for first_transformation, second_transformation in zip(
+        first,
+        second,
+        strict=True,
+    ):
+        assert torch.equal(
+            first_transformation.matrix,
+            second_transformation.matrix,
+        )
+        expected_is_improper = bool(torch.det(first_transformation.matrix) < 0)
+        assert first_transformation.is_improper == expected_is_improper
+        assert second_transformation.is_improper == expected_is_improper
+
+
+@pytest.mark.parametrize("n", [0, 1])
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        torch.float16,
+        torch.bfloat16,
+        torch.complex64,
+        torch.int64,
+    ],
+)
+def test_random_transformations_rejects_unsupported_dtype(n, dtype):
+    with pytest.raises(ValueError, match="torch.float32 or torch.float64"):
+        random_transformations(
+            n,
+            device=torch.device("cpu"),
+            dtype=dtype,
+        )
+
+
+@pytest.mark.parametrize(
+    ("value", "error"),
+    [
+        (-1, ValueError),
+        (True, TypeError),
+        (1.5, TypeError),
+    ],
+)
+def test_transformation_counts_and_limits_reject_invalid_values(value, error):
+    with pytest.raises(error, match="max_angular_momentum"):
+        O3Transformation(torch.eye(3, dtype=torch.float64), value)
+
+    with pytest.raises(error, match="max_angular_momentum"):
+        random_transformations(
+            0,
+            max_angular_momentum=value,
+            device=torch.device("cpu"),
+            dtype=torch.float64,
+        )
+
+    with pytest.raises(error, match="n must"):
+        random_transformations(
+            value,
+            device=torch.device("cpu"),
+            dtype=torch.float64,
+        )
+
+
+def test_transformation_creation_rejects_invalid_matrix():
+    with pytest.raises(ValueError, match="shape"):
+        O3Transformation(
+            torch.eye(2, dtype=torch.float64),
+            max_angular_momentum=0,
+        )
+
+    matrix = torch.eye(3, dtype=torch.float64)
+    matrix[0, 0] = 2.0
+    with pytest.raises(ValueError, match="not orthogonal"):
+        O3Transformation(
+            matrix,
+            max_angular_momentum=0,
+        )
+
+
+@pytest.mark.parametrize("is_improper", [False, True])
+def test_create_from_internal_matrix_matches_constructor(is_improper):
+    matrix = _rotation_90_degrees_around_z()
+    if is_improper:
+        matrix = -matrix
+
+    expected = O3Transformation(
+        matrix,
+        max_angular_momentum=2,
+    )
+    actual = O3Transformation._create_from_internal_matrix(
+        matrix,
+        max_angular_momentum=2,
+        is_improper=is_improper,
+    )
+
+    torch.testing.assert_close(actual.matrix, expected.matrix)
+    assert actual.dtype == expected.dtype
+    assert actual.device == expected.device
+    assert actual.is_improper == expected.is_improper
+
+    for ell in range(3):
+        torch.testing.assert_close(
+            actual.wigner_D_matrix(ell),
+            expected.wigner_D_matrix(ell),
+        )
+
+
+def test_external_matrix_changes_do_not_modify_transformation():
+    expected = torch.eye(3, dtype=torch.float64)
+    source = expected.clone()
+    transformation = O3Transformation(
+        source,
+        max_angular_momentum=0,
+    )
+
+    source[:] = -expected
+    assert torch.equal(transformation.matrix, expected)
+
+    returned = transformation.matrix
+    returned[:] = -expected
+    assert torch.equal(transformation.matrix, expected)
+
+    assert transformation.is_improper is False
+    assert torch.equal(
+        transformation.transform_cartesian(expected),
+        expected,
+    )
+
+
+def test_wigner_cache_is_built_only_when_needed():
+    transformation = O3Transformation(
+        torch.eye(3, dtype=torch.float64),
+        max_angular_momentum=2,
+    )
+    assert transformation._wigner_D_cache is None
+
+    transformation.transform_cartesian(
+        torch.ones((4, 3), dtype=torch.float64),
+    )
+    assert transformation._wigner_D_cache is None
+
+    transformation.wigner_D_matrix(1)
+    cache = transformation._wigner_D_cache
+    assert cache is not None
+
+    transformation.wigner_D_matrix(2)
+    assert transformation._wigner_D_cache is cache
+
+
+def test_wigner_D_matrix_returns_independent_copy():
+    transformation = O3Transformation(
+        torch.eye(3, dtype=torch.float64),
+        max_angular_momentum=1,
+    )
+    expected = transformation.wigner_D_matrix(1).clone()
+
+    returned = transformation.wigner_D_matrix(1)
+    returned.zero_()
+
+    assert torch.equal(
+        transformation.wigner_D_matrix(1),
+        expected,
+    )
+
+
+@pytest.mark.parametrize(
+    ("ell", "error"),
+    [
+        (-1, ValueError),
+        (True, TypeError),
+        (1.0, TypeError),
+    ],
+)
+def test_wigner_D_matrix_and_transform_spherical_reject_invalid_ell(ell, error):
+    transformation = O3Transformation(torch.eye(3, dtype=torch.float64), 1)
+
+    with pytest.raises(error, match="ell must be a non-negative integer"):
+        transformation.wigner_D_matrix(ell)
+
+    with pytest.raises(error, match="ell must be a non-negative integer"):
+        transformation.transform_spherical(
+            torch.ones((1, 3), dtype=torch.float64),
+            ell=ell,
+            sigma=1,
+        )
+
+
+def test_wigner_D_matrix_and_transform_spherical_reject_ell_above_configured_maximum():
+    transformation = O3Transformation(torch.eye(3, dtype=torch.float64), 0)
+
+    with pytest.raises(ValueError, match="ell=1 exceeds max_angular_momentum=0"):
+        transformation.wigner_D_matrix(1)
+
+    with pytest.raises(ValueError, match="ell=1 exceeds max_angular_momentum=0"):
+        transformation.transform_spherical(
+            torch.ones((1, 3), dtype=torch.float64),
+            ell=1,
+            sigma=1,
+        )
+
+
+@pytest.mark.parametrize(
+    ("matrix", "is_improper"),
+    [
+        (torch.eye(3), False),
+        (-torch.eye(3), True),
+    ],
+)
+@pytest.mark.parametrize("ell", [0, 1])
+@pytest.mark.parametrize("sigma", [1, -1])
+def test_transform_spherical_applies_o3_parity_factor(
+    matrix,
+    is_improper,
+    ell,
+    sigma,
+):
+    matrix = matrix.to(dtype=torch.float64)
+    transformation = O3Transformation(
+        matrix,
+        max_angular_momentum=ell,
+    )
+    values = torch.arange(
+        1,
+        2 * (2 * ell + 1) + 1,
+        dtype=torch.float64,
+    ).reshape(2, 2 * ell + 1)
+
+    parity_factor = sigma * (-1) ** ell if is_improper else 1
+    expected = values * parity_factor
+
+    assert torch.allclose(
+        transformation.transform_spherical(values, ell, sigma),
+        expected,
+        rtol=0.0,
+        atol=1e-12,
+    )
+
+
+@pytest.mark.parametrize(
+    "matrix",
+    [
+        torch.eye(3),
+        -torch.eye(3),
+    ],
+)
+@pytest.mark.parametrize(
+    ("sigma", "error"),
+    [
+        (2, ValueError),
+        (-2, ValueError),
+        (1.0, TypeError),
+        (True, TypeError),
+    ],
+)
+def test_transform_spherical_rejects_invalid_sigma(matrix, sigma, error):
+    transformation = O3Transformation(
+        matrix.to(dtype=torch.float64),
+        max_angular_momentum=0,
+    )
+
+    with pytest.raises(
+        error,
+        match=r"sigma must be either -1 or \+1",
+    ):
+        transformation.transform_spherical(
+            torch.ones((1, 1), dtype=torch.float64),
+            ell=0,
+            sigma=sigma,
+        )
 
 
 def _axis_angle(axis, theta):
@@ -229,6 +657,112 @@ def _axis_angle(axis, theta):
             ],
         ]
     )
+
+
+def test_complex_to_real_spherical_harmonics_transform_is_unitary():
+    """The complex-to-real basis transformations are unitary."""
+    for ell in range(9):
+        transform = _complex_to_real_spherical_harmonics_transform(ell)
+        size = 2 * ell + 1
+
+        np.testing.assert_allclose(
+            transform @ transform.conj().T,
+            np.eye(size),
+            rtol=0.0,
+            atol=1e-15,
+            err_msg=f"ell={ell}",
+        )
+
+
+def test_real_wigner_D_matrices_are_orthogonal_and_compose():
+    """Real Wigner-D matrices through ell=8 must be orthogonal.
+
+    Combining two rotations must give the product of their Wigner-D matrices.
+    """
+    ell_max = 8
+    first_rotation = torch.tensor(
+        _axis_angle([1.0, 2.0, 3.0], 0.7),
+        dtype=torch.float64,
+    )
+    second_rotation = torch.tensor(
+        _axis_angle([-2.0, 1.0, 0.5], 2.4),
+        dtype=torch.float64,
+    )
+    complex_to_real = {
+        ell: _complex_to_real_spherical_harmonics_transform(ell)
+        for ell in range(ell_max + 1)
+    }
+
+    def real_wigner_D_matrices(rotation):
+        return _compute_real_wigner_d_matrices(
+            ell_max,
+            _rotation_to_angles(rotation),
+            complex_to_real,
+        )
+
+    first = real_wigner_D_matrices(first_rotation)
+    second = real_wigner_D_matrices(second_rotation)
+    composed = real_wigner_D_matrices(first_rotation @ second_rotation)
+
+    for ell in range(ell_max + 1):
+        identity = torch.eye(2 * ell + 1, dtype=torch.float64)
+        for matrix in (first[ell], second[ell], composed[ell]):
+            torch.testing.assert_close(
+                matrix.T @ matrix,
+                identity,
+                rtol=0.0,
+                atol=1e-12,
+            )
+
+        torch.testing.assert_close(
+            composed[ell],
+            first[ell] @ second[ell],
+            rtol=0.0,
+            atol=1e-12,
+        )
+
+
+@pytest.mark.parametrize("device,dtype", ALL_DEVICE_DTYPE)
+def test_build_wigner_D_cache_returns_all_ranks_on_requested_dtype_and_device(
+    device,
+    dtype,
+):
+    """Return every rank on the requested dtype and device.
+
+    A proper rotation and its improper counterpart must produce equal caches.
+    """
+    device = torch.device(device)
+    dtype = getattr(torch, dtype)
+    ell_max = 3
+    proper = torch.tensor(
+        _axis_angle([1.0, 2.0, 3.0], 0.7),
+        device=device,
+        dtype=dtype,
+    )
+
+    proper_cache = build_wigner_D_cache(
+        ell_max,
+        proper,
+        device=device,
+        dtype=dtype,
+    )
+    improper_cache = build_wigner_D_cache(
+        ell_max,
+        -proper,
+        device=device,
+        dtype=dtype,
+    )
+
+    expected_ranks = set(range(ell_max + 1))
+    for cache in (proper_cache, improper_cache):
+        assert set(cache) == expected_ranks
+        for ell, matrix in cache.items():
+            assert matrix.shape == (2 * ell + 1, 2 * ell + 1)
+            assert matrix.dtype == dtype
+            assert matrix.device == proper.device
+
+    for ell in range(ell_max + 1):
+        assert torch.equal(proper_cache[ell], improper_cache[ell])
 
 
 # Change of basis from Cartesian (x, y, z) to real ell=1 spherical harmonics, ordered
@@ -272,7 +806,48 @@ def test_general_rotation_L1_wigner_matches_cartesian(matrix):
     transformation = O3Transformation(matrix, max_angular_momentum=1)
 
     expected = CARTESIAN_TO_SPHERICAL_L1 @ proper @ CARTESIAN_TO_SPHERICAL_L1.T
-    assert torch.allclose(transformation._wigner_D_cache[1], expected, atol=1e-12)
+    assert torch.allclose(transformation.wigner_D_matrix(1), expected, atol=1e-12)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+@pytest.mark.parametrize("is_improper", [False, True])
+@pytest.mark.parametrize(
+    "cos_beta",
+    [
+        pytest.param(1.0, id="beta-zero"),
+        pytest.param(-1.0, id="beta-pi"),
+    ],
+)
+def test_wigner_D_matrix_handles_roundoff_at_both_euler_poles(
+    cos_beta,
+    is_improper,
+    dtype,
+):
+    """One-ULP matrix roundoff must preserve rotations at beta=0 and beta=pi."""
+    alpha = 0.73
+    cos_alpha = np.cos(alpha)
+    sin_alpha = np.sin(alpha)
+    proper = torch.tensor(
+        [
+            [cos_beta * cos_alpha, -sin_alpha, 0.0],
+            [cos_beta * sin_alpha, cos_alpha, 0.0],
+            [0.0, 0.0, cos_beta],
+        ],
+        dtype=dtype,
+    )
+
+    matrix = proper.clone()
+    matrix[2, 2] = torch.nextafter(matrix[2, 2], torch.zeros_like(matrix[2, 2]))
+    if is_improper:
+        matrix = -matrix
+
+    transformation = O3Transformation(matrix, max_angular_momentum=1)
+    basis = CARTESIAN_TO_SPHERICAL_L1.to(dtype=dtype)
+    expected = basis @ proper @ basis.T
+    actual = transformation.wigner_D_matrix(1)
+
+    atol = 1e-6 if dtype == torch.float32 else 1e-14
+    torch.testing.assert_close(actual, expected, rtol=0.0, atol=atol)
 
 
 @pytest.mark.parametrize("matrix", TRANSFORMATIONS)
@@ -287,39 +862,29 @@ def test_spherical_rotation_matches_cartesian(matrix, device, dtype):
 
     cartesian_vectors = torch.randn(2, 3, 1, dtype=dtype, device=device)
 
-    cartesian = TensorMap(
-        Labels(["_"], torch.tensor([[0]], device=device)),
-        [
-            TensorBlock(
-                values=cartesian_vectors,
-                samples=Labels(
-                    ["system", "atom"],
-                    torch.tensor([[0, 0], [0, 1]], device=device),
-                ),
-                components=[
-                    Labels(["xyz"], torch.arange(3, device=device).reshape(-1, 1))
-                ],
-                properties=Labels(["p"], torch.tensor([[0]], device=device)),
-            )
-        ],
+    samples = Labels(
+        ["system", "atom"],
+        torch.tensor([[0, 0], [0, 1]], device=device),
+    )
+    cartesian = _single_block_tensor_map(
+        values=cartesian_vectors,
+        samples=samples,
+        components=[Labels(["xyz"], torch.arange(3, device=device).reshape(-1, 1))],
     )
     # spherical encoding: w = C @ v along the component axis
     cart_to_sph = CARTESIAN_TO_SPHERICAL_L1.to(device=device, dtype=dtype)
-    spherical_values = torch.einsum("Aa,iap->iAp", cart_to_sph, cartesian_vectors)
-    spherical = TensorMap(
-        Labels(["o3_lambda", "o3_sigma"], torch.tensor([[1, 1]], device=device)),
-        [
-            TensorBlock(
-                values=spherical_values,
-                samples=Labels(
-                    ["system", "atom"],
-                    torch.tensor([[0, 0], [0, 1]], device=device),
-                ),
-                components=[
-                    Labels(["o3_mu"], torch.arange(-1, 2, device=device).reshape(-1, 1))
-                ],
-                properties=Labels(["p"], torch.tensor([[0]], device=device)),
-            )
+    spherical_values = torch.einsum(
+        "Aa,iap->iAp", cart_to_sph, cartesian_vectors
+    ).requires_grad_()
+    spherical = _single_block_tensor_map(
+        keys=Labels(
+            ["o3_lambda", "o3_sigma"],
+            torch.tensor([[1, 1]], device=device),
+        ),
+        values=spherical_values,
+        samples=samples,
+        components=[
+            Labels(["o3_mu"], torch.arange(-1, 2, device=device).reshape(-1, 1))
         ],
     )
 
@@ -335,23 +900,34 @@ def test_spherical_rotation_matches_cartesian(matrix, device, dtype):
     assert torch.allclose(
         spherical_transformed.block().values, expected_spherical, atol=atol
     )
+    gradient = torch.autograd.grad(
+        spherical_transformed.block().values.square().sum(), spherical_values
+    )[0]
+    assert torch.allclose(gradient, 2.0 * spherical_values, atol=atol)
 
 
-def test_gradients_are_rotated():
+def test_transform_tensor_routes_gradient_rows_by_parent_system():
+    """Gradients follow parent systems while metadata and inputs are preserved."""
     systems = [
         _make_system([1, 1]),
         _make_system([8, 8, 8]),
     ]
-    R0 = torch.tensor(_axis_angle([1.0, 2.0, 3.0], 0.7), dtype=torch.float64)
-    R1 = torch.tensor(_axis_angle([0.0, 1.0, 1.0], 1.9), dtype=torch.float64)
+    R_92 = torch.tensor(_axis_angle([1.0, 2.0, 3.0], 0.7), dtype=torch.float64)
+    R_38 = torch.tensor(_axis_angle([0.0, 1.0, 1.0], 1.9), dtype=torch.float64)
 
     values = torch.tensor([[1.0], [2.0]], dtype=torch.float64)
-    pos_grad = torch.randn(5, 3, 1, dtype=torch.float64)  # 2 + 3 atoms
+    pos_grad = torch.randn(
+        5,
+        3,
+        1,
+        dtype=torch.float64,
+        requires_grad=True,
+    )  # 2 + 3 atoms
     strain_grad = torch.randn(2, 3, 3, 1, dtype=torch.float64)
 
     block = TensorBlock(
         values=values,
-        samples=Labels(["system"], torch.tensor([[0], [1]])),
+        samples=Labels(["system"], torch.tensor([[92], [38]])),
         components=[],
         properties=Labels(["energy"], torch.tensor([[0]])),
     )
@@ -381,53 +957,82 @@ def test_gradients_are_rotated():
         ),
     )
     tensor = TensorMap(Labels(["_"], torch.tensor([[0]])), [block])
+    values_before = values.detach().clone()
+    pos_grad_before = pos_grad.detach().clone()
+    strain_grad_before = strain_grad.detach().clone()
 
     transformed = transform_tensor(
         tensor,
         systems,
         [
-            O3Transformation(R0, max_angular_momentum=1),
-            O3Transformation(R1, max_angular_momentum=1),
+            O3Transformation(R_92, max_angular_momentum=1),
+            O3Transformation(R_38, max_angular_momentum=1),
         ],
+        system_ids=[92, 38],
+    )
+    transformed_block = transformed.block()
+
+    assert torch.equal(transformed_block.values, values_before)
+
+    # Position-gradient samples 0 and 2 use R_92; samples 1, 3, and 4 use R_38.
+    expected_pos = pos_grad_before.clone()
+    expected_pos[0] = R_92 @ pos_grad_before[0]
+    expected_pos[1] = R_38 @ pos_grad_before[1]
+    expected_pos[2] = R_92 @ pos_grad_before[2]
+    expected_pos[3] = R_38 @ pos_grad_before[3]
+    expected_pos[4] = R_38 @ pos_grad_before[4]
+
+    transformed_pos = transformed_block.gradient("positions").values
+    assert torch.allclose(transformed_pos, expected_pos)
+
+    # Strain-gradient samples 0 and 1 use R_92 and R_38, respectively.
+    expected_strain = strain_grad_before.clone()
+    expected_strain[0] = torch.einsum(
+        "Aa,abp,Bb->ABp", R_92, strain_grad_before[0], R_92
+    )
+    expected_strain[1] = torch.einsum(
+        "Aa,abp,Bb->ABp", R_38, strain_grad_before[1], R_38
+    )
+    assert torch.allclose(
+        transformed_block.gradient("strain").values,
+        expected_strain,
     )
 
-    # values should not change
-    assert torch.allclose(transformed.block().values, values)
+    input_block = tensor.block()
+    assert torch.equal(input_block.values, values_before)
+    assert torch.equal(input_block.gradient("positions").values, pos_grad_before)
+    assert torch.equal(input_block.gradient("strain").values, strain_grad_before)
 
-    # positions gradients: rows 0,2 -> R0, rows 1,3,4 -> R1
-    expected_pos = pos_grad.clone()
-    expected_pos[0] = R0 @ pos_grad[0]
-    expected_pos[1] = R1 @ pos_grad[1]
-    expected_pos[2] = R0 @ pos_grad[2]
-    expected_pos[3] = R1 @ pos_grad[3]
-    expected_pos[4] = R1 @ pos_grad[4]
+    assert transformed_block.samples == input_block.samples
+    assert transformed_block.components == input_block.components
+    assert transformed_block.properties == input_block.properties
+    assert transformed_block.gradients_list() == input_block.gradients_list()
+    for gradient_name in input_block.gradients_list():
+        transformed_gradient = transformed_block.gradient(gradient_name)
+        input_gradient = input_block.gradient(gradient_name)
+        assert transformed_gradient.samples == input_gradient.samples
+        assert transformed_gradient.components == input_gradient.components
+        assert transformed_gradient.properties == input_gradient.properties
 
+    autograd_gradient = torch.autograd.grad(
+        transformed_pos.square().sum(),
+        pos_grad,
+    )[0]
     assert torch.allclose(
-        transformed.block().gradient("positions").values, expected_pos
-    )
-
-    # strain gradients: row 0 -> R0 S R0.T, row 1 -> R1 S R1.T
-    expected_strain = strain_grad.clone()
-    expected_strain[0] = torch.einsum("Aa,abp,Bb->ABp", R0, strain_grad[0], R0)
-    expected_strain[1] = torch.einsum("Aa,abp,Bb->ABp", R1, strain_grad[1], R1)
-    assert torch.allclose(
-        transformed.block().gradient("strain").values, expected_strain
+        autograd_gradient,
+        2.0 * pos_grad,
+        rtol=0.0,
+        atol=1e-12,
     )
 
 
 def test_unsupported_component_axis_raises():
     """Unknown component-axis names fail loudly."""
     systems = [_make_system([1])]
-    tensor = TensorMap(
-        Labels(["_"], torch.tensor([[0]])),
-        [
-            TensorBlock(
-                values=torch.zeros(1, 3, 1, dtype=torch.float64),
-                samples=Labels(["system"], torch.tensor([[0]])),
-                components=[Labels(["direction"], torch.arange(3).reshape(-1, 1))],
-                properties=Labels(["p"], torch.tensor([[0]])),
-            )
-        ],
+    tensor = _single_block_tensor_map(
+        values=torch.zeros(1, 3, 1, dtype=torch.float64),
+        samples=Labels(["system"], torch.tensor([[0]])),
+        components=[Labels(["direction"], torch.arange(3).reshape(-1, 1))],
     )
 
     message = (
@@ -441,102 +1046,681 @@ def test_unsupported_component_axis_raises():
         )
 
 
-def test_system_ids_explicit_match():
-    """Explicit ``system_ids`` correctly routes rows with non-contiguous labels."""
-    systems = [_make_system([1, 8]), _make_system([1, 8])]
-
-    R0 = O3Transformation(torch.eye(3, dtype=torch.float64), 1)
-    # 90-degree rotation around z: (x,y) -> (-y, x)
-    c, s = np.cos(np.pi / 2), np.sin(np.pi / 2)
-    R1 = O3Transformation(
-        torch.tensor([[c, -s, 0], [s, c, 0], [0, 0, 1]], dtype=torch.float64), 1
+def test_transform_tensor_rejects_invalid_spherical_sigma():
+    """TensorMap transformation rejects invalid spherical parity metadata."""
+    tensor = _single_block_tensor_map(
+        keys=Labels(
+            ["o3_lambda", "o3_sigma"],
+            torch.tensor([[0, 2]]),
+        ),
+        values=torch.ones((1, 1, 1), dtype=torch.float64),
+        samples=Labels(["system"], torch.tensor([[0]])),
+        components=[Labels(["o3_mu"], torch.tensor([[0]]))],
     )
 
-    # row 0 (label 92) -> R0 (identity): unchanged
-    # row 1 (label 38) -> R1 (z-90): (0,2,0) -> (-2,0,0)
-    vector_values = torch.tensor(
-        [[[1.0], [0.0], [0.0]], [[0.0], [2.0], [0.0]]],
+    with pytest.raises(
+        ValueError,
+        match=re.escape("sigma must be either -1 or +1"),
+    ):
+        transform_tensor(
+            tensor,
+            [_make_system([1])],
+            [
+                O3Transformation(
+                    torch.eye(3, dtype=torch.float64),
+                    max_angular_momentum=0,
+                )
+            ],
+        )
+
+
+@pytest.mark.parametrize(
+    ("location", "component", "keys", "message"),
+    [
+        pytest.param(
+            "values",
+            Labels(["xyz"], torch.tensor([[2], [0], [1]])),
+            Labels(["_"], torch.tensor([[0]])),
+            "Cartesian component axis 'xyz' must use labels",
+            id="value-cartesian-label-order",
+        ),
+        pytest.param(
+            "values",
+            Labels(["o3_mu"], torch.tensor([[1], [-1], [0]])),
+            Labels(
+                ["o3_lambda", "o3_sigma"],
+                torch.tensor([[1, 1]]),
+            ),
+            "Spherical component axis 'o3_mu' for ell=1 must use labels",
+            id="value-spherical-label-order",
+        ),
+        pytest.param(
+            "gradient",
+            Labels(["xyz"], torch.tensor([[2], [0], [1]])),
+            Labels(["_"], torch.tensor([[0]])),
+            "Cartesian component axis 'xyz' must use labels",
+            id="gradient-cartesian-label-order",
+        ),
+        pytest.param(
+            "values",
+            Labels(["o3_mu"], torch.tensor([[0]])),
+            Labels(
+                ["o3_lambda", "o3_sigma"],
+                torch.tensor([[-1, 1]]),
+            ),
+            "ell must be a non-negative integer",
+            id="negative-spherical-angular-momentum",
+        ),
+    ],
+)
+def test_transform_tensor_validates_empty_component_metadata(
+    location,
+    component,
+    keys,
+    message,
+):
+    """Empty values and gradients still require valid component metadata."""
+    if location == "values":
+        block = TensorBlock(
+            values=torch.empty(
+                (0, len(component), 1),
+                dtype=torch.float64,
+            ),
+            samples=Labels(
+                ["system"],
+                torch.empty((0, 1), dtype=torch.int64),
+            ),
+            components=[component],
+            properties=Labels(["p"], torch.tensor([[0]])),
+        )
+    else:
+        block = TensorBlock(
+            values=torch.ones((1, 1), dtype=torch.float64),
+            samples=Labels(["system"], torch.tensor([[0]])),
+            components=[],
+            properties=Labels(["p"], torch.tensor([[0]])),
+        )
+        block.add_gradient(
+            "positions",
+            TensorBlock(
+                values=torch.empty(
+                    (0, len(component), 1),
+                    dtype=torch.float64,
+                ),
+                samples=Labels(
+                    ["sample"],
+                    torch.empty((0, 1), dtype=torch.int64),
+                ),
+                components=[component],
+                properties=block.properties,
+            ),
+        )
+
+    tensor = TensorMap(keys, [block])
+
+    with pytest.raises(ValueError, match=re.escape(message)):
+        transform_tensor(
+            tensor,
+            [_make_system([1])],
+            [
+                O3Transformation(
+                    torch.eye(3, dtype=torch.float64),
+                    max_angular_momentum=1,
+                )
+            ],
+        )
+
+
+@pytest.mark.parametrize("sigma_9", [1, -1])
+def test_transform_tensor_combines_spherical_axis_parities(sigma_9):
+    """Improper parity factors multiply across spherical component axes."""
+    values = torch.arange(
+        1,
+        10,
+        dtype=torch.float64,
+    ).reshape(1, 3, 3, 1)
+    tensor = _single_block_tensor_map(
+        keys=Labels(
+            [
+                "o3_lambda_1",
+                "o3_lambda_9",
+                "o3_sigma_1",
+                "o3_sigma_9",
+            ],
+            torch.tensor([[1, 1, 1, sigma_9]]),
+        ),
+        values=values,
+        samples=Labels(["system"], torch.tensor([[0]])),
+        components=[
+            Labels(
+                ["o3_mu_1"],
+                torch.arange(-1, 2).reshape(-1, 1),
+            ),
+            Labels(
+                ["o3_mu_9"],
+                torch.arange(-1, 2).reshape(-1, 1),
+            ),
+        ],
+    )
+
+    transformed = transform_tensor(
+        tensor,
+        [_make_system([1])],
+        [
+            O3Transformation(
+                -torch.eye(3, dtype=torch.float64),
+                max_angular_momentum=1,
+            )
+        ],
+    )
+
+    assert torch.allclose(
+        transformed.block().values,
+        sigma_9 * values,
+        rtol=0.0,
+        atol=1e-12,
+    )
+
+
+def test_transform_tensor_enforces_ten_component_axis_limit():
+    """Ten component axes are transformed and an eleventh is rejected."""
+    # The first spherical axis is unsuffixed by convention; the nine axes below
+    # use `o3_mu` through `o3_mu_8`, followed by Cartesian `xyz_9`.
+    spherical_suffixes = [""] + [f"_{index}" for index in range(1, 9)]
+    components = [
+        Labels([f"o3_mu{suffix}"], torch.tensor([[0]])) for suffix in spherical_suffixes
+    ]
+    components.append(Labels(["xyz_9"], torch.arange(3).reshape(-1, 1)))
+
+    key_names = [f"o3_lambda{suffix}" for suffix in spherical_suffixes] + [
+        f"o3_sigma{suffix}" for suffix in spherical_suffixes
+    ]
+    values = torch.tensor(
+        [1.0, 2.0, 3.0],
+        dtype=torch.float64,
+    ).reshape([1] + [1] * 9 + [3, 1])
+    tensor = _single_block_tensor_map(
+        keys=Labels(key_names, torch.tensor([[0] * 9 + [1] * 9])),
+        values=values,
+        samples=Labels(["system"], torch.tensor([[0]])),
+        components=components,
+    )
+
+    system = _make_system([1])
+    transformation = O3Transformation(
+        -torch.eye(3, dtype=torch.float64),
+        max_angular_momentum=0,
+    )
+    transformed = transform_tensor(
+        tensor,
+        [system],
+        [transformation],
+    )
+    assert torch.equal(transformed.block().values, -values)
+
+    too_many_components = components + [Labels(["xyz"], torch.arange(3).reshape(-1, 1))]
+    too_many_tensor = _single_block_tensor_map(
+        keys=tensor.keys,
+        values=torch.zeros(
+            [1] + [1] * 9 + [3, 3, 1],
+            dtype=torch.float64,
+        ),
+        samples=tensor.block().samples,
+        components=too_many_components,
+        properties=tensor.block().properties,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="can not transform a tensor with 11 component axes; at most 10",
+    ):
+        transform_tensor(
+            too_many_tensor,
+            [system],
+            [transformation],
+        )
+
+
+def _system_ids_inputs():
+    systems = [_make_system([1]), _make_system([8])]
+    transformations = [
+        O3Transformation(torch.eye(3, dtype=torch.float64), 0),
+        O3Transformation(torch.eye(3, dtype=torch.float64), 0),
+    ]
+    return systems, transformations
+
+
+@pytest.mark.parametrize(
+    ("system_ids", "sample_system_ids"),
+    [
+        pytest.param(None, [0, 1], id="default"),
+        pytest.param([92, 38], [92, 38], id="python-list"),
+        pytest.param(
+            torch.tensor([92, -7], dtype=torch.int32),
+            [92, -7],
+            id="integer-tensor",
+        ),
+    ],
+)
+@pytest.mark.parametrize("entry_point", ["block", "tensor"])
+def test_transform_block_and_tensor_route_rows_by_system_id(
+    entry_point,
+    system_ids,
+    sample_system_ids,
+):
+    """Default, list, and tensor IDs route rows through ``transform_block`` and
+    ``transform_tensor``.
+    """
+    systems = [_make_system([1]), _make_system([8])]
+    transformations = [
+        O3Transformation(
+            torch.tensor(
+                [
+                    [-1.0, 0.0, 0.0],
+                    [0.0, -1.0, 0.0],
+                    [0.0, 0.0, 1.0],
+                ],
+                dtype=torch.float64,
+            ),
+            max_angular_momentum=0,
+        ),
+        O3Transformation(
+            _rotation_90_degrees_around_z(),
+            max_angular_momentum=0,
+        ),
+    ]
+    block = TensorBlock(
+        values=torch.tensor(
+            [
+                [[1.0], [0.0], [0.0]],
+                [[0.0], [2.0], [0.0]],
+            ],
+            dtype=torch.float64,
+        ),
+        samples=Labels(
+            ["system", "atom"],
+            torch.tensor(
+                [
+                    [sample_system_ids[0], 0],
+                    [sample_system_ids[1], 0],
+                ]
+            ),
+        ),
+        components=[Labels(["xyz"], torch.arange(3).reshape(-1, 1))],
+        properties=Labels(["p"], torch.tensor([[0]])),
+    )
+
+    kwargs = {} if system_ids is None else {"system_ids": system_ids}
+    keys = Labels(["_"], torch.tensor([[0]]))
+    if entry_point == "block":
+        transformed = transform_block(
+            keys[0],
+            block,
+            systems,
+            transformations,
+            **kwargs,
+        )
+    else:
+        transformed = transform_tensor(
+            TensorMap(keys, [block]),
+            systems,
+            transformations,
+            **kwargs,
+        ).block()
+
+    expected = torch.tensor(
+        [
+            [[-1.0], [0.0], [0.0]],
+            [[-2.0], [0.0], [0.0]],
+        ],
         dtype=torch.float64,
     )
-    tensor = TensorMap(
-        Labels(["_"], torch.tensor([[0]])),
-        [
-            TensorBlock(
-                values=vector_values.clone(),
-                samples=Labels(
-                    ["system", "atom"],
-                    torch.tensor([[92, 0], [38, 0]]),
-                ),
-                components=[Labels(["xyz"], torch.arange(3).reshape(-1, 1))],
-                properties=Labels(["p"], torch.tensor([[0]])),
+    assert torch.equal(transformed.values, expected)
+
+
+@pytest.mark.parametrize(
+    ("system_ids", "message"),
+    [
+        pytest.param([92], "exactly one entry per system", id="wrong-count"),
+        pytest.param([92, 92], "one distinct entry per system", id="duplicate"),
+        pytest.param(
+            torch.tensor([[92, -7]]),
+            "system_ids must be one-dimensional",
+            id="two-dimensional-tensor",
+        ),
+        pytest.param(
+            torch.tensor([92.0, -7.0]),
+            "system_ids must contain integers",
+            id="floating-point-tensor",
+        ),
+        pytest.param(
+            [92.0, -7.0],
+            "system_ids must contain integers",
+            id="floating-point-list",
+        ),
+        pytest.param(
+            [True, False],
+            "system_ids must contain integers",
+            id="boolean-list",
+        ),
+    ],
+)
+def test_validate_system_ids_rejects_invalid_ids(system_ids, message):
+    """Reject ambiguous or structurally invalid system identifiers."""
+    systems, transformations = _system_ids_inputs()
+
+    with pytest.raises(ValueError, match=message):
+        _validate_system_ids(
+            systems,
+            transformations,
+            system_ids,
+            expected_device=torch.device("cpu"),
+        )
+
+
+def test_validate_system_ids_requires_one_transformation_per_system():
+    """Each system must have exactly one transformation."""
+    systems, transformations = _system_ids_inputs()
+
+    with pytest.raises(ValueError, match="Expected one transformation per system"):
+        _validate_system_ids(
+            systems,
+            transformations[:1],
+            [92, -7],
+            expected_device=torch.device("cpu"),
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_validate_system_ids_checks_device_only_when_defined():
+    """Reject device mismatches, while allowing IDs when no device is specified."""
+    systems, transformations = _system_ids_inputs()
+
+    with pytest.raises(
+        ValueError,
+        match="system_ids are on device cpu, but the values to transform are on device",
+    ):
+        _validate_system_ids(
+            systems,
+            transformations,
+            torch.tensor([92, -7]),
+            expected_device=torch.device("cuda"),
+        )
+
+    empty_cuda_ids = torch.empty(0, dtype=torch.long, device="cuda")
+    validated = _validate_system_ids(
+        [],
+        [],
+        empty_cuda_ids,
+        expected_device=None,
+    )
+    assert validated.device == empty_cuda_ids.device
+
+
+@pytest.mark.parametrize("entry_point", ["block", "tensor"])
+@pytest.mark.parametrize(
+    ("dtype", "device"),
+    [
+        pytest.param(torch.float32, torch.device("cpu"), id="dtype"),
+        pytest.param(
+            torch.float64,
+            torch.device("cuda"),
+            marks=pytest.mark.skipif(
+                not torch.cuda.is_available(),
+                reason="CUDA is not available",
+            ),
+            id="device",
+        ),
+    ],
+)
+def test_transform_block_and_tensor_reject_mismatched_transformation_with_no_rows(
+    entry_point,
+    dtype,
+    device,
+):
+    """Every transformation must match the values even when it has no rows."""
+    block = TensorBlock(
+        values=torch.ones((1, 1), dtype=torch.float64),
+        samples=Labels(["system"], torch.tensor([[92]])),
+        components=[],
+        properties=Labels(["p"], torch.tensor([[0]])),
+    )
+    systems, transformations = _system_ids_inputs()
+    transformations[1] = O3Transformation(
+        torch.eye(3, dtype=dtype, device=device),
+        max_angular_momentum=0,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Transformation at index 1 has dtype/device",
+    ):
+        if entry_point == "block":
+            transform_block(
+                Labels(["_"], torch.tensor([[0]]))[0],
+                block,
+                systems,
+                transformations,
+                system_ids=[92, 38],
             )
+        else:
+            transform_tensor(
+                TensorMap(Labels(["_"], torch.tensor([[0]])), [block]),
+                systems,
+                transformations,
+                system_ids=[92, 38],
+            )
+
+
+def test_transform_block_leaves_empty_block_unchanged_without_systems():
+    """An empty block remains unchanged when no transformations are requested."""
+    block = TensorBlock(
+        values=torch.empty((0, 1), dtype=torch.float64),
+        samples=Labels(
+            ["system"],
+            torch.empty((0, 1), dtype=torch.int64),
+        ),
+        components=[],
+        properties=Labels(["p"], torch.tensor([[0]])),
+    )
+
+    transformed = transform_block(
+        Labels(["_"], torch.tensor([[0]]))[0],
+        block,
+        [],
+        [],
+    )
+
+    assert torch.equal(transformed.values, block.values)
+    assert transformed.samples == block.samples
+    assert transformed.components == block.components
+    assert transformed.properties == block.properties
+
+
+def test_transform_tensor_preserves_empty_map_information():
+    """An empty TensorMap retains its information without imposing a values dtype."""
+    empty = TensorMap(
+        Labels(
+            ["_"],
+            torch.empty((0, 1), dtype=torch.int64),
+        ),
+        [],
+    )
+    empty.set_info("unit", "eV")
+    transformed = transform_tensor(
+        empty,
+        [_make_system([1]), _make_system([8])],
+        [
+            O3Transformation(
+                torch.eye(3, dtype=torch.float64),
+                max_angular_momentum=0,
+            ),
+            O3Transformation(
+                torch.eye(3, dtype=torch.float32),
+                max_angular_momentum=0,
+            ),
         ],
     )
 
-    transformed = transform_tensor(tensor, systems, [R0, R1], system_ids=[92, 38])
-    result = transformed.block().values
-    # row 0 (system 92) rotated by R0 (identity)
-    assert torch.allclose(result[0], vector_values[0])
-    # row 1 (system 38) rotated by R1 (z-90)
-    expected = torch.tensor([[[-2.0], [0.0], [0.0]]], dtype=torch.float64)
-    assert torch.allclose(result[1], expected)
+    assert len(transformed) == 0
+    assert transformed.keys == empty.keys
+    assert transformed.info() == empty.info()
 
 
-def test_system_ids_uncovered_samples_raises():
-    """All distinct system indices in samples must appear in ``system_ids``."""
+@pytest.mark.parametrize(
+    ("kwargs", "unknown_labels", "expected_system_ids"),
+    [
+        pytest.param(
+            {"system_ids": [92, 99]},
+            [38],
+            [92, 99],
+            id="one-unknown-label",
+        ),
+        pytest.param(
+            {},
+            [38, 92],
+            [0, 1],
+            id="default-system-ids",
+        ),
+    ],
+)
+def test_transform_tensor_rejects_unknown_system_labels(
+    kwargs,
+    unknown_labels,
+    expected_system_ids,
+):
+    """Every value row must match one of the requested systems."""
     systems = [_make_system([1, 8]), _make_system([1, 8])]
-    R = O3Transformation(torch.eye(3, dtype=torch.float64), 1)
-
-    tensor = TensorMap(
-        Labels(["_"], torch.tensor([[0]])),
-        [
-            TensorBlock(
-                values=torch.zeros(2, 3, 1, dtype=torch.float64),
-                samples=Labels(
-                    ["system", "atom"],
-                    torch.tensor([[92, 0], [38, 0]]),
-                ),
-                components=[Labels(["xyz"], torch.arange(3).reshape(-1, 1))],
-                properties=Labels(["p"], torch.tensor([[0]])),
-            )
-        ],
-    )
-
-    message = (
-        "Block samples contain system labels [38, 92] that are not in "
-        "system_ids=[99, 100]. Every sample must be assigned to a system "
-        "in the transformation."
-    )
-    with pytest.raises(ValueError, match=re.escape(message)):
-        transform_tensor(tensor, systems, [R, R], system_ids=[99, 100])
-
-    message = (
-        "Block samples contain system labels [38, 92] that are not in "
-        "system_ids=[0, 1]. Every sample must be assigned to a system "
-        "in the transformation."
-    )
-    with pytest.raises(ValueError, match=re.escape(message)):
-        # default system_ids=[0, 1] also misses labels 92 and 38
-        transform_tensor(tensor, systems, [R, R])
-
-
-def test_system_ids_single_system_ignores_label():
-    """Single-system blocks return all rows regardless of the ``"system"`` label."""
-    systems = [_make_system([1])]
-    values = torch.tensor([[[1.0], [2.0], [3.0]]], dtype=torch.float64)
-
-    tensor = TensorMap(
-        Labels(["_"], torch.tensor([[0]])),
-        [
-            TensorBlock(
-                values=values.clone(),
-                samples=Labels(["system", "atom"], torch.tensor([[4, 0]])),
-                components=[Labels(["xyz"], torch.arange(3).reshape(-1, 1))],
-                properties=Labels(["p"], torch.tensor([[0]])),
-            )
-        ],
-    )
-
     transformation = O3Transformation(torch.eye(3, dtype=torch.float64), 1)
+
+    tensor = _single_block_tensor_map(
+        values=torch.zeros(2, 3, 1, dtype=torch.float64),
+        samples=Labels(
+            ["system", "atom"],
+            torch.tensor([[92, 0], [38, 0]]),
+        ),
+        components=[Labels(["xyz"], torch.arange(3).reshape(-1, 1))],
+    )
+
+    message = (
+        f"Block samples contain system labels {unknown_labels} that are not in "
+        f"system_ids={expected_system_ids}. Every sample must be assigned to a "
+        "system in the transformation."
+    )
+    with pytest.raises(ValueError, match=re.escape(message)):
+        transform_tensor(
+            tensor,
+            systems,
+            [transformation, transformation],
+            **kwargs,
+        )
+
+
+@pytest.mark.parametrize(
+    "samples",
+    [
+        pytest.param(
+            Labels(["atom"], torch.tensor([[0], [1]])),
+            id="without-system-label",
+        ),
+        pytest.param(
+            Labels(
+                ["system", "atom"],
+                torch.tensor([[4, 0], [4, 1]]),
+            ),
+            id="unrelated-system-label",
+        ),
+    ],
+)
+def test_transform_tensor_routes_all_rows_for_single_system(samples):
+    """With one system, all rows are transformed regardless of ``"system"`` labels."""
+    systems = [_make_system([1, 1])]
+
+    transformation = O3Transformation(_rotation_90_degrees_around_z(), 1)
+    values = torch.tensor(
+        [
+            [[1.0], [2.0], [3.0]],
+            [[-1.0], [4.0], [0.0]],
+        ],
+        dtype=torch.float64,
+    )
+    tensor = _single_block_tensor_map(
+        values=values,
+        samples=samples,
+        components=[Labels(["xyz"], torch.arange(3).reshape(-1, 1))],
+    )
+
     transformed = transform_tensor(tensor, systems, [transformation])
-    assert torch.allclose(transformed.block().values, values)
+
+    expected = torch.tensor(
+        [
+            [[-2.0], [1.0], [3.0]],
+            [[-4.0], [-1.0], [0.0]],
+        ],
+        dtype=torch.float64,
+    )
+    assert torch.equal(transformed.block().values, expected)
+
+
+def test_transform_tensor_accepts_block_with_subset_of_systems():
+    """Transform a block whose rows belong to only a subset of the input systems."""
+    systems = [_make_system([1]), _make_system([8])]
+
+    transformation_92 = O3Transformation(_rotation_90_degrees_around_z(), 1)
+    transformation_38 = O3Transformation(
+        torch.eye(3, dtype=torch.float64),
+        1,
+    )
+
+    tensor = _single_block_tensor_map(
+        values=torch.tensor(
+            [[[1.0], [2.0], [3.0]]],
+            dtype=torch.float64,
+        ),
+        samples=Labels(
+            ["system", "atom"],
+            torch.tensor([[92, 0]]),
+        ),
+        components=[Labels(["xyz"], torch.arange(3).reshape(-1, 1))],
+    )
+
+    transformed = transform_tensor(
+        tensor,
+        systems,
+        [transformation_92, transformation_38],
+        # The second system has no samples in this block. Its ID exceeds the
+        # int32 range, checking that Python IDs are preserved as torch.long.
+        system_ids=[92, 2**40],
+    )
+
+    expected = torch.tensor(
+        [[[-2.0], [1.0], [3.0]]],
+        dtype=torch.float64,
+    )
+    assert torch.equal(transformed.block().values, expected)
+
+
+def test_transform_tensor_rejects_missing_system_column_for_multiple_systems():
+    """With multiple systems, each row must identify which system it belongs to."""
+    systems = [_make_system([1]), _make_system([8])]
+    transformation = O3Transformation(
+        torch.eye(3, dtype=torch.float64),
+        max_angular_momentum=0,
+    )
+
+    tensor = _single_block_tensor_map(
+        values=torch.zeros((1, 1), dtype=torch.float64),
+        samples=Labels(["atom"], torch.tensor([[0]])),
+        components=[],
+    )
+
+    message = (
+        "Rotational augmentation expects output samples to include a 'system' "
+        "dimension when transforming multiple systems."
+    )
+    with pytest.raises(ValueError, match=re.escape(message)):
+        transform_tensor(
+            tensor,
+            systems,
+            [transformation, transformation],
+        )

--- a/python/metatomic_torch/tests/o3.py
+++ b/python/metatomic_torch/tests/o3.py
@@ -1,5 +1,6 @@
 import re
 
+import metatensor.torch as mts
 import numpy as np
 import pytest
 import torch
@@ -17,7 +18,11 @@ from metatomic.torch.o3 import (
     transform_system,
     transform_tensor,
 )
-from metatomic.torch.o3._tranformations import _validate_system_ids
+from metatomic.torch.o3._tranformations import (
+    _max_o3_lambda_in_tensor,
+    _transform_tensor_with_precomputed_matrices,
+    _validate_system_ids,
+)
 from metatomic.torch.o3._wigner import (
     _complex_to_real_spherical_harmonics_transform,
     build_wigner_D_cache,
@@ -101,6 +106,62 @@ def _single_block_tensor_map(
             )
         ],
     )
+
+
+def _stack_o3_matrices(transformations, max_angular_momentum):
+    """Stack Cartesian and Wigner matrices from O3 transformations."""
+    matrices = torch.stack(
+        [transformation.matrix for transformation in transformations]
+    )
+    wigner_matrices = [
+        torch.stack(
+            [transformation.wigner_D_matrix(ell) for transformation in transformations]
+        )
+        for ell in range(max_angular_momentum + 1)
+    ]
+    return matrices, wigner_matrices
+
+
+def test_max_o3_lambda_in_tensor_checks_values_and_gradients_in_torchscript():
+    """Inspect value and gradient ranks while ignoring Cartesian component axes."""
+    properties = Labels("property", torch.tensor([[0]]))
+    block = TensorBlock(
+        values=torch.ones((1, 3, 1), dtype=torch.float64),
+        samples=Labels("system", torch.tensor([[0]])),
+        components=[Labels("o3_mu", torch.arange(-1, 2).reshape(-1, 1))],
+        properties=properties,
+    )
+    block.add_gradient(
+        "parameter",
+        TensorBlock(
+            values=torch.ones((1, 7, 3, 1), dtype=torch.float64),
+            samples=Labels(
+                ["sample", "parameter"],
+                torch.tensor([[0, 0]]),
+            ),
+            components=[
+                Labels("o3_mu_1", torch.arange(-3, 4).reshape(-1, 1)),
+                Labels("o3_mu", torch.arange(-1, 2).reshape(-1, 1)),
+            ],
+            properties=properties,
+        ),
+    )
+    spherical = TensorMap(
+        Labels(
+            ["o3_lambda", "o3_sigma", "o3_lambda_1", "o3_sigma_1"],
+            torch.tensor([[1, 1, 3, -1]]),
+        ),
+        [block],
+    )
+    cartesian = _single_block_tensor_map(
+        values=torch.ones((1, 3, 1), dtype=torch.float64),
+        samples=Labels("system", torch.tensor([[0]])),
+        components=[Labels("xyz", torch.arange(3).reshape(-1, 1))],
+    )
+
+    scripted_maximum = torch.jit.script(_max_o3_lambda_in_tensor)
+    assert scripted_maximum(spherical) == 3
+    assert scripted_maximum(cartesian) == -1
 
 
 @pytest.mark.parametrize("device,dtype", ALL_DEVICE_DTYPE)
@@ -1652,4 +1713,300 @@ def test_transform_tensor_rejects_missing_system_column_for_multiple_systems():
             tensor,
             systems,
             [transformation, transformation],
+        )
+
+
+@pytest.mark.parametrize("device,dtype", ALL_DEVICE_DTYPE)
+@pytest.mark.parametrize("is_improper", [False, True])
+def test_precomputed_tensor_transform_matches_transform_tensor(
+    device,
+    dtype,
+    is_improper,
+):
+    """Match ``transform_tensor`` for scripted, mixed-axis O(3) batches."""
+    dtype = getattr(torch, dtype)
+    atol = 1.0e-5 if dtype == torch.float32 else 1.0e-12
+    sign = -1.0 if is_improper else 1.0
+    proper_matrices = [
+        _rotation_90_degrees_around_z().to(device=device, dtype=dtype),
+        torch.tensor(
+            _axis_angle([1.0, 2.0, 3.0], 0.7),
+            device=device,
+            dtype=dtype,
+        ),
+    ]
+    transformations = [
+        O3Transformation(sign * matrix, max_angular_momentum=2)
+        for matrix in proper_matrices
+    ]
+    matrices, wigner_matrices = _stack_o3_matrices(
+        transformations,
+        max_angular_momentum=2,
+    )
+
+    keys = Labels(
+        ["o3_lambda_1", "o3_sigma_1", "o3_lambda_2", "o3_sigma_2"],
+        torch.tensor([[1, 1, 2, 1]], device=device),
+    )
+    properties = Labels("property", torch.tensor([[0], [1]], device=device))
+    components = [
+        Labels("xyz", torch.arange(3, device=device).reshape(-1, 1)),
+        Labels("o3_mu_1", torch.arange(-1, 2, device=device).reshape(-1, 1)),
+        Labels("o3_mu_2", torch.arange(-2, 3, device=device).reshape(-1, 1)),
+    ]
+    values = torch.linspace(
+        -2.0,
+        3.0,
+        3 * 3 * 3 * 5 * 2,
+        device=device,
+        dtype=dtype,
+    ).reshape(3, 3, 3, 5, 2)
+    values.requires_grad_()
+    gradient_values = torch.linspace(
+        1.0,
+        5.0,
+        4 * 3 * 3 * 5 * 2,
+        device=device,
+        dtype=dtype,
+    ).reshape(4, 3, 3, 5, 2)
+    gradient_values.requires_grad_()
+
+    block = TensorBlock(
+        values=values,
+        samples=Labels(
+            ["system", "atom"],
+            torch.tensor([[1, 2], [0, 0], [1, 1]], device=device),
+        ),
+        components=components,
+        properties=properties,
+    )
+    block.add_gradient(
+        "parameter",
+        TensorBlock(
+            values=gradient_values,
+            samples=Labels(
+                ["sample", "parameter"],
+                torch.tensor(
+                    [[2, 0], [0, 1], [1, 2], [2, 3]],
+                    device=device,
+                ),
+            ),
+            components=components,
+            properties=properties,
+        ),
+    )
+    tensor = TensorMap(keys, [block])
+    tensor.set_info("unit", "arbitrary")
+    values_before = values.detach().clone()
+    gradient_values_before = gradient_values.detach().clone()
+
+    expected = transform_tensor(
+        tensor,
+        [
+            _make_system([1], device=device, dtype=dtype),
+            _make_system([8], device=device, dtype=dtype),
+        ],
+        transformations,
+    )
+    scripted_transform = torch.jit.script(_transform_tensor_with_precomputed_matrices)
+    result = scripted_transform(
+        tensor,
+        matrices,
+        wigner_matrices,
+        is_improper,
+    )
+
+    mts.allclose_raise(result, expected, rtol=0.0, atol=atol)
+    assert result.info() == expected.info()
+    assert torch.equal(values, values_before)
+    assert torch.equal(gradient_values, gradient_values_before)
+
+    result_loss = result.block_by_id(0).values.square().sum()
+    result_loss = (
+        result_loss + result.block_by_id(0).gradient("parameter").values.square().sum()
+    )
+    value_gradient, explicit_gradient_gradient = torch.autograd.grad(
+        result_loss,
+        (values, gradient_values),
+    )
+    assert torch.allclose(value_gradient, 2.0 * values, rtol=0.0, atol=atol)
+    assert torch.allclose(
+        explicit_gradient_gradient,
+        2.0 * gradient_values,
+        rtol=0.0,
+        atol=atol,
+    )
+
+
+def test_precomputed_tensor_transform_single_transformation_is_scriptable():
+    """The scripted singleton path should not require a ``system`` sample label."""
+    transformation = O3Transformation(
+        _rotation_90_degrees_around_z(),
+        max_angular_momentum=1,
+    )
+    matrices, wigner_matrices = _stack_o3_matrices(
+        [transformation],
+        max_angular_momentum=1,
+    )
+    tensor = _single_block_tensor_map(
+        keys=Labels(
+            ["o3_lambda", "o3_sigma"],
+            torch.tensor([[1, 1]]),
+        ),
+        values=torch.tensor(
+            [[[1.0], [2.0], [3.0]], [[-1.0], [4.0], [0.0]]],
+            dtype=torch.float64,
+        ),
+        samples=Labels("atom", torch.tensor([[0], [1]])),
+        components=[
+            Labels("o3_mu", torch.arange(-1, 2).reshape(-1, 1)),
+        ],
+    )
+
+    scripted_transform = torch.jit.script(_transform_tensor_with_precomputed_matrices)
+    result = scripted_transform(
+        tensor,
+        matrices,
+        wigner_matrices,
+        False,
+    )
+    expected = transform_tensor(
+        tensor,
+        [_make_system([1])],
+        [transformation],
+    )
+
+    assert torch.allclose(
+        result.block().values,
+        expected.block().values,
+        rtol=0.0,
+        atol=1.0e-12,
+    )
+
+
+def test_precomputed_tensor_transform_scalar_does_not_alias_input():
+    """A transformed scalar should own its storage, as in ``transform_tensor``."""
+    values = torch.tensor([[1.0]], dtype=torch.float64)
+    tensor = _single_block_tensor_map(
+        values=values,
+        samples=Labels("system", torch.tensor([[0]])),
+        components=[],
+    )
+
+    result = _transform_tensor_with_precomputed_matrices(
+        tensor,
+        torch.eye(3, dtype=torch.float64).unsqueeze(0),
+        [],
+        False,
+    )
+    result.block().values.add_(1.0)
+
+    assert torch.equal(values, torch.tensor([[1.0]], dtype=torch.float64))
+
+
+@pytest.mark.parametrize(
+    ("matrices", "error", "message"),
+    [
+        pytest.param(
+            torch.empty((0, 3, 3), dtype=torch.float64),
+            ValueError,
+            "shape.*N > 0",
+            id="empty",
+        ),
+        pytest.param(
+            torch.empty((1, 2, 3), dtype=torch.float64),
+            ValueError,
+            "shape.*N > 0",
+            id="wrong-shape",
+        ),
+        pytest.param(
+            torch.eye(3, dtype=torch.float16).unsqueeze(0),
+            TypeError,
+            "float32 or float64",
+            id="unsupported-dtype",
+        ),
+        pytest.param(
+            torch.eye(3, dtype=torch.float32).unsqueeze(0),
+            ValueError,
+            "same dtype and device",
+            id="tensor-dtype-mismatch",
+        ),
+    ],
+)
+def test_precomputed_tensor_transform_rejects_invalid_matrix_batch(
+    matrices,
+    error,
+    message,
+):
+    """Reject malformed matrix batches and incompatible numerical types."""
+    tensor = _single_block_tensor_map(
+        values=torch.ones((1, 1), dtype=torch.float64),
+        samples=Labels("sample", torch.tensor([[0]])),
+        components=[],
+    )
+
+    with pytest.raises(error, match=message):
+        _transform_tensor_with_precomputed_matrices(
+            tensor,
+            matrices,
+            [],
+            False,
+        )
+
+
+def test_precomputed_tensor_transform_rejects_invalid_routing_and_wigner_rank():
+    """Reject ambiguous local routing and unavailable spherical ranks."""
+    transformations = [
+        O3Transformation(torch.eye(3, dtype=torch.float64), 1),
+        O3Transformation(_rotation_90_degrees_around_z(), 1),
+    ]
+    matrices, wigner_matrices = _stack_o3_matrices(
+        transformations,
+        max_angular_momentum=1,
+    )
+
+    missing_system = _single_block_tensor_map(
+        values=torch.ones((1, 1), dtype=torch.float64),
+        samples=Labels("sample", torch.tensor([[0]])),
+        components=[],
+    )
+    with pytest.raises(ValueError, match="require a 'system'"):
+        _transform_tensor_with_precomputed_matrices(
+            missing_system,
+            matrices,
+            wigner_matrices,
+            False,
+        )
+
+    for system_index in (-1, 2):
+        out_of_range = _single_block_tensor_map(
+            values=torch.ones((1, 1), dtype=torch.float64),
+            samples=Labels("system", torch.tensor([[system_index]])),
+            components=[],
+        )
+        with pytest.raises(ValueError, match="exceed the transformation batch"):
+            _transform_tensor_with_precomputed_matrices(
+                out_of_range,
+                matrices,
+                wigner_matrices,
+                False,
+            )
+
+    unavailable_rank = _single_block_tensor_map(
+        keys=Labels(
+            ["o3_lambda", "o3_sigma"],
+            torch.tensor([[1, 1]]),
+        ),
+        values=torch.ones((1, 3, 1), dtype=torch.float64),
+        samples=Labels("system", torch.tensor([[0]])),
+        components=[
+            Labels("o3_mu", torch.arange(-1, 2).reshape(-1, 1)),
+        ],
+    )
+    with pytest.raises(ValueError, match="rank exceeds the Wigner-D storage"):
+        _transform_tensor_with_precomputed_matrices(
+            unavailable_rank,
+            matrices,
+            wigner_matrices[:1],
+            False,
         )

--- a/python/metatomic_torch/tests/o3.py
+++ b/python/metatomic_torch/tests/o3.py
@@ -467,7 +467,7 @@ def test_create_from_internal_matrix_matches_constructor(is_improper):
         )
 
 
-def test_external_matrix_changes_do_not_modify_transformation():
+def test_constructor_copies_input_matrix():
     expected = torch.eye(3, dtype=torch.float64)
     source = expected.clone()
     transformation = O3Transformation(
@@ -477,11 +477,6 @@ def test_external_matrix_changes_do_not_modify_transformation():
 
     source[:] = -expected
     assert torch.equal(transformation.matrix, expected)
-
-    returned = transformation.matrix
-    returned[:] = -expected
-    assert torch.equal(transformation.matrix, expected)
-
     assert transformation.is_improper is False
     assert torch.equal(
         transformation.transform_cartesian(expected),
@@ -507,22 +502,6 @@ def test_wigner_cache_is_built_only_when_needed():
 
     transformation.wigner_D_matrix(2)
     assert transformation._wigner_D_cache is cache
-
-
-def test_wigner_D_matrix_returns_independent_copy():
-    transformation = O3Transformation(
-        torch.eye(3, dtype=torch.float64),
-        max_angular_momentum=1,
-    )
-    expected = transformation.wigner_D_matrix(1).clone()
-
-    returned = transformation.wigner_D_matrix(1)
-    returned.zero_()
-
-    assert torch.equal(
-        transformation.wigner_D_matrix(1),
-        expected,
-    )
 
 
 @pytest.mark.parametrize(

--- a/python/metatomic_torch/tests/o3.py
+++ b/python/metatomic_torch/tests/o3.py
@@ -20,7 +20,6 @@ from metatomic.torch.o3 import (
 from metatomic.torch.o3._tranformations import _validate_system_ids
 from metatomic.torch.o3._wigner import (
     _complex_to_real_spherical_harmonics_transform,
-    _rotation_to_angles,
     build_wigner_D_cache,
 )
 

--- a/python/metatomic_torch/tests/o3.py
+++ b/python/metatomic_torch/tests/o3.py
@@ -124,7 +124,7 @@ def _stack_o3_matrices(transformations, max_angular_momentum):
 
 
 def test_max_o3_lambda_in_tensor():
-    """Sizes serialized Wigner-D storage for exported wrappers, scripted."""
+    """Check `_max_o3_lambda_in_tensor`, including in torchscript mode"""
     properties = Labels("property", torch.tensor([[0]]))
     block = TensorBlock(
         values=torch.ones((1, 3, 1), dtype=torch.float64),
@@ -326,36 +326,48 @@ def test_transform_system_preserves_neighbor_gradients():
 def test_transformation_validation():
     """Realistic construction mistakes fail with a clear error."""
     # negative counts and angular momentum limits
-    with pytest.raises(ValueError, match="max_angular_momentum"):
+    message = re.escape("max_angular_momentum must be a non-negative integer, got -1.")
+    with pytest.raises(ValueError, match=f"^{message}$"):
         O3Transformation(torch.eye(3, dtype=torch.float64), -1)
-    with pytest.raises(ValueError, match="max_angular_momentum"):
+    with pytest.raises(ValueError, match=f"^{message}$"):
         random_transformations(
             0, max_angular_momentum=-1, device=torch.device("cpu"), dtype=torch.float64
         )
-    with pytest.raises(ValueError, match="n must"):
+    message = re.escape("n must be a non-negative integer, got -1.")
+    with pytest.raises(ValueError, match=f"^{message}$"):
         random_transformations(-1, device=torch.device("cpu"), dtype=torch.float64)
 
     # models only declare float32/float64 capabilities
-    with pytest.raises(ValueError, match="torch.float32 or torch.float64"):
+    message = re.escape(
+        "dtype must be torch.float32 or torch.float64, got torch.float16."
+    )
+    with pytest.raises(ValueError, match=f"^{message}$"):
         random_transformations(0, device=torch.device("cpu"), dtype=torch.float16)
 
     # matrices must be (3, 3) and orthogonal
-    with pytest.raises(ValueError, match="shape"):
+    message = re.escape("Transformation has shape (2, 2); expected (3, 3).")
+    with pytest.raises(ValueError, match=f"^{message}$"):
         O3Transformation(torch.eye(2, dtype=torch.float64), max_angular_momentum=0)
     matrix = torch.eye(3, dtype=torch.float64)
     matrix[0, 0] = 2.0
-    with pytest.raises(ValueError, match="not orthogonal"):
+    message = re.escape("Transformation is not orthogonal (R @ R.T deviates from I).")
+    with pytest.raises(ValueError, match=f"^{message}$"):
         O3Transformation(matrix, max_angular_momentum=0)
 
     # Wigner-D requests need a valid ell
     transformation = O3Transformation(torch.eye(3, dtype=torch.float64), 1)
-    with pytest.raises(ValueError, match="ell must be a non-negative integer"):
+    message = re.escape("ell must be a non-negative integer, got -1.")
+    with pytest.raises(ValueError, match=f"^{message}$"):
         transformation.wigner_D_matrix(-1)
 
     # systems must match the transformation dtype/device
     system = _make_system([1], dtype=torch.float64)
     transformation = O3Transformation(torch.eye(3, dtype=torch.float32), 0)
-    with pytest.raises(ValueError, match="differing from the transformations"):
+    message = re.escape(
+        "System has positions with dtype/device (torch.float64, cpu) differing "
+        "from the transformations (torch.float32, cpu)."
+    )
+    with pytest.raises(ValueError, match=f"^{message}$"):
         transform_system(system, transformation)
 
 
@@ -393,39 +405,20 @@ def test_random_rotations_are_orthogonal():
         assert abs(float(torch.det(matrix)) - 1.0) < atol
 
 
-def test_random_transformations_reproducibility():
-    """Seeded sampling with inversions is reproducible and covers both cosets."""
-    kwargs = {
-        "max_angular_momentum": 1,
-        "device": "cpu",
-        "dtype": torch.float64,
-        "include_inversions": True,
-    }
-    first = random_transformations(
-        20, generator=torch.Generator().manual_seed(20260718), **kwargs
-    )
-    second = random_transformations(
-        20, generator=torch.Generator().manual_seed(20260718), **kwargs
+def test_random_transformations_include_inversions():
+    """Sampling with inversions covers both O(3) cosets and sets is_improper."""
+    transformations = random_transformations(
+        20,
+        device="cpu",
+        dtype=torch.float64,
+        include_inversions=True,
+        generator=torch.Generator().manual_seed(20260718),
     )
 
-    for a, b in zip(first, second, strict=True):
-        assert torch.equal(a.matrix, b.matrix)
-        assert a.is_improper == b.is_improper
-        assert a.is_improper == bool(torch.det(a.matrix) < 0)
-
-    determinants = torch.stack([torch.det(t.matrix) for t in first])
+    determinants = torch.stack([torch.det(t.matrix) for t in transformations])
     assert (determinants > 0).any() and (determinants < 0).any()
-
-
-def test_constructor_copies_input_matrix():
-    """In-place edits of the input matrix do not affect the transformation."""
-    expected = torch.eye(3, dtype=torch.float64)
-    source = expected.clone()
-    transformation = O3Transformation(source, max_angular_momentum=0)
-
-    source[:] = -expected
-    assert torch.equal(transformation.matrix, expected)
-    assert transformation.is_improper is False
+    for transformation in transformations:
+        assert transformation.is_improper == bool(torch.det(transformation.matrix) < 0)
 
 
 def test_o3_parity_factor():
@@ -744,7 +737,12 @@ def test_component_metadata_validation():
         samples=Labels(["system"], torch.tensor([[0]])),
         components=[Labels(["direction"], torch.arange(3).reshape(-1, 1))],
     )
-    with pytest.raises(ValueError, match="neither a Cartesian"):
+    message = re.escape(
+        "Found a component axis 'direction', which is neither a Cartesian "
+        "('xyz'/'xyz_1'/'xyz_2'/...) nor spherical ('o3_mu'/'o3_mu_1'/...) axis; "
+        "it can not be transformed."
+    )
+    with pytest.raises(ValueError, match=f"^{message}$"):
         transform_tensor(tensor, systems, transformations)
 
     # o3_sigma outside {-1, +1}
@@ -754,7 +752,8 @@ def test_component_metadata_validation():
         samples=Labels(["system"], torch.tensor([[0]])),
         components=[Labels(["o3_mu"], torch.tensor([[0]]))],
     )
-    with pytest.raises(ValueError, match=re.escape("sigma must be either -1 or +1")):
+    message = re.escape("sigma must be either -1 or +1, got 2.")
+    with pytest.raises(ValueError, match=f"^{message}$"):
         transform_tensor(tensor, systems, transformations)
 
     # misordered Cartesian labels
@@ -763,7 +762,10 @@ def test_component_metadata_validation():
         samples=Labels(["system"], torch.tensor([[0]])),
         components=[Labels(["xyz"], torch.tensor([[2], [0], [1]]))],
     )
-    with pytest.raises(ValueError, match="Cartesian component axis 'xyz' must use"):
+    message = re.escape(
+        "Cartesian component axis 'xyz' must use labels [0, 1, 2] in x, y, z order."
+    )
+    with pytest.raises(ValueError, match=f"^{message}$"):
         transform_tensor(tensor, systems, transformations)
 
     # misordered spherical labels on an empty block: the validation is
@@ -778,7 +780,11 @@ def test_component_metadata_validation():
         Labels(["o3_lambda", "o3_sigma"], torch.tensor([[1, 1]])),
         [block],
     )
-    with pytest.raises(ValueError, match="Spherical component axis 'o3_mu' for ell=1"):
+    message = re.escape(
+        "Spherical component axis 'o3_mu' for ell=1 must use labels from -1 "
+        "through 1 in ascending order."
+    )
+    with pytest.raises(ValueError, match=f"^{message}$"):
         transform_tensor(tensor, systems, transformations)
 
 
@@ -797,7 +803,8 @@ def test_insufficient_max_angular_momentum():
         device=torch.device("cpu"),
         dtype=torch.float64,
     )
-    with pytest.raises(ValueError, match="ell=1 exceeds max_angular_momentum=0"):
+    message = re.escape("ell=1 exceeds max_angular_momentum=0.")
+    with pytest.raises(ValueError, match=f"^{message}$"):
         transform_tensor(tensor, systems, transformations)
 
     transformations = random_transformations(
@@ -941,19 +948,33 @@ def test_system_ids_validation():
     ]
 
     # one transformation per system, one distinct id per system
-    with pytest.raises(ValueError, match="Expected one transformation per system"):
+    message = re.escape(
+        "Expected one transformation per system, but got len(systems)=2 and "
+        "len(transformations)=1."
+    )
+    with pytest.raises(ValueError, match=f"^{message}$"):
         transform_tensor(
             _scalar_two_system_tensor(), systems, transformations[:1], [92, -7]
         )
-    with pytest.raises(ValueError, match="exactly one entry per system"):
+    message = re.escape(
+        "system_ids must contain exactly one entry per system, but got "
+        "len(system_ids)=1 and len(systems)=2."
+    )
+    with pytest.raises(ValueError, match=f"^{message}$"):
         transform_tensor(_scalar_two_system_tensor(), systems, transformations, [92])
-    with pytest.raises(ValueError, match="one distinct entry per system"):
+    message = re.escape(
+        "system_ids must contain one distinct entry per system, but got [92, 92]."
+    )
+    with pytest.raises(ValueError, match=f"^{message}$"):
         transform_tensor(
             _scalar_two_system_tensor(), systems, transformations, [92, 92]
         )
 
     # ids must live with the values ("meta" needs no accelerator hardware)
-    with pytest.raises(ValueError, match="system_ids are on device cpu"):
+    message = re.escape(
+        "system_ids are on device cpu, but the values to transform are on device meta."
+    )
+    with pytest.raises(ValueError, match=f"^{message}$"):
         transform_tensor(
             _scalar_two_system_tensor(device="meta"),
             systems,
@@ -962,7 +983,12 @@ def test_system_ids_validation():
         )
 
     # every "system" label present in a block must appear in system_ids
-    with pytest.raises(ValueError, match="that are not in system_ids"):
+    message = re.escape(
+        "Block samples contain system labels [38] that are not in "
+        "system_ids=[92, 99]. Every sample must be assigned to a system in the "
+        "transformation."
+    )
+    with pytest.raises(ValueError, match=f"^{message}$"):
         transform_tensor(
             _scalar_two_system_tensor(), systems, transformations, [92, 99]
         )
@@ -973,7 +999,11 @@ def test_system_ids_validation():
         samples=Labels(["atom"], torch.tensor([[0]])),
         components=[],
     )
-    with pytest.raises(ValueError, match="to include a 'system' dimension"):
+    message = re.escape(
+        "Rotational augmentation expects output samples to include a 'system' "
+        "dimension when transforming multiple systems."
+    )
+    with pytest.raises(ValueError, match=f"^{message}$"):
         transform_tensor(no_system_column, systems, transformations)
 
     # a transformation with no assigned rows is still validated: a silent
@@ -985,7 +1015,11 @@ def test_system_ids_validation():
         properties=Labels(["p"], torch.tensor([[0]])),
     )
     transformations[1] = O3Transformation(torch.eye(3, dtype=torch.float32), 0)
-    with pytest.raises(ValueError, match="Transformation at index 1 has dtype/device"):
+    message = re.escape(
+        "Transformation at index 1 has dtype/device (torch.float32, cpu), "
+        "differing from the values to transform (torch.float64, cpu)."
+    )
+    with pytest.raises(ValueError, match=f"^{message}$"):
         transform_tensor(
             TensorMap(Labels(["_"], torch.tensor([[0]])), [block]),
             systems,
@@ -1305,7 +1339,8 @@ def test_precomputed_tensor_transform_rejects_invalid_routing_and_wigner_rank():
         samples=Labels("sample", torch.tensor([[0]])),
         components=[],
     )
-    with pytest.raises(ValueError, match="require a 'system'"):
+    message = re.escape("multiple transformations require a 'system' sample dimension")
+    with pytest.raises(ValueError, match=f"^{message}$"):
         _transform_tensor_with_precomputed_matrices(
             missing_system,
             matrices,
@@ -1319,7 +1354,8 @@ def test_precomputed_tensor_transform_rejects_invalid_routing_and_wigner_rank():
             samples=Labels("system", torch.tensor([[system_index]])),
             components=[],
         )
-        with pytest.raises(ValueError, match="exceed the transformation batch"):
+        message = re.escape("sample system indices exceed the transformation batch")
+        with pytest.raises(ValueError, match=f"^{message}$"):
             _transform_tensor_with_precomputed_matrices(
                 out_of_range,
                 matrices,
@@ -1338,7 +1374,8 @@ def test_precomputed_tensor_transform_rejects_invalid_routing_and_wigner_rank():
             Labels("o3_mu", torch.arange(-1, 2).reshape(-1, 1)),
         ],
     )
-    with pytest.raises(ValueError, match="rank exceeds the Wigner-D storage"):
+    message = re.escape("spherical rank exceeds the Wigner-D storage")
+    with pytest.raises(ValueError, match=f"^{message}$"):
         _transform_tensor_with_precomputed_matrices(
             unavailable_rank,
             matrices,

--- a/python/metatomic_torch/tests/o3.py
+++ b/python/metatomic_torch/tests/o3.py
@@ -18,15 +18,16 @@ from metatomic.torch.o3 import (
     transform_system,
     transform_tensor,
 )
+
+# These private helpers back exported symmetrized-model wrappers and have no public
+# entry point yet; their tests below compare them against the public transform_tensor.
 from metatomic.torch.o3._tranformations import (
     _max_o3_lambda_in_tensor,
     _transform_tensor_with_precomputed_matrices,
-    _validate_system_ids,
 )
-from metatomic.torch.o3._wigner import (
-    _complex_to_real_spherical_harmonics_transform,
-    build_wigner_D_cache,
-)
+
+# The complex-to-real spherical harmonics conversion is defined only here for now.
+from metatomic.torch.o3._wigner import _complex_to_real_spherical_harmonics_transform
 
 from ._tests_utils import can_use_mps_backend
 
@@ -122,8 +123,8 @@ def _stack_o3_matrices(transformations, max_angular_momentum):
     return matrices, wigner_matrices
 
 
-def test_max_o3_lambda_in_tensor_checks_values_and_gradients_in_torchscript():
-    """Inspect value and gradient ranks while ignoring Cartesian component axes."""
+def test_max_o3_lambda_in_tensor():
+    """Sizes serialized Wigner-D storage for exported wrappers, scripted."""
     properties = Labels("property", torch.tensor([[0]]))
     block = TensorBlock(
         values=torch.ones((1, 3, 1), dtype=torch.float64),
@@ -165,15 +166,11 @@ def test_max_o3_lambda_in_tensor_checks_values_and_gradients_in_torchscript():
 
 
 @pytest.mark.parametrize("device,dtype", ALL_DEVICE_DTYPE)
-def test_transform_system_rotates_geometry_neighbor_lists_and_custom_data(
-    device,
-    dtype,
-):
+def test_transform_system(device, dtype):
     """Geometry, neighbor vectors, and custom TensorMaps receive one transformation."""
     dtype = getattr(torch, dtype)
     atol = 1e-6 if dtype == torch.float32 else 1e-12
 
-    # create a system with neighbor list and custom data
     system = _make_system(
         [1, 1, 1],
         positions=torch.tensor(
@@ -205,13 +202,12 @@ def test_transform_system_rotates_geometry_neighbor_lists_and_custom_data(
     )
     system.add_neighbor_list(options, neighbors)
 
-    # scalar per-atom data spread over two blocks: both must pass through untouched
     samples = Labels(
         ["system", "atom"],
         torch.tensor([[0, 0], [0, 2], [0, 1]], device=device),
     )
     scalar = TensorMap(
-        keys=Labels(["k"], torch.tensor([[0], [1]], device=device)),
+        keys=Labels(["k"], torch.tensor([[0]], device=device)),
         blocks=[
             TensorBlock(
                 values=torch.tensor([[1.0], [2.0], [3.0]], dtype=dtype, device=device),
@@ -219,18 +215,10 @@ def test_transform_system_rotates_geometry_neighbor_lists_and_custom_data(
                 components=[],
                 properties=Labels(["p"], torch.tensor([[0]], device=device)),
             ),
-            TensorBlock(
-                values=torch.tensor([[3.0], [4.0], [5.0]], dtype=dtype, device=device),
-                samples=samples,
-                components=[],
-                properties=Labels(["p"], torch.tensor([[0]], device=device)),
-            ),
         ],
     )
     scalar.set_info("unit", "eV")
-    scalar.set_info("custom", "preserved by transformation")
 
-    # xyz vector per-atom data: must rotate by R on the component axis
     vector_values = torch.tensor(
         [[[1.0], [0.0], [0.0]], [[0.0], [2.0], [0.0]], [[0.0], [0.0], [3.0]]],
         dtype=dtype,
@@ -269,13 +257,8 @@ def test_transform_system_rotates_geometry_neighbor_lists_and_custom_data(
     assert torch.allclose(new_neighbors, expected, atol=atol)
 
     new_scalar = rotated.get_data("custom::scalar")
-    assert new_scalar.keys == scalar.keys
     assert new_scalar.info() == scalar.info()
-    for block_id in range(len(scalar.keys)):
-        assert torch.allclose(
-            new_scalar.block_by_id(block_id).values,
-            scalar.block_by_id(block_id).values,
-        )
+    assert torch.allclose(new_scalar.block().values, scalar.block().values)
 
     new_vector = rotated.get_data("custom::vector").block().values
     expected_vector = (vector_values.squeeze(-1) @ matrix.T).unsqueeze(-1)
@@ -340,46 +323,67 @@ def test_transform_system_preserves_neighbor_gradients():
     assert torch.allclose(gradient, expected, atol=1e-12)
 
 
-def test_transform_system_rejects_dtype_mismatch():
-    """System positions and transformation matrix must have the same dtype."""
-    system = _make_system([1], dtype=torch.float64)
-    transformation = O3Transformation(
-        torch.eye(3, dtype=torch.float32),
-        max_angular_momentum=0,
-    )
+def test_transformation_validation():
+    """Realistic construction mistakes fail with a clear error."""
+    # negative counts and angular momentum limits
+    with pytest.raises(ValueError, match="max_angular_momentum"):
+        O3Transformation(torch.eye(3, dtype=torch.float64), -1)
+    with pytest.raises(ValueError, match="max_angular_momentum"):
+        random_transformations(
+            0, max_angular_momentum=-1, device=torch.device("cpu"), dtype=torch.float64
+        )
+    with pytest.raises(ValueError, match="n must"):
+        random_transformations(-1, device=torch.device("cpu"), dtype=torch.float64)
 
+    # models only declare float32/float64 capabilities
+    with pytest.raises(ValueError, match="torch.float32 or torch.float64"):
+        random_transformations(0, device=torch.device("cpu"), dtype=torch.float16)
+
+    # matrices must be (3, 3) and orthogonal
+    with pytest.raises(ValueError, match="shape"):
+        O3Transformation(torch.eye(2, dtype=torch.float64), max_angular_momentum=0)
+    matrix = torch.eye(3, dtype=torch.float64)
+    matrix[0, 0] = 2.0
+    with pytest.raises(ValueError, match="not orthogonal"):
+        O3Transformation(matrix, max_angular_momentum=0)
+
+    # Wigner-D requests need a valid ell
+    transformation = O3Transformation(torch.eye(3, dtype=torch.float64), 1)
+    with pytest.raises(ValueError, match="ell must be a non-negative integer"):
+        transformation.wigner_D_matrix(-1)
+
+    # systems must match the transformation dtype/device
+    system = _make_system([1], dtype=torch.float64)
+    transformation = O3Transformation(torch.eye(3, dtype=torch.float32), 0)
     with pytest.raises(ValueError, match="differing from the transformations"):
         transform_system(system, transformation)
 
 
-@pytest.mark.parametrize("device,dtype", ALL_DEVICE_DTYPE)
-def test_random_rotations_are_orthogonal(device, dtype):
-    dtype = getattr(torch, dtype)
-    atol = 1e-5 if dtype == torch.float32 else 1e-10
+def test_random_rotations_are_orthogonal():
+    """Sampling without inversions yields proper rotations, including n=0."""
+    atol = 1e-10
 
     assert (
         random_transformations(
             0,
-            device=torch.device(device),
-            dtype=dtype,
+            device=torch.device("cpu"),
+            dtype=torch.float64,
         )
         == []
     )
 
     transformations = random_transformations(
         20,
-        device=torch.device(device),
-        dtype=dtype,
+        device=torch.device("cpu"),
+        dtype=torch.float64,
     )
 
     assert len(transformations) == 20
-    identity = torch.eye(3, device=device, dtype=dtype)
+    identity = torch.eye(3, dtype=torch.float64)
 
     for transformation in transformations:
         matrix = transformation.matrix
 
-        assert transformation.device == identity.device
-        assert transformation.dtype == dtype
         assert matrix.shape == (3, 3)
         assert torch.allclose(
             matrix @ matrix.T,
@@ -389,284 +393,62 @@ def test_random_rotations_are_orthogonal(device, dtype):
         assert abs(float(torch.det(matrix)) - 1.0) < atol
 
 
-def test_random_transformations_include_inversions_and_are_reproducible():
-    default_generated = random_transformations(
-        100,
-        device="cpu",
-        dtype=torch.float64,
-        include_inversions=True,
-    )
+def test_random_transformations_reproducibility():
+    """Seeded sampling with inversions is reproducible and covers both cosets."""
+    kwargs = {
+        "max_angular_momentum": 1,
+        "device": "cpu",
+        "dtype": torch.float64,
+        "include_inversions": True,
+    }
     first = random_transformations(
-        100,
-        device="cpu",
-        dtype=torch.float64,
-        include_inversions=True,
-        generator=torch.Generator().manual_seed(20260718),
+        20, generator=torch.Generator().manual_seed(20260718), **kwargs
     )
     second = random_transformations(
-        100,
-        device="cpu",
-        dtype=torch.float64,
-        include_inversions=True,
-        generator=torch.Generator().manual_seed(20260718),
+        20, generator=torch.Generator().manual_seed(20260718), **kwargs
     )
 
-    determinants = torch.stack(
-        [torch.det(transformation.matrix) for transformation in default_generated]
-    )
-    assert torch.allclose(
-        determinants.abs(),
-        torch.ones(100, dtype=torch.float64),
-        atol=1e-10,
-    )
+    for a, b in zip(first, second, strict=True):
+        assert torch.equal(a.matrix, b.matrix)
+        assert a.is_improper == b.is_improper
+        assert a.is_improper == bool(torch.det(a.matrix) < 0)
+
+    determinants = torch.stack([torch.det(t.matrix) for t in first])
     assert (determinants > 0).any() and (determinants < 0).any()
-
-    for first_transformation, second_transformation in zip(
-        first,
-        second,
-        strict=True,
-    ):
-        assert torch.equal(
-            first_transformation.matrix,
-            second_transformation.matrix,
-        )
-        expected_is_improper = bool(torch.det(first_transformation.matrix) < 0)
-        assert first_transformation.is_improper == expected_is_improper
-        assert second_transformation.is_improper == expected_is_improper
-
-
-@pytest.mark.parametrize("n", [0, 1])
-@pytest.mark.parametrize(
-    "dtype",
-    [
-        torch.float16,
-        torch.bfloat16,
-        torch.complex64,
-        torch.int64,
-    ],
-)
-def test_random_transformations_rejects_unsupported_dtype(n, dtype):
-    with pytest.raises(ValueError, match="torch.float32 or torch.float64"):
-        random_transformations(
-            n,
-            device=torch.device("cpu"),
-            dtype=dtype,
-        )
-
-
-@pytest.mark.parametrize(
-    ("value", "error"),
-    [
-        (-1, ValueError),
-        (True, TypeError),
-        (1.5, TypeError),
-    ],
-)
-def test_transformation_counts_and_limits_reject_invalid_values(value, error):
-    with pytest.raises(error, match="max_angular_momentum"):
-        O3Transformation(torch.eye(3, dtype=torch.float64), value)
-
-    with pytest.raises(error, match="max_angular_momentum"):
-        random_transformations(
-            0,
-            max_angular_momentum=value,
-            device=torch.device("cpu"),
-            dtype=torch.float64,
-        )
-
-    with pytest.raises(error, match="n must"):
-        random_transformations(
-            value,
-            device=torch.device("cpu"),
-            dtype=torch.float64,
-        )
-
-
-def test_transformation_creation_rejects_invalid_matrix():
-    with pytest.raises(ValueError, match="shape"):
-        O3Transformation(
-            torch.eye(2, dtype=torch.float64),
-            max_angular_momentum=0,
-        )
-
-    matrix = torch.eye(3, dtype=torch.float64)
-    matrix[0, 0] = 2.0
-    with pytest.raises(ValueError, match="not orthogonal"):
-        O3Transformation(
-            matrix,
-            max_angular_momentum=0,
-        )
-
-
-@pytest.mark.parametrize("is_improper", [False, True])
-def test_create_from_internal_matrix_matches_constructor(is_improper):
-    matrix = _rotation_90_degrees_around_z()
-    if is_improper:
-        matrix = -matrix
-
-    expected = O3Transformation(
-        matrix,
-        max_angular_momentum=2,
-    )
-    actual = O3Transformation._create_from_internal_matrix(
-        matrix,
-        max_angular_momentum=2,
-        is_improper=is_improper,
-    )
-
-    torch.testing.assert_close(actual.matrix, expected.matrix)
-    assert actual.dtype == expected.dtype
-    assert actual.device == expected.device
-    assert actual.is_improper == expected.is_improper
-
-    for ell in range(3):
-        torch.testing.assert_close(
-            actual.wigner_D_matrix(ell),
-            expected.wigner_D_matrix(ell),
-        )
 
 
 def test_constructor_copies_input_matrix():
+    """In-place edits of the input matrix do not affect the transformation."""
     expected = torch.eye(3, dtype=torch.float64)
     source = expected.clone()
-    transformation = O3Transformation(
-        source,
-        max_angular_momentum=0,
-    )
+    transformation = O3Transformation(source, max_angular_momentum=0)
 
     source[:] = -expected
     assert torch.equal(transformation.matrix, expected)
     assert transformation.is_improper is False
-    assert torch.equal(
-        transformation.transform_cartesian(expected),
-        expected,
-    )
 
 
-def test_wigner_cache_is_built_only_when_needed():
+def test_o3_parity_factor():
+    """Improper transformations scale spherical values by ``sigma * (-1)**ell``."""
     transformation = O3Transformation(
-        torch.eye(3, dtype=torch.float64),
-        max_angular_momentum=2,
-    )
-    assert transformation._wigner_D_cache is None
-
-    transformation.transform_cartesian(
-        torch.ones((4, 3), dtype=torch.float64),
-    )
-    assert transformation._wigner_D_cache is None
-
-    transformation.wigner_D_matrix(1)
-    cache = transformation._wigner_D_cache
-    assert cache is not None
-
-    transformation.wigner_D_matrix(2)
-    assert transformation._wigner_D_cache is cache
-
-
-@pytest.mark.parametrize(
-    ("ell", "error"),
-    [
-        (-1, ValueError),
-        (True, TypeError),
-        (1.0, TypeError),
-    ],
-)
-def test_wigner_D_matrix_and_transform_spherical_reject_invalid_ell(ell, error):
-    transformation = O3Transformation(torch.eye(3, dtype=torch.float64), 1)
-
-    with pytest.raises(error, match="ell must be a non-negative integer"):
-        transformation.wigner_D_matrix(ell)
-
-    with pytest.raises(error, match="ell must be a non-negative integer"):
-        transformation.transform_spherical(
-            torch.ones((1, 3), dtype=torch.float64),
-            ell=ell,
-            sigma=1,
-        )
-
-
-def test_wigner_D_matrix_and_transform_spherical_reject_ell_above_configured_maximum():
-    transformation = O3Transformation(torch.eye(3, dtype=torch.float64), 0)
-
-    with pytest.raises(ValueError, match="ell=1 exceeds max_angular_momentum=0"):
-        transformation.wigner_D_matrix(1)
-
-    with pytest.raises(ValueError, match="ell=1 exceeds max_angular_momentum=0"):
-        transformation.transform_spherical(
-            torch.ones((1, 3), dtype=torch.float64),
-            ell=1,
-            sigma=1,
-        )
-
-
-@pytest.mark.parametrize(
-    ("matrix", "is_improper"),
-    [
-        (torch.eye(3), False),
-        (-torch.eye(3), True),
-    ],
-)
-@pytest.mark.parametrize("ell", [0, 1])
-@pytest.mark.parametrize("sigma", [1, -1])
-def test_transform_spherical_applies_o3_parity_factor(
-    matrix,
-    is_improper,
-    ell,
-    sigma,
-):
-    matrix = matrix.to(dtype=torch.float64)
-    transformation = O3Transformation(
-        matrix,
-        max_angular_momentum=ell,
-    )
-    values = torch.arange(
-        1,
-        2 * (2 * ell + 1) + 1,
-        dtype=torch.float64,
-    ).reshape(2, 2 * ell + 1)
-
-    parity_factor = sigma * (-1) ** ell if is_improper else 1
-    expected = values * parity_factor
-
-    assert torch.allclose(
-        transformation.transform_spherical(values, ell, sigma),
-        expected,
-        rtol=0.0,
-        atol=1e-12,
+        -torch.eye(3, dtype=torch.float64),
+        max_angular_momentum=1,
     )
 
-
-@pytest.mark.parametrize(
-    "matrix",
-    [
-        torch.eye(3),
-        -torch.eye(3),
-    ],
-)
-@pytest.mark.parametrize(
-    ("sigma", "error"),
-    [
-        (2, ValueError),
-        (-2, ValueError),
-        (1.0, TypeError),
-        (True, TypeError),
-    ],
-)
-def test_transform_spherical_rejects_invalid_sigma(matrix, sigma, error):
-    transformation = O3Transformation(
-        matrix.to(dtype=torch.float64),
-        max_angular_momentum=0,
-    )
-
-    with pytest.raises(
-        error,
-        match=r"sigma must be either -1 or \+1",
-    ):
-        transformation.transform_spherical(
-            torch.ones((1, 1), dtype=torch.float64),
-            ell=0,
-            sigma=sigma,
-        )
+    for ell in (0, 1):
+        values = torch.arange(
+            1,
+            2 * (2 * ell + 1) + 1,
+            dtype=torch.float64,
+        ).reshape(2, 2 * ell + 1)
+        for sigma in (1, -1):
+            expected = values * (sigma * (-1) ** ell)
+            assert torch.allclose(
+                transformation.transform_spherical(values, ell, sigma),
+                expected,
+                rtol=0.0,
+                atol=1e-12,
+            )
 
 
 def _axis_angle(axis, theta):
@@ -712,47 +494,14 @@ def test_complex_to_real_spherical_harmonics_transform_is_unitary():
         )
 
 
-@pytest.mark.parametrize("device,dtype", ALL_DEVICE_DTYPE)
-def test_build_wigner_D_cache_returns_all_ranks_on_requested_dtype_and_device(
-    device,
-    dtype,
-):
-    """Return every rank on the requested dtype and device.
+def test_wigner_D_depends_only_on_proper_part():
+    """The inversion enters as a separate parity factor, not in the Wigner-D."""
+    matrix = torch.tensor(_axis_angle([1.0, 2.0, 3.0], 0.7), dtype=torch.float64)
+    proper = O3Transformation(matrix, max_angular_momentum=3)
+    improper = O3Transformation(-matrix, max_angular_momentum=3)
 
-    A proper rotation and its improper counterpart must produce equal caches.
-    """
-    device = torch.device(device)
-    dtype = getattr(torch, dtype)
-    ell_max = 3
-    proper = torch.tensor(
-        _axis_angle([1.0, 2.0, 3.0], 0.7),
-        device=device,
-        dtype=dtype,
-    )
-
-    proper_cache = build_wigner_D_cache(
-        ell_max,
-        proper,
-        device=device,
-        dtype=dtype,
-    )
-    improper_cache = build_wigner_D_cache(
-        ell_max,
-        -proper,
-        device=device,
-        dtype=dtype,
-    )
-
-    expected_ranks = set(range(ell_max + 1))
-    for cache in (proper_cache, improper_cache):
-        assert set(cache) == expected_ranks
-        for ell, matrix in cache.items():
-            assert matrix.shape == (2 * ell + 1, 2 * ell + 1)
-            assert matrix.dtype == dtype
-            assert matrix.device == proper.device
-
-    for ell in range(ell_max + 1):
-        assert torch.equal(proper_cache[ell], improper_cache[ell])
+    for ell in range(4):
+        assert torch.equal(proper.wigner_D_matrix(ell), improper.wigner_D_matrix(ell))
 
 
 # Change of basis from Cartesian (x, y, z) to real ell=1 spherical harmonics, ordered
@@ -790,114 +539,95 @@ TRANSFORMATIONS = [
 
 
 @pytest.mark.parametrize("matrix", TRANSFORMATIONS)
-def test_general_rotation_L1_wigner_matches_cartesian(matrix):
-    """For ell=1, Wigner-D matches the Cartesian basis-change formula."""
+def test_L1_wigner_matches_cartesian(matrix):
+    """For ell=1, Wigner-D is the Cartesian rotation in the (y, z, x) basis."""
     proper = matrix if torch.det(matrix) > 0 else -matrix
     transformation = O3Transformation(matrix, max_angular_momentum=1)
 
-    expected = CARTESIAN_TO_SPHERICAL_L1 @ proper @ CARTESIAN_TO_SPHERICAL_L1.T
+    C = CARTESIAN_TO_SPHERICAL_L1
+    expected = C @ proper @ C.T
     assert torch.allclose(transformation.wigner_D_matrix(1), expected, atol=1e-12)
+
+    # the spherical action of an ell=1, sigma=+1 vector equals the Cartesian
+    # action, inversion included
+    vectors = torch.tensor(
+        [[1.0, 0.0, 0.0], [0.2, -1.3, 0.7], [-0.5, 0.1, 2.0]],
+        dtype=torch.float64,
+    )
+    torch.testing.assert_close(
+        transformation.transform_spherical(vectors @ C.T, ell=1, sigma=1),
+        transformation.transform_cartesian(vectors) @ C.T,
+        rtol=0.0,
+        atol=1e-12,
+    )
+
+
+def _real_solid_harmonics_l2(v):
+    """Real ell=2 solid harmonics of a Cartesian vector, ordered m = -2..2, in
+    the same real-spherical-harmonics convention as the ell=1 (y, z, x) map."""
+    x, y, z = v
+    r2 = x * x + y * y + z * z
+    s3 = np.sqrt(3.0)
+    return torch.stack(
+        [
+            s3 * x * y,
+            s3 * y * z,
+            0.5 * (3.0 * z * z - r2),
+            s3 * x * z,
+            0.5 * s3 * (x * x - y * y),
+        ]
+    )
+
+
+def test_l2_wigner_D_equivariance():
+    """D2 @ Y2(v) == Y2(R @ v): independent reference above ell=1."""
+    matrix = torch.tensor(_axis_angle([1.0, 2.0, 3.0], 0.7), dtype=torch.float64)
+    transformation = O3Transformation(matrix, max_angular_momentum=2)
+    D2 = transformation.wigner_D_matrix(2)
+
+    for v in torch.tensor(
+        [[1.0, 0.0, 0.0], [0.2, -1.3, 0.7], [-0.5, 0.1, 2.0]],
+        dtype=torch.float64,
+    ):
+        torch.testing.assert_close(
+            D2 @ _real_solid_harmonics_l2(v),
+            _real_solid_harmonics_l2(matrix @ v),
+            rtol=0.0,
+            atol=1e-12,
+        )
 
 
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
-@pytest.mark.parametrize("is_improper", [False, True])
-@pytest.mark.parametrize(
-    "cos_beta",
-    [
-        pytest.param(1.0, id="beta-zero"),
-        pytest.param(-1.0, id="beta-pi"),
-    ],
-)
-def test_wigner_D_matrix_handles_roundoff_at_both_euler_poles(
-    cos_beta,
-    is_improper,
-    dtype,
-):
+def test_wigner_D_roundoff_at_euler_poles(dtype):
     """One-ULP matrix roundoff must preserve rotations at beta=0 and beta=pi."""
     alpha = 0.73
     cos_alpha = np.cos(alpha)
     sin_alpha = np.sin(alpha)
-    proper = torch.tensor(
-        [
-            [cos_beta * cos_alpha, -sin_alpha, 0.0],
-            [cos_beta * sin_alpha, cos_alpha, 0.0],
-            [0.0, 0.0, cos_beta],
-        ],
-        dtype=dtype,
-    )
-
-    matrix = proper.clone()
-    matrix[2, 2] = torch.nextafter(matrix[2, 2], torch.zeros_like(matrix[2, 2]))
-    if is_improper:
-        matrix = -matrix
-
-    transformation = O3Transformation(matrix, max_angular_momentum=1)
     basis = CARTESIAN_TO_SPHERICAL_L1.to(dtype=dtype)
-    expected = basis @ proper @ basis.T
-    actual = transformation.wigner_D_matrix(1)
-
     atol = 1e-6 if dtype == torch.float32 else 1e-14
-    torch.testing.assert_close(actual, expected, rtol=0.0, atol=atol)
+
+    for cos_beta in (1.0, -1.0):
+        proper = torch.tensor(
+            [
+                [cos_beta * cos_alpha, -sin_alpha, 0.0],
+                [cos_beta * sin_alpha, cos_alpha, 0.0],
+                [0.0, 0.0, cos_beta],
+            ],
+            dtype=dtype,
+        )
+
+        matrix = proper.clone()
+        matrix[2, 2] = torch.nextafter(matrix[2, 2], torch.zeros_like(matrix[2, 2]))
+
+        transformation = O3Transformation(matrix, max_angular_momentum=1)
+        expected = basis @ proper @ basis.T
+        actual = transformation.wigner_D_matrix(1)
+
+        torch.testing.assert_close(actual, expected, rtol=0.0, atol=atol)
 
 
-@pytest.mark.parametrize("matrix", TRANSFORMATIONS)
-@pytest.mark.parametrize("device,dtype", ALL_DEVICE_DTYPE)
-def test_spherical_rotation_matches_cartesian(matrix, device, dtype):
-    dtype = getattr(torch, dtype)
-    atol = 1e-6 if dtype == torch.float32 else 1e-12
-
-    matrix = matrix.to(device=device, dtype=dtype)
-
-    system = _make_system([1, 1], device=device, dtype=dtype)
-
-    cartesian_vectors = torch.randn(2, 3, 1, dtype=dtype, device=device)
-
-    samples = Labels(
-        ["system", "atom"],
-        torch.tensor([[0, 0], [0, 1]], device=device),
-    )
-    cartesian = _single_block_tensor_map(
-        values=cartesian_vectors,
-        samples=samples,
-        components=[Labels(["xyz"], torch.arange(3, device=device).reshape(-1, 1))],
-    )
-    # spherical encoding: w = C @ v along the component axis
-    cart_to_sph = CARTESIAN_TO_SPHERICAL_L1.to(device=device, dtype=dtype)
-    spherical_values = torch.einsum(
-        "Aa,iap->iAp", cart_to_sph, cartesian_vectors
-    ).requires_grad_()
-    spherical = _single_block_tensor_map(
-        keys=Labels(
-            ["o3_lambda", "o3_sigma"],
-            torch.tensor([[1, 1]], device=device),
-        ),
-        values=spherical_values,
-        samples=samples,
-        components=[
-            Labels(["o3_mu"], torch.arange(-1, 2, device=device).reshape(-1, 1))
-        ],
-    )
-
-    transformation = O3Transformation(matrix, max_angular_momentum=1)
-
-    cartesian_transformed = transform_tensor(cartesian, [system], [transformation])
-    spherical_transformed = transform_tensor(spherical, [system], [transformation])
-
-    expected_spherical = torch.einsum(
-        "Aa,iap->iAp", cart_to_sph, cartesian_transformed.block().values
-    )
-
-    assert torch.allclose(
-        spherical_transformed.block().values, expected_spherical, atol=atol
-    )
-    gradient = torch.autograd.grad(
-        spherical_transformed.block().values.square().sum(), spherical_values
-    )[0]
-    assert torch.allclose(gradient, 2.0 * spherical_values, atol=atol)
-
-
-def test_transform_tensor_routes_gradient_rows_by_parent_system():
-    """Gradients follow parent systems while metadata and inputs are preserved."""
+def test_gradient_rows_follow_parent_system():
+    """Gradient rows use their parent sample's transformation; inputs unchanged."""
     systems = [
         _make_system([1, 1]),
         _make_system([8, 8, 8]),
@@ -964,7 +694,6 @@ def test_transform_tensor_routes_gradient_rows_by_parent_system():
 
     assert torch.equal(transformed_block.values, values_before)
 
-    # Position-gradient samples 0 and 2 use R_92; samples 1, 3, and 4 use R_38.
     expected_pos = pos_grad_before.clone()
     expected_pos[0] = R_92 @ pos_grad_before[0]
     expected_pos[1] = R_38 @ pos_grad_before[1]
@@ -975,7 +704,6 @@ def test_transform_tensor_routes_gradient_rows_by_parent_system():
     transformed_pos = transformed_block.gradient("positions").values
     assert torch.allclose(transformed_pos, expected_pos)
 
-    # Strain-gradient samples 0 and 1 use R_92 and R_38, respectively.
     expected_strain = strain_grad_before.clone()
     expected_strain[0] = torch.einsum(
         "Aa,abp,Bb->ABp", R_92, strain_grad_before[0], R_92
@@ -993,17 +721,6 @@ def test_transform_tensor_routes_gradient_rows_by_parent_system():
     assert torch.equal(input_block.gradient("positions").values, pos_grad_before)
     assert torch.equal(input_block.gradient("strain").values, strain_grad_before)
 
-    assert transformed_block.samples == input_block.samples
-    assert transformed_block.components == input_block.components
-    assert transformed_block.properties == input_block.properties
-    assert transformed_block.gradients_list() == input_block.gradients_list()
-    for gradient_name in input_block.gradients_list():
-        transformed_gradient = transformed_block.gradient(gradient_name)
-        input_gradient = input_block.gradient(gradient_name)
-        assert transformed_gradient.samples == input_gradient.samples
-        assert transformed_gradient.components == input_gradient.components
-        assert transformed_gradient.properties == input_gradient.properties
-
     autograd_gradient = torch.autograd.grad(
         transformed_pos.square().sum(),
         pos_grad,
@@ -1016,291 +733,122 @@ def test_transform_tensor_routes_gradient_rows_by_parent_system():
     )
 
 
-def test_unsupported_component_axis_raises():
-    """Unknown component-axis names fail loudly."""
+def test_component_metadata_validation():
+    """Hand-built blocks with wrong component metadata fail with clear errors."""
     systems = [_make_system([1])]
+    transformations = [O3Transformation(torch.eye(3, dtype=torch.float64), 1)]
+
+    # unknown component axis name
     tensor = _single_block_tensor_map(
         values=torch.zeros(1, 3, 1, dtype=torch.float64),
         samples=Labels(["system"], torch.tensor([[0]])),
         components=[Labels(["direction"], torch.arange(3).reshape(-1, 1))],
     )
+    with pytest.raises(ValueError, match="neither a Cartesian"):
+        transform_tensor(tensor, systems, transformations)
 
-    message = (
-        "Found a component axis 'direction', which is neither a Cartesian "
-        "('xyz'/'xyz_1'/'xyz_2'/...) nor spherical ('o3_mu'/'o3_mu_1'/...) axis; "
-        "it can not be transformed."
-    )
-    with pytest.raises(ValueError, match=re.escape(message)):
-        transform_tensor(
-            tensor, systems, [O3Transformation(torch.eye(3, dtype=torch.float64), 1)]
-        )
-
-
-def test_transform_tensor_rejects_invalid_spherical_sigma():
-    """TensorMap transformation rejects invalid spherical parity metadata."""
+    # o3_sigma outside {-1, +1}
     tensor = _single_block_tensor_map(
-        keys=Labels(
-            ["o3_lambda", "o3_sigma"],
-            torch.tensor([[0, 2]]),
-        ),
+        keys=Labels(["o3_lambda", "o3_sigma"], torch.tensor([[0, 2]])),
         values=torch.ones((1, 1, 1), dtype=torch.float64),
         samples=Labels(["system"], torch.tensor([[0]])),
         components=[Labels(["o3_mu"], torch.tensor([[0]]))],
     )
+    with pytest.raises(ValueError, match=re.escape("sigma must be either -1 or +1")):
+        transform_tensor(tensor, systems, transformations)
 
-    with pytest.raises(
-        ValueError,
-        match=re.escape("sigma must be either -1 or +1"),
-    ):
-        transform_tensor(
-            tensor,
-            [_make_system([1])],
-            [
-                O3Transformation(
-                    torch.eye(3, dtype=torch.float64),
-                    max_angular_momentum=0,
-                )
-            ],
-        )
-
-
-@pytest.mark.parametrize(
-    ("location", "component", "keys", "message"),
-    [
-        pytest.param(
-            "values",
-            Labels(["xyz"], torch.tensor([[2], [0], [1]])),
-            Labels(["_"], torch.tensor([[0]])),
-            "Cartesian component axis 'xyz' must use labels",
-            id="value-cartesian-label-order",
-        ),
-        pytest.param(
-            "values",
-            Labels(["o3_mu"], torch.tensor([[1], [-1], [0]])),
-            Labels(
-                ["o3_lambda", "o3_sigma"],
-                torch.tensor([[1, 1]]),
-            ),
-            "Spherical component axis 'o3_mu' for ell=1 must use labels",
-            id="value-spherical-label-order",
-        ),
-        pytest.param(
-            "gradient",
-            Labels(["xyz"], torch.tensor([[2], [0], [1]])),
-            Labels(["_"], torch.tensor([[0]])),
-            "Cartesian component axis 'xyz' must use labels",
-            id="gradient-cartesian-label-order",
-        ),
-        pytest.param(
-            "values",
-            Labels(["o3_mu"], torch.tensor([[0]])),
-            Labels(
-                ["o3_lambda", "o3_sigma"],
-                torch.tensor([[-1, 1]]),
-            ),
-            "ell must be a non-negative integer",
-            id="negative-spherical-angular-momentum",
-        ),
-    ],
-)
-def test_transform_tensor_validates_empty_component_metadata(
-    location,
-    component,
-    keys,
-    message,
-):
-    """Empty values and gradients still require valid component metadata."""
-    if location == "values":
-        block = TensorBlock(
-            values=torch.empty(
-                (0, len(component), 1),
-                dtype=torch.float64,
-            ),
-            samples=Labels(
-                ["system"],
-                torch.empty((0, 1), dtype=torch.int64),
-            ),
-            components=[component],
-            properties=Labels(["p"], torch.tensor([[0]])),
-        )
-    else:
-        block = TensorBlock(
-            values=torch.ones((1, 1), dtype=torch.float64),
-            samples=Labels(["system"], torch.tensor([[0]])),
-            components=[],
-            properties=Labels(["p"], torch.tensor([[0]])),
-        )
-        block.add_gradient(
-            "positions",
-            TensorBlock(
-                values=torch.empty(
-                    (0, len(component), 1),
-                    dtype=torch.float64,
-                ),
-                samples=Labels(
-                    ["sample"],
-                    torch.empty((0, 1), dtype=torch.int64),
-                ),
-                components=[component],
-                properties=block.properties,
-            ),
-        )
-
-    tensor = TensorMap(keys, [block])
-
-    with pytest.raises(ValueError, match=re.escape(message)):
-        transform_tensor(
-            tensor,
-            [_make_system([1])],
-            [
-                O3Transformation(
-                    torch.eye(3, dtype=torch.float64),
-                    max_angular_momentum=1,
-                )
-            ],
-        )
-
-
-@pytest.mark.parametrize("sigma_9", [1, -1])
-def test_transform_tensor_combines_spherical_axis_parities(sigma_9):
-    """Improper parity factors multiply across spherical component axes."""
-    values = torch.arange(
-        1,
-        10,
-        dtype=torch.float64,
-    ).reshape(1, 3, 3, 1)
+    # misordered Cartesian labels
     tensor = _single_block_tensor_map(
-        keys=Labels(
-            [
-                "o3_lambda_1",
-                "o3_lambda_9",
-                "o3_sigma_1",
-                "o3_sigma_9",
-            ],
-            torch.tensor([[1, 1, 1, sigma_9]]),
-        ),
-        values=values,
+        values=torch.ones((1, 3, 1), dtype=torch.float64),
         samples=Labels(["system"], torch.tensor([[0]])),
-        components=[
-            Labels(
-                ["o3_mu_1"],
-                torch.arange(-1, 2).reshape(-1, 1),
-            ),
-            Labels(
-                ["o3_mu_9"],
-                torch.arange(-1, 2).reshape(-1, 1),
-            ),
-        ],
+        components=[Labels(["xyz"], torch.tensor([[2], [0], [1]]))],
     )
+    with pytest.raises(ValueError, match="Cartesian component axis 'xyz' must use"):
+        transform_tensor(tensor, systems, transformations)
 
-    transformed = transform_tensor(
-        tensor,
-        [_make_system([1])],
-        [
-            O3Transformation(
-                -torch.eye(3, dtype=torch.float64),
-                max_angular_momentum=1,
-            )
-        ],
+    # misordered spherical labels on an empty block: the validation is
+    # metadata-driven, not row-driven
+    block = TensorBlock(
+        values=torch.empty((0, 3, 1), dtype=torch.float64),
+        samples=Labels(["system"], torch.empty((0, 1), dtype=torch.int64)),
+        components=[Labels(["o3_mu"], torch.tensor([[1], [-1], [0]]))],
+        properties=Labels(["p"], torch.tensor([[0]])),
     )
+    tensor = TensorMap(
+        Labels(["o3_lambda", "o3_sigma"], torch.tensor([[1, 1]])),
+        [block],
+    )
+    with pytest.raises(ValueError, match="Spherical component axis 'o3_mu' for ell=1"):
+        transform_tensor(tensor, systems, transformations)
 
-    assert torch.allclose(
-        transformed.block().values,
-        sigma_9 * values,
+
+def test_insufficient_max_angular_momentum():
+    """The default ``max_angular_momentum=0`` fails clearly on spherical data."""
+    tensor = _single_block_tensor_map(
+        keys=Labels(["o3_lambda", "o3_sigma"], torch.tensor([[1, 1]])),
+        values=torch.tensor([[[1.0], [2.0], [3.0]]], dtype=torch.float64),
+        samples=Labels(["system"], torch.tensor([[0]])),
+        components=[Labels(["o3_mu"], torch.arange(-1, 2).reshape(-1, 1))],
+    )
+    systems = [_make_system([1])]
+
+    transformations = random_transformations(
+        1,
+        device=torch.device("cpu"),
+        dtype=torch.float64,
+    )
+    with pytest.raises(ValueError, match="ell=1 exceeds max_angular_momentum=0"):
+        transform_tensor(tensor, systems, transformations)
+
+    transformations = random_transformations(
+        1,
+        max_angular_momentum=1,
+        device=torch.device("cpu"),
+        dtype=torch.float64,
+    )
+    transformed = transform_tensor(tensor, systems, transformations)
+    # a rotation (with sigma parity +-1) preserves the norm of ell=1 values
+    torch.testing.assert_close(
+        transformed.block().values.norm(),
+        tensor.block().values.norm(),
         rtol=0.0,
         atol=1e-12,
     )
 
 
-def test_transform_tensor_enforces_ten_component_axis_limit():
-    """Ten component axes are transformed and an eleventh is rejected."""
-    # The first spherical axis is unsuffixed by convention; the nine axes below
-    # use `o3_mu` through `o3_mu_8`, followed by Cartesian `xyz_9`.
-    spherical_suffixes = [""] + [f"_{index}" for index in range(1, 9)]
-    components = [
-        Labels([f"o3_mu{suffix}"], torch.tensor([[0]])) for suffix in spherical_suffixes
-    ]
-    components.append(Labels(["xyz_9"], torch.arange(3).reshape(-1, 1)))
+def test_transform_tensor_combines_spherical_axis_parities():
+    """Improper parity factors multiply across spherical component axes."""
+    values = torch.arange(1, 10, dtype=torch.float64).reshape(1, 3, 3, 1)
+    for sigma_9 in (1, -1):
+        tensor = _single_block_tensor_map(
+            keys=Labels(
+                ["o3_lambda_1", "o3_lambda_9", "o3_sigma_1", "o3_sigma_9"],
+                torch.tensor([[1, 1, 1, sigma_9]]),
+            ),
+            values=values,
+            samples=Labels(["system"], torch.tensor([[0]])),
+            components=[
+                Labels(["o3_mu_1"], torch.arange(-1, 2).reshape(-1, 1)),
+                Labels(["o3_mu_9"], torch.arange(-1, 2).reshape(-1, 1)),
+            ],
+        )
 
-    key_names = [f"o3_lambda{suffix}" for suffix in spherical_suffixes] + [
-        f"o3_sigma{suffix}" for suffix in spherical_suffixes
-    ]
-    values = torch.tensor(
-        [1.0, 2.0, 3.0],
-        dtype=torch.float64,
-    ).reshape([1] + [1] * 9 + [3, 1])
-    tensor = _single_block_tensor_map(
-        keys=Labels(key_names, torch.tensor([[0] * 9 + [1] * 9])),
-        values=values,
-        samples=Labels(["system"], torch.tensor([[0]])),
-        components=components,
-    )
+        transformed = transform_tensor(
+            tensor,
+            [_make_system([1])],
+            [O3Transformation(-torch.eye(3, dtype=torch.float64), 1)],
+        )
 
-    system = _make_system([1])
-    transformation = O3Transformation(
-        -torch.eye(3, dtype=torch.float64),
-        max_angular_momentum=0,
-    )
-    transformed = transform_tensor(
-        tensor,
-        [system],
-        [transformation],
-    )
-    assert torch.equal(transformed.block().values, -values)
-
-    too_many_components = components + [Labels(["xyz"], torch.arange(3).reshape(-1, 1))]
-    too_many_tensor = _single_block_tensor_map(
-        keys=tensor.keys,
-        values=torch.zeros(
-            [1] + [1] * 9 + [3, 3, 1],
-            dtype=torch.float64,
-        ),
-        samples=tensor.block().samples,
-        components=too_many_components,
-        properties=tensor.block().properties,
-    )
-
-    with pytest.raises(
-        ValueError,
-        match="can not transform a tensor with 11 component axes; at most 10",
-    ):
-        transform_tensor(
-            too_many_tensor,
-            [system],
-            [transformation],
+        assert torch.allclose(
+            transformed.block().values,
+            sigma_9 * values,
+            rtol=0.0,
+            atol=1e-12,
         )
 
 
-def _system_ids_inputs():
-    systems = [_make_system([1]), _make_system([8])]
-    transformations = [
-        O3Transformation(torch.eye(3, dtype=torch.float64), 0),
-        O3Transformation(torch.eye(3, dtype=torch.float64), 0),
-    ]
-    return systems, transformations
-
-
-@pytest.mark.parametrize(
-    ("system_ids", "sample_system_ids"),
-    [
-        pytest.param(None, [0, 1], id="default"),
-        pytest.param([92, 38], [92, 38], id="python-list"),
-        pytest.param(
-            torch.tensor([92, -7], dtype=torch.int32),
-            [92, -7],
-            id="integer-tensor",
-        ),
-    ],
-)
-@pytest.mark.parametrize("entry_point", ["block", "tensor"])
-def test_transform_block_and_tensor_route_rows_by_system_id(
-    entry_point,
-    system_ids,
-    sample_system_ids,
-):
-    """Default, list, and tensor IDs route rows through ``transform_block`` and
-    ``transform_tensor``.
-    """
+def test_rows_route_by_system_id():
+    """Default, list, and tensor IDs route each row to its own transformation."""
     systems = [_make_system([1]), _make_system([8])]
     transformations = [
         O3Transformation(
@@ -1319,45 +867,7 @@ def test_transform_block_and_tensor_route_rows_by_system_id(
             max_angular_momentum=0,
         ),
     ]
-    block = TensorBlock(
-        values=torch.tensor(
-            [
-                [[1.0], [0.0], [0.0]],
-                [[0.0], [2.0], [0.0]],
-            ],
-            dtype=torch.float64,
-        ),
-        samples=Labels(
-            ["system", "atom"],
-            torch.tensor(
-                [
-                    [sample_system_ids[0], 0],
-                    [sample_system_ids[1], 0],
-                ]
-            ),
-        ),
-        components=[Labels(["xyz"], torch.arange(3).reshape(-1, 1))],
-        properties=Labels(["p"], torch.tensor([[0]])),
-    )
-
-    kwargs = {} if system_ids is None else {"system_ids": system_ids}
     keys = Labels(["_"], torch.tensor([[0]]))
-    if entry_point == "block":
-        transformed = transform_block(
-            keys[0],
-            block,
-            systems,
-            transformations,
-            **kwargs,
-        )
-    else:
-        transformed = transform_tensor(
-            TensorMap(keys, [block]),
-            systems,
-            transformations,
-            **kwargs,
-        ).block()
-
     expected = torch.tensor(
         [
             [[-1.0], [0.0], [0.0]],
@@ -1365,145 +875,135 @@ def test_transform_block_and_tensor_route_rows_by_system_id(
         ],
         dtype=torch.float64,
     )
-    assert torch.equal(transformed.values, expected)
 
+    def make_block(sample_system_ids):
+        # TensorMap takes ownership of its blocks, so each call needs a new one
+        return TensorBlock(
+            values=torch.tensor(
+                [
+                    [[1.0], [0.0], [0.0]],
+                    [[0.0], [2.0], [0.0]],
+                ],
+                dtype=torch.float64,
+            ),
+            samples=Labels(
+                ["system", "atom"],
+                torch.tensor(
+                    [
+                        [sample_system_ids[0], 0],
+                        [sample_system_ids[1], 0],
+                    ]
+                ),
+            ),
+            components=[Labels(["xyz"], torch.arange(3).reshape(-1, 1))],
+            properties=Labels(["p"], torch.tensor([[0]])),
+        )
 
-@pytest.mark.parametrize(
-    ("system_ids", "message"),
-    [
-        pytest.param([92], "exactly one entry per system", id="wrong-count"),
-        pytest.param([92, 92], "one distinct entry per system", id="duplicate"),
-        pytest.param(
-            torch.tensor([[92, -7]]),
-            "system_ids must be one-dimensional",
-            id="two-dimensional-tensor",
-        ),
-        pytest.param(
-            torch.tensor([92.0, -7.0]),
-            "system_ids must contain integers",
-            id="floating-point-tensor",
-        ),
-        pytest.param(
-            [92.0, -7.0],
-            "system_ids must contain integers",
-            id="floating-point-list",
-        ),
-        pytest.param(
-            [True, False],
-            "system_ids must contain integers",
-            id="boolean-list",
-        ),
-    ],
-)
-def test_validate_system_ids_rejects_invalid_ids(system_ids, message):
-    """Reject ambiguous or structurally invalid system identifiers."""
-    systems, transformations = _system_ids_inputs()
-
-    with pytest.raises(ValueError, match=message):
-        _validate_system_ids(
+    for system_ids, sample_system_ids in [
+        (None, [0, 1]),
+        ([92, 38], [92, 38]),
+        (torch.tensor([92, -7], dtype=torch.int32), [92, -7]),
+    ]:
+        kwargs = {} if system_ids is None else {"system_ids": system_ids}
+        transformed = transform_tensor(
+            TensorMap(keys, [make_block(sample_system_ids)]),
             systems,
             transformations,
-            system_ids,
-            expected_device=torch.device("cpu"),
-        )
+            **kwargs,
+        ).block()
+        assert torch.equal(transformed.values, expected)
+
+    # the public transform_block entry point agrees
+    transformed_block = transform_block(
+        keys[0],
+        make_block([0, 1]),
+        systems,
+        transformations,
+    )
+    assert torch.equal(transformed_block.values, expected)
 
 
-def test_validate_system_ids_requires_one_transformation_per_system():
-    """Each system must have exactly one transformation."""
-    systems, transformations = _system_ids_inputs()
+def _scalar_two_system_tensor(device="cpu"):
+    """A minimal two-row scalar TensorMap with ``"system"`` labels 92 and 38."""
+    return _single_block_tensor_map(
+        values=torch.zeros((2, 1), dtype=torch.float64, device=device),
+        samples=Labels(["system"], torch.tensor([[92], [38]], device=device)),
+        components=[],
+    )
 
+
+def test_system_ids_validation():
+    """Bad system assignments fail up front instead of misrouting rows."""
+    systems = [_make_system([1]), _make_system([8])]
+    transformations = [
+        O3Transformation(torch.eye(3, dtype=torch.float64), 0),
+        O3Transformation(torch.eye(3, dtype=torch.float64), 0),
+    ]
+
+    # one transformation per system, one distinct id per system
     with pytest.raises(ValueError, match="Expected one transformation per system"):
-        _validate_system_ids(
-            systems,
-            transformations[:1],
-            [92, -7],
-            expected_device=torch.device("cpu"),
+        transform_tensor(
+            _scalar_two_system_tensor(), systems, transformations[:1], [92, -7]
+        )
+    with pytest.raises(ValueError, match="exactly one entry per system"):
+        transform_tensor(_scalar_two_system_tensor(), systems, transformations, [92])
+    with pytest.raises(ValueError, match="one distinct entry per system"):
+        transform_tensor(
+            _scalar_two_system_tensor(), systems, transformations, [92, 92]
         )
 
-
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
-def test_validate_system_ids_checks_device_only_when_defined():
-    """Reject device mismatches, while allowing IDs when no device is specified."""
-    systems, transformations = _system_ids_inputs()
-
-    with pytest.raises(
-        ValueError,
-        match="system_ids are on device cpu, but the values to transform are on device",
-    ):
-        _validate_system_ids(
+    # ids must live with the values ("meta" needs no accelerator hardware)
+    with pytest.raises(ValueError, match="system_ids are on device cpu"):
+        transform_tensor(
+            _scalar_two_system_tensor(device="meta"),
             systems,
             transformations,
             torch.tensor([92, -7]),
-            expected_device=torch.device("cuda"),
         )
 
-    empty_cuda_ids = torch.empty(0, dtype=torch.long, device="cuda")
-    validated = _validate_system_ids(
-        [],
-        [],
-        empty_cuda_ids,
-        expected_device=None,
+    # every "system" label present in a block must appear in system_ids
+    with pytest.raises(ValueError, match="that are not in system_ids"):
+        transform_tensor(
+            _scalar_two_system_tensor(), systems, transformations, [92, 99]
+        )
+
+    # with multiple systems, each row must identify its system
+    no_system_column = _single_block_tensor_map(
+        values=torch.zeros((1, 1), dtype=torch.float64),
+        samples=Labels(["atom"], torch.tensor([[0]])),
+        components=[],
     )
-    assert validated.device == empty_cuda_ids.device
+    with pytest.raises(ValueError, match="to include a 'system' dimension"):
+        transform_tensor(no_system_column, systems, transformations)
 
-
-@pytest.mark.parametrize("entry_point", ["block", "tensor"])
-@pytest.mark.parametrize(
-    ("dtype", "device"),
-    [
-        pytest.param(torch.float32, torch.device("cpu"), id="dtype"),
-        pytest.param(
-            torch.float64,
-            torch.device("cuda"),
-            marks=pytest.mark.skipif(
-                not torch.cuda.is_available(),
-                reason="CUDA is not available",
-            ),
-            id="device",
-        ),
-    ],
-)
-def test_transform_block_and_tensor_reject_mismatched_transformation_with_no_rows(
-    entry_point,
-    dtype,
-    device,
-):
-    """Every transformation must match the values even when it has no rows."""
+    # a transformation with no assigned rows is still validated: a silent
+    # mismatch would only surface once such rows appear in another batch
     block = TensorBlock(
         values=torch.ones((1, 1), dtype=torch.float64),
         samples=Labels(["system"], torch.tensor([[92]])),
         components=[],
         properties=Labels(["p"], torch.tensor([[0]])),
     )
-    systems, transformations = _system_ids_inputs()
-    transformations[1] = O3Transformation(
-        torch.eye(3, dtype=dtype, device=device),
-        max_angular_momentum=0,
+    transformations[1] = O3Transformation(torch.eye(3, dtype=torch.float32), 0)
+    with pytest.raises(ValueError, match="Transformation at index 1 has dtype/device"):
+        transform_tensor(
+            TensorMap(Labels(["_"], torch.tensor([[0]])), [block]),
+            systems,
+            transformations,
+            system_ids=[92, 38],
+        )
+
+
+def test_transform_empty_inputs_are_no_ops():
+    """Empty blocks, empty TensorMaps, and empty system lists pass through."""
+    non_empty = _single_block_tensor_map(
+        values=torch.tensor([[1.0], [2.0]], dtype=torch.float64),
+        samples=Labels(["system"], torch.tensor([[0], [1]])),
+        components=[],
     )
+    passthrough = transform_tensor(non_empty, [], [])
+    assert torch.equal(passthrough.block().values, non_empty.block().values)
 
-    with pytest.raises(
-        ValueError,
-        match="Transformation at index 1 has dtype/device",
-    ):
-        if entry_point == "block":
-            transform_block(
-                Labels(["_"], torch.tensor([[0]]))[0],
-                block,
-                systems,
-                transformations,
-                system_ids=[92, 38],
-            )
-        else:
-            transform_tensor(
-                TensorMap(Labels(["_"], torch.tensor([[0]])), [block]),
-                systems,
-                transformations,
-                system_ids=[92, 38],
-            )
-
-
-def test_transform_block_leaves_empty_block_unchanged_without_systems():
-    """An empty block remains unchanged when no transformations are requested."""
     block = TensorBlock(
         values=torch.empty((0, 1), dtype=torch.float64),
         samples=Labels(
@@ -1523,12 +1023,7 @@ def test_transform_block_leaves_empty_block_unchanged_without_systems():
 
     assert torch.equal(transformed.values, block.values)
     assert transformed.samples == block.samples
-    assert transformed.components == block.components
-    assert transformed.properties == block.properties
 
-
-def test_transform_tensor_preserves_empty_map_information():
-    """An empty TensorMap retains its information without imposing a values dtype."""
     empty = TensorMap(
         Labels(
             ["_"],
@@ -1536,8 +1031,9 @@ def test_transform_tensor_preserves_empty_map_information():
         ),
         [],
     )
-    empty.set_info("unit", "eV")
-    transformed = transform_tensor(
+    # the mixed transformation dtypes check that no values dtype is imposed
+    # when there is nothing to transform
+    transformed_map = transform_tensor(
         empty,
         [_make_system([1]), _make_system([8])],
         [
@@ -1552,77 +1048,11 @@ def test_transform_tensor_preserves_empty_map_information():
         ],
     )
 
-    assert len(transformed) == 0
-    assert transformed.keys == empty.keys
-    assert transformed.info() == empty.info()
+    assert len(transformed_map) == 0
+    assert transformed_map.keys == empty.keys
 
 
-@pytest.mark.parametrize(
-    ("kwargs", "unknown_labels", "expected_system_ids"),
-    [
-        pytest.param(
-            {"system_ids": [92, 99]},
-            [38],
-            [92, 99],
-            id="one-unknown-label",
-        ),
-        pytest.param(
-            {},
-            [38, 92],
-            [0, 1],
-            id="default-system-ids",
-        ),
-    ],
-)
-def test_transform_tensor_rejects_unknown_system_labels(
-    kwargs,
-    unknown_labels,
-    expected_system_ids,
-):
-    """Every value row must match one of the requested systems."""
-    systems = [_make_system([1, 8]), _make_system([1, 8])]
-    transformation = O3Transformation(torch.eye(3, dtype=torch.float64), 1)
-
-    tensor = _single_block_tensor_map(
-        values=torch.zeros(2, 3, 1, dtype=torch.float64),
-        samples=Labels(
-            ["system", "atom"],
-            torch.tensor([[92, 0], [38, 0]]),
-        ),
-        components=[Labels(["xyz"], torch.arange(3).reshape(-1, 1))],
-    )
-
-    message = (
-        f"Block samples contain system labels {unknown_labels} that are not in "
-        f"system_ids={expected_system_ids}. Every sample must be assigned to a "
-        "system in the transformation."
-    )
-    with pytest.raises(ValueError, match=re.escape(message)):
-        transform_tensor(
-            tensor,
-            systems,
-            [transformation, transformation],
-            **kwargs,
-        )
-
-
-@pytest.mark.parametrize(
-    "samples",
-    [
-        pytest.param(
-            Labels(["atom"], torch.tensor([[0], [1]])),
-            id="without-system-label",
-        ),
-        pytest.param(
-            Labels(
-                ["system", "atom"],
-                torch.tensor([[4, 0], [4, 1]]),
-            ),
-            id="unrelated-system-label",
-        ),
-    ],
-)
-def test_transform_tensor_routes_all_rows_for_single_system(samples):
+def test_single_system_routes_all_rows():
     """With one system, all rows are transformed regardless of ``"system"`` labels."""
     systems = [_make_system([1, 1])]
 
@@ -1634,14 +1064,6 @@ def test_transform_tensor_routes_all_rows_for_single_system(samples):
         ],
         dtype=torch.float64,
     )
-    tensor = _single_block_tensor_map(
-        values=values,
-        samples=samples,
-        components=[Labels(["xyz"], torch.arange(3).reshape(-1, 1))],
-    )
-
-    transformed = transform_tensor(tensor, systems, [transformation])
-
     expected = torch.tensor(
         [
             [[-2.0], [1.0], [3.0]],
@@ -1649,11 +1071,22 @@ def test_transform_tensor_routes_all_rows_for_single_system(samples):
         ],
         dtype=torch.float64,
     )
-    assert torch.equal(transformed.block().values, expected)
+
+    for samples in [
+        Labels(["atom"], torch.tensor([[0], [1]])),
+        Labels(["system", "atom"], torch.tensor([[4, 0], [4, 1]])),
+    ]:
+        tensor = _single_block_tensor_map(
+            values=values,
+            samples=samples,
+            components=[Labels(["xyz"], torch.arange(3).reshape(-1, 1))],
+        )
+        transformed = transform_tensor(tensor, systems, [transformation])
+        assert torch.equal(transformed.block().values, expected)
 
 
-def test_transform_tensor_accepts_block_with_subset_of_systems():
-    """Transform a block whose rows belong to only a subset of the input systems."""
+def test_block_with_subset_of_systems():
+    """Blocks may cover only some systems; ids must survive beyond int32."""
     systems = [_make_system([1]), _make_system([8])]
 
     transformation_92 = O3Transformation(_rotation_90_degrees_around_z(), 1)
@@ -1678,8 +1111,6 @@ def test_transform_tensor_accepts_block_with_subset_of_systems():
         tensor,
         systems,
         [transformation_92, transformation_38],
-        # The second system has no samples in this block. Its ID exceeds the
-        # int32 range, checking that Python IDs are preserved as torch.long.
         system_ids=[92, 2**40],
     )
 
@@ -1690,32 +1121,6 @@ def test_transform_tensor_accepts_block_with_subset_of_systems():
     assert torch.equal(transformed.block().values, expected)
 
 
-def test_transform_tensor_rejects_missing_system_column_for_multiple_systems():
-    """With multiple systems, each row must identify which system it belongs to."""
-    systems = [_make_system([1]), _make_system([8])]
-    transformation = O3Transformation(
-        torch.eye(3, dtype=torch.float64),
-        max_angular_momentum=0,
-    )
-
-    tensor = _single_block_tensor_map(
-        values=torch.zeros((1, 1), dtype=torch.float64),
-        samples=Labels(["atom"], torch.tensor([[0]])),
-        components=[],
-    )
-
-    message = (
-        "Rotational augmentation expects output samples to include a 'system' "
-        "dimension when transforming multiple systems."
-    )
-    with pytest.raises(ValueError, match=re.escape(message)):
-        transform_tensor(
-            tensor,
-            systems,
-            [transformation, transformation],
-        )
-
-
 @pytest.mark.parametrize("device,dtype", ALL_DEVICE_DTYPE)
 @pytest.mark.parametrize("is_improper", [False, True])
 def test_precomputed_tensor_transform_matches_transform_tensor(
@@ -1723,7 +1128,7 @@ def test_precomputed_tensor_transform_matches_transform_tensor(
     dtype,
     is_improper,
 ):
-    """Match ``transform_tensor`` for scripted, mixed-axis O(3) batches."""
+    """The scripted precomputed-matrices path matches ``transform_tensor``."""
     dtype = getattr(torch, dtype)
     atol = 1.0e-5 if dtype == torch.float32 else 1.0e-12
     sign = -1.0 if is_improper else 1.0
@@ -1884,78 +1289,8 @@ def test_precomputed_tensor_transform_single_transformation_is_scriptable():
     )
 
 
-def test_precomputed_tensor_transform_scalar_does_not_alias_input():
-    """A transformed scalar should own its storage, as in ``transform_tensor``."""
-    values = torch.tensor([[1.0]], dtype=torch.float64)
-    tensor = _single_block_tensor_map(
-        values=values,
-        samples=Labels("system", torch.tensor([[0]])),
-        components=[],
-    )
-
-    result = _transform_tensor_with_precomputed_matrices(
-        tensor,
-        torch.eye(3, dtype=torch.float64).unsqueeze(0),
-        [],
-        False,
-    )
-    result.block().values.add_(1.0)
-
-    assert torch.equal(values, torch.tensor([[1.0]], dtype=torch.float64))
-
-
-@pytest.mark.parametrize(
-    ("matrices", "error", "message"),
-    [
-        pytest.param(
-            torch.empty((0, 3, 3), dtype=torch.float64),
-            ValueError,
-            "shape.*N > 0",
-            id="empty",
-        ),
-        pytest.param(
-            torch.empty((1, 2, 3), dtype=torch.float64),
-            ValueError,
-            "shape.*N > 0",
-            id="wrong-shape",
-        ),
-        pytest.param(
-            torch.eye(3, dtype=torch.float16).unsqueeze(0),
-            TypeError,
-            "float32 or float64",
-            id="unsupported-dtype",
-        ),
-        pytest.param(
-            torch.eye(3, dtype=torch.float32).unsqueeze(0),
-            ValueError,
-            "same dtype and device",
-            id="tensor-dtype-mismatch",
-        ),
-    ],
-)
-def test_precomputed_tensor_transform_rejects_invalid_matrix_batch(
-    matrices,
-    error,
-    message,
-):
-    """Reject malformed matrix batches and incompatible numerical types."""
-    tensor = _single_block_tensor_map(
-        values=torch.ones((1, 1), dtype=torch.float64),
-        samples=Labels("sample", torch.tensor([[0]])),
-        components=[],
-    )
-
-    with pytest.raises(error, match=message):
-        _transform_tensor_with_precomputed_matrices(
-            tensor,
-            matrices,
-            [],
-            False,
-        )
-
-
 def test_precomputed_tensor_transform_rejects_invalid_routing_and_wigner_rank():
-    """Reject ambiguous local routing and unavailable spherical ranks."""
+    """Ambiguous routing or missing Wigner-D ranks fail instead of misrotating."""
     transformations = [
         O3Transformation(torch.eye(3, dtype=torch.float64), 1),
         O3Transformation(_rotation_90_degrees_around_z(), 1),

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ testing_deps =
 metatomic_deps =
     metatensor-torch >=0.10.0,<0.11
     metatensor-operations >=0.5.0,<0.6
-    wigners
+    wigners >=0.4.0
 
 
 ################################################################################


### PR DESCRIPTION
This PR extracts and improves the O(3)-only part initially developed in #119.

## What changes

- Correct spherical parity for improper transformations: the additional factor is `o3_sigma * (-1) ** o3_lambda` and is applied only to the improper O(3) component.
- Make real Wigner-D evaluation stable near both ZYZ Euler-angle poles and use the structured `wigner_D_array` API directly.
- Store an independent copy of the matrix passed to `O3Transformation`, and construct the Wigner cache only when spherical data is first requested.
- Build randomly sampled transformations through one batched validation and a trusted internal construction path.
- Preserve TensorMap information and registered-neighbor autograd while transforming Systems, blocks, values, and gradients.
- Validate angular-momentum arguments, spherical/Cartesian component metadata, system assignments, and transformation dtype/device consistently.
- Support all ten component-axis positions already recognized by the O(3) naming convention.
- Document the resulting public contract and require `wigners >= 0.4.0` for the structured Wigner-D API.

## Compatibility decisions

This PR proposes renaming `O3Transformation.is_inverted` property to `is_improper`, which describes the actual condition (`det(matrix) < 0`) more precisely. 

The following observable behaviors also become explicit:

- matrices passed to the public `O3Transformation` constructor are copied, while `matrix` and `wigner_D_matrix` retain their released no-copy return behavior;
- Wigner-D construction moves from object construction to first spherical use;
- `random_transformations` accepts the model-capability dtypes `torch.float32` and `torch.float64`;
- structurally ambiguous component metadata and system identifiers are rejected before numerical transformation.

## Performance evidence

The retained optimizations were isolated from correctness changes:

- Wigner-D matrices are now built only when a spherical transformation or a direct Wigner-D request requires them. For 32 float64 CUDA transformations with `max_angular_momentum=4`, this reduced creation time by 72.9% and creation plus Cartesian-only use by 71.9%. The Wigner-D cost is just deferred as shown by the fact that, when a spherical transformation was requested immediately, total time was unchanged within 0.2%.
- When `random_transformations` generated 32 to 4096 transformations, replacing separate validation of every 3×3 matrix with one batched validation reduced creation time by 82.7–97.9% on CPU float64 and 90.8–99.6% on CUDA.

The compared matrices, proper/improper classifications, and representative Wigner-D results were identical. 

## Validation

- canonical Ruff formatting and lint checks passed;
- 121 focused O(3) cases passed, including CPU/CUDA and float32/float64 cases;
- all 243 tests in the complete `metatomic-torch` Python suite passed;
- the canonical documentation build passed with Sphinx warnings treated as errors.

# Contributor (creator of pull-request) checklist

- [x] Tests updated (for new features and bugfixes)?
- [x] Documentation updated (for new features)?
- [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

- [ ] CHANGELOG updated with public API or any other important changes?