### PR TITLE
fix float max_neighbors passed to nvalchemi

### DIFF
--- a/python/metatomic_ase/src/metatomic_ase/_neighbors.py
+++ b/python/metatomic_ase/src/metatomic_ase/_neighbors.py
@@ -1,3 +1,4 @@
+import math
 import warnings
 from typing import List
 
@@ -141,7 +142,7 @@ def _compute_requested_neighbors_nvalchemi(systems, requested_options):
                 pbc=system.pbc,
                 # Similar to the default in vesin, to make sure we have enough space for
                 # all pairs with large cutoffs.
-                max_neighbors=len(system) * max(128, cutoff**3),
+                max_neighbors=math.ceil(len(system) * max(128, cutoff**3)),
                 return_neighbor_list=True,
             )
             D = (

--- a/python/metatomic_torchsim/metatomic_torchsim/_neighbors.py
+++ b/python/metatomic_torchsim/metatomic_torchsim/_neighbors.py
@@ -1,3 +1,4 @@
+import math
 import warnings
 from typing import List
 
@@ -141,7 +142,7 @@ def _compute_requested_neighbors_nvalchemi(systems, requested_options):
                 pbc=system.pbc,
                 # Similar to the default in vesin, to make sure we have enough space for
                 # all pairs with large cutoffs.
-                max_neighbors=len(system) * max(128, cutoff**3),
+                max_neighbors=math.ceil(len(system) * max(128, cutoff**3)),
                 return_neighbor_list=True,
             )
             D = (


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

# Summary

Fix a type error in the CUDA/nvalchemi neighbour-list backend for large cutoffs.

#259 added a `max_neighbors` estimate:

```python
len(system) * max(128, cutoff**3)
```
`cutoff` is a float, so this expression is also a float once `cutoff**3 > 128` (i.e. above roughly 5 Å). However, nvalchemi requires `max_neighbors` to be an integer.

I noticed this whilst running benchmarks on ml-peg with pet-cam-xl. this can be reproduced by running e.g. the lattice constant benchmark on gpu.


# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [ ] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?
