### PR TITLE
C api tutorials

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,6 +1,7 @@
 Contribution via pull requests are always welcome. Source code is available from
 `Github`_. Before submitting a pull request, please open an issue to discuss
-your changes. Use only the `main` branch as the target branch when submitting a pull request (PR).
+your changes. By default, pull requests (PR) should target the `main` branch,
+unless stacking multiple PRs for review or working on a long-term features.
 
 .. _`Github` : https://github.com/metatensor/metatomic
 

--- a/examples/c/1-create-system.c
+++ b/examples/c/1-create-system.c
@@ -64,7 +64,7 @@ void dlpack_deleter(DLManagedTensorVersioned *self) {
 // %%
 //
 // We then define a helper function to create a DLPack tensor from a flat data
-// buffer. The tensor is created as a row-major, contiguous tensor on CPU, with
+// buffer. The tensor is created as a `row-major, contiguous` tensor on CPU, with
 // the specified shape and data type. The caller owns the data buffer, and is
 // responsible for freeing it after the tensor is no longer needed.
 
@@ -241,20 +241,120 @@ if (status != MTA_SUCCESS) {
 // Use the system
 // --------------
 //
-// Now that we have a :c:type:`mta_system_t`, we can use it with the rest of the
-// metatomic API, pass it to a model, etc. Here we just query its size and print
-// it.
+// Now that we have a :c:type:`mta_system_t`, we can query its attributes with
+// the rest of the metatomic API. A system always stores atomic types,
+// positions, the cell, and periodic boundary conditions. Forces and energies
+// are **not** part of the system: they are model outputs, obtained later by
+// calling :c:func:`mta_execute_model`.
+//
+// Start by checking the number of atoms and the length unit:
 
 uintptr_t size = 0;
 status = mta_system_size(system, &size);
-if (status == MTA_SUCCESS) {
-    printf("created system with %lu atoms\n", (unsigned long)size);
-} else {
-    printf("failed to get system size\n");
+if (status != MTA_SUCCESS) {
+    fprintf(stderr, "failed to get system size\n");
     mta_system_free(system);
     return EXIT_FAILURE;
 }
+printf("created system with %lu atoms\n", (unsigned long)size);
 
+mta_string_t length_unit = NULL;
+status = mta_system_get_length_unit(system, &length_unit);
+if (status != MTA_SUCCESS) {
+    fprintf(stderr, "failed to get length unit\n");
+    mta_system_free(system);
+    return EXIT_FAILURE;
+}
+printf("length unit: %s\n", mta_string_view(length_unit));
+mta_string_free(length_unit);
+
+// %%
+//
+// Query types, positions, cell, and PBC
+// -------------------------------------
+//
+// :c:func:`mta_system_get_data` returns a **borrowed** DLPack view of the
+// requested data. You must call the tensor's ``deleter`` when you are done;
+// do not modify the underlying buffer.
+
+DLManagedTensorVersioned* data = NULL;
+
+status = mta_system_get_data(system, MTA_SYSTEM_DATA_TYPES, &data);
+if (status != MTA_SUCCESS) {
+    fprintf(stderr, "failed to get types\n");
+    mta_system_free(system);
+    return EXIT_FAILURE;
+}
+int32_t* types_view = (int32_t*)((char*)data->dl_tensor.data + data->dl_tensor.byte_offset);
+printf("types:");
+for (uintptr_t i = 0; i < size; i++) {
+    printf(" %d", types_view[i]);
+}
+printf("\n");
+data->deleter(data);
+
+status = mta_system_get_data(system, MTA_SYSTEM_DATA_POSITIONS, &data);
+if (status != MTA_SUCCESS) {
+    fprintf(stderr, "failed to get positions\n");
+    mta_system_free(system);
+    return EXIT_FAILURE;
+}
+double* positions_view = (double*)((char*)data->dl_tensor.data + data->dl_tensor.byte_offset);
+printf("positions:\n");
+for (uintptr_t i = 0; i < size; i++) {
+    printf("  %.3f %.3f %.3f\n",
+           positions_view[3 * i + 0],
+           positions_view[3 * i + 1],
+           positions_view[3 * i + 2]);
+}
+data->deleter(data);
+
+status = mta_system_get_data(system, MTA_SYSTEM_DATA_CELL, &data);
+if (status != MTA_SUCCESS) {
+    fprintf(stderr, "failed to get cell\n");
+    mta_system_free(system);
+    return EXIT_FAILURE;
+}
+double* cell_view = (double*)((char*)data->dl_tensor.data + data->dl_tensor.byte_offset);
+printf("cell:\n");
+for (int i = 0; i < 3; i++) {
+    printf("  %.3f %.3f %.3f\n",
+           cell_view[3 * i + 0],
+           cell_view[3 * i + 1],
+           cell_view[3 * i + 2]);
+}
+data->deleter(data);
+
+status = mta_system_get_data(system, MTA_SYSTEM_DATA_PBC, &data);
+if (status != MTA_SUCCESS) {
+    fprintf(stderr, "failed to get pbc\n");
+    mta_system_free(system);
+    return EXIT_FAILURE;
+}
+uint8_t* pbc_view = (uint8_t*)((char*)data->dl_tensor.data + data->dl_tensor.byte_offset);
+printf("pbc: %s %s %s\n",
+       pbc_view[0] ? "true" : "false",
+       pbc_view[1] ? "true" : "false",
+       pbc_view[2] ? "true" : "false");
+data->deleter(data);
+
+// %%
+//
+// Running this program prints::
+//
+//     created system with 4 atoms
+//     length unit: Angstrom
+//     types: 1 1 6 6
+//     positions:
+//       0.000 0.000 0.000
+//       0.500 0.500 0.000
+//       0.500 0.000 0.500
+//       0.000 0.500 0.500
+//     cell:
+//       1.000 0.000 0.000
+//       0.000 1.000 0.000
+//       0.000 0.000 1.000
+//     pbc: true true true
 
 // %%
 //

--- a/examples/c/2-add-model.c
+++ b/examples/c/2-add-model.c
@@ -1,385 +1,42 @@
-// Defining a harmonic model
-// =========================
+// Defining a model (WIP)
+// ======================
 //
 // This tutorial shows how to implement a metatomic model in C by filling an
-// :c:type:`mta_model_t` vtable, registering it through a plugin, and evaluating
-// energy and forces for a small system.
+// :c:type:`mta_model_t` vtable and registering it through a plugin.
 //
-// We use Einstein's solid: each atom is an independent harmonic oscillator
-// around an equilibrium position,
+// .. warning::
+//
+//     **Work in progress.** ``execute_inner`` is not implemented here. Returning
+//     energy TensorMaps (and forces as position gradients) will land in a
+//     follow-up tutorial. This file only covers the model vtable, metadata,
+//     and in-process plugin registration.
+//
+// We use Einstein's solid as the running example: each atom is an independent
+// harmonic oscillator around an equilibrium position,
 //
 // .. math::
 //
-//     E = \sum_i k \left(\vec{r}_i - \vec{r}_i^0\right)^2,
-//
-// so the force on atom :math:`i` is :math:`\vec{F}_i = -2k(\vec{r}_i -
-// \vec{r}_i^0)`. In metatomic, forces are returned as the negative of the
-// ``"positions"`` energy gradient (see :ref:`energy-quantity-gradients`).
+//     E = \sum_i k \left(\vec{r}_i - \vec{r}_i^0\right)^2.
 
-#include <math.h>
-#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include <metatomic.h>
-#include <metatensor/dlpack/dlpack.h>
-
-// Dense CPU arrays for building metatensor Labels / TensorMaps
-// ------------------------------------------------------------
-//
-// The helpers below implement a small ``mts_array_t`` backend so this
-// example can construct energy TensorMaps (and position gradients)
-// without depending on the C++ ``SimpleDataArray`` helpers.
-
-/* Minimal CPU dense arrays for metatensor TensorMaps in C tutorials.
- *
- * Only the callbacks needed to build Labels / TensorBlocks and read values
- * back are fully implemented. Advanced ops return an error.
- */
-
-typedef struct {
-    uintptr_t* shape;
-    uintptr_t shape_count;
-    uint8_t* data;
-    uintptr_t n_bytes;
-    DLDataType dtype;
-} DenseArray;
-
-typedef struct {
-    DenseArray* array;
-    int64_t* shape;
-    int64_t* strides;
-} DenseDLPackContext;
-
-static mts_data_origin_t dense_array_origin_id(void) {
-    static mts_data_origin_t origin = 0;
-    if (origin == 0) {
-        mts_register_data_origin("metatomic::examples::DenseArray", &origin);
-    }
-    return origin;
-}
-
-static void dense_array_free(DenseArray* array) {
-    if (array == NULL) {
-        return;
-    }
-    free(array->shape);
-    free(array->data);
-    free(array);
-}
-
-static DenseArray* dense_array_new(
-    const uintptr_t* shape,
-    uintptr_t shape_count,
-    DLDataType dtype,
-    const void* values,
-    uintptr_t n_bytes
-) {
-    DenseArray* array = calloc(1, sizeof(DenseArray));
-    if (array == NULL) {
-        return NULL;
-    }
-
-    array->shape_count = shape_count;
-    array->dtype = dtype;
-    array->n_bytes = n_bytes;
-
-    if (shape_count > 0) {
-        array->shape = malloc(shape_count * sizeof(uintptr_t));
-        if (array->shape == NULL) {
-            free(array);
-            return NULL;
-        }
-        memcpy(array->shape, shape, shape_count * sizeof(uintptr_t));
-    }
-
-    array->data = malloc(n_bytes == 0 ? 1 : n_bytes);
-    if (array->data == NULL) {
-        free(array->shape);
-        free(array);
-        return NULL;
-    }
-    if (values != NULL && n_bytes > 0) {
-        memcpy(array->data, values, n_bytes);
-    } else if (n_bytes > 0) {
-        memset(array->data, 0, n_bytes);
-    }
-    return array;
-}
-
-static void dense_dlpack_deleter(DLManagedTensorVersioned* self) {
-    if (self == NULL) {
-        return;
-    }
-    DenseDLPackContext* ctx = (DenseDLPackContext*)self->manager_ctx;
-    if (ctx != NULL) {
-        free(ctx->shape);
-        free(ctx->strides);
-        free(ctx);
-    }
-    free(self);
-}
-
-static void dense_array_destroy(void* ptr) {
-    dense_array_free((DenseArray*)ptr);
-}
-
-static mts_status_t dense_array_origin(const void* ptr, mts_data_origin_t* origin) {
-    (void)ptr;
-    *origin = dense_array_origin_id();
-    return MTS_SUCCESS;
-}
-
-static mts_status_t dense_array_device(const void* ptr, DLDevice* device) {
-    (void)ptr;
-    device->device_type = kDLCPU;
-    device->device_id = 0;
-    return MTS_SUCCESS;
-}
-
-static mts_status_t dense_array_dtype(const void* ptr, DLDataType* dtype) {
-    *dtype = ((const DenseArray*)ptr)->dtype;
-    return MTS_SUCCESS;
-}
-
-static mts_status_t dense_array_shape(
-    const void* ptr,
-    const uintptr_t** shape,
-    uintptr_t* shape_count
-) {
-    const DenseArray* array = (const DenseArray*)ptr;
-    *shape = array->shape;
-    *shape_count = array->shape_count;
-    return MTS_SUCCESS;
-}
-
-static mts_status_t dense_array_as_dlpack(
-    void* ptr,
-    DLManagedTensorVersioned** out,
-    DLDevice device,
-    const int64_t* stream,
-    DLPackVersion max_version
-) {
-    DenseArray* array = (DenseArray*)ptr;
-
-    if (device.device_type != kDLCPU) {
-        mts_set_last_error("DenseArray only supports CPU", "dense_array", NULL, NULL);
-        return MTS_CALLBACK_ERROR;
-    }
-    if (stream != NULL) {
-        mts_set_last_error("DenseArray does not support streams", "dense_array", NULL, NULL);
-        return MTS_CALLBACK_ERROR;
-    }
-    if (max_version.major != DLPACK_MAJOR_VERSION) {
-        mts_set_last_error("unsupported DLPack version", "dense_array", NULL, NULL);
-        return MTS_CALLBACK_ERROR;
-    }
-
-    DenseDLPackContext* ctx = calloc(1, sizeof(DenseDLPackContext));
-    DLManagedTensorVersioned* tensor = calloc(1, sizeof(DLManagedTensorVersioned));
-    if (ctx == NULL || tensor == NULL) {
-        free(ctx);
-        free(tensor);
-        mts_set_last_error("out of memory", "dense_array", NULL, NULL);
-        return MTS_CALLBACK_ERROR;
-    }
-
-    if (array->shape_count > 0) {
-        ctx->shape = malloc(array->shape_count * sizeof(int64_t));
-        ctx->strides = malloc(array->shape_count * sizeof(int64_t));
-        if (ctx->shape == NULL || ctx->strides == NULL) {
-            free(ctx->shape);
-            free(ctx->strides);
-            free(ctx);
-            free(tensor);
-            mts_set_last_error("out of memory", "dense_array", NULL, NULL);
-            return MTS_CALLBACK_ERROR;
-        }
-        int64_t stride = 1;
-        for (uintptr_t i = array->shape_count; i-- > 0;) {
-            ctx->shape[i] = (int64_t)array->shape[i];
-            ctx->strides[i] = stride;
-            stride *= ctx->shape[i];
-        }
-    }
-
-    ctx->array = array;
-    tensor->version.major = DLPACK_MAJOR_VERSION;
-    tensor->version.minor = DLPACK_MINOR_VERSION;
-    tensor->manager_ctx = ctx;
-    tensor->deleter = dense_dlpack_deleter;
-    tensor->dl_tensor.data = array->data;
-    tensor->dl_tensor.device = device;
-    tensor->dl_tensor.ndim = (int32_t)array->shape_count;
-    tensor->dl_tensor.dtype = array->dtype;
-    tensor->dl_tensor.shape = ctx->shape;
-    tensor->dl_tensor.strides = ctx->strides;
-    tensor->dl_tensor.byte_offset = 0;
-
-    *out = tensor;
-    return MTS_SUCCESS;
-}
-
-static mts_status_t dense_array_unsupported(void) {
-    mts_set_last_error(
-        "operation not implemented for tutorial DenseArray",
-        "dense_array",
-        NULL,
-        NULL
-    );
-    return MTS_CALLBACK_ERROR;
-}
-
-static mts_status_t dense_array_reshape(void* array, const uintptr_t* shape, uintptr_t shape_count) {
-    (void)array;
-    (void)shape;
-    (void)shape_count;
-    return dense_array_unsupported();
-}
-
-static mts_status_t dense_array_swap_axes(void* array, uintptr_t axis_1, uintptr_t axis_2) {
-    (void)array;
-    (void)axis_1;
-    (void)axis_2;
-    return dense_array_unsupported();
-}
-
-static mts_status_t dense_array_create(
-    const void* array,
-    const uintptr_t* shape,
-    uintptr_t shape_count,
-    struct mts_array_t fill_value,
-    struct mts_array_t* new_array
-) {
-    (void)array;
-    (void)shape;
-    (void)shape_count;
-    (void)fill_value;
-    (void)new_array;
-    return dense_array_unsupported();
-}
-
-static mts_status_t dense_array_copy(const void* array, DLDevice device, struct mts_array_t* new_array) {
-    (void)array;
-    (void)device;
-    (void)new_array;
-    return dense_array_unsupported();
-}
-
-static mts_status_t dense_array_from_dlpack(
-    const void* array,
-    DLManagedTensorVersioned* dl_managed_tensor,
-    struct mts_array_t* new_array
-) {
-    (void)array;
-    (void)dl_managed_tensor;
-    (void)new_array;
-    return dense_array_unsupported();
-}
-
-static mts_status_t dense_array_move_data(
-    void* output,
-    const void* input,
-    const struct mts_data_movement_t* movements,
-    uintptr_t movements_count
-) {
-    (void)output;
-    (void)input;
-    (void)movements;
-    (void)movements_count;
-    return dense_array_unsupported();
-}
-
-static struct mts_array_t dense_array_to_mts(DenseArray* array) {
-    struct mts_array_t mts = {
-        .ptr = array,
-        .destroy = dense_array_destroy,
-        .origin = dense_array_origin,
-        .device = dense_array_device,
-        .dtype = dense_array_dtype,
-        .as_dlpack = dense_array_as_dlpack,
-        .from_dlpack = dense_array_from_dlpack,
-        .shape = dense_array_shape,
-        .reshape = dense_array_reshape,
-        .swap_axes = dense_array_swap_axes,
-        .create = dense_array_create,
-        .copy = dense_array_copy,
-        .move_data = dense_array_move_data,
-    };
-    return mts;
-}
-
-static struct mts_array_t dense_f64(const uintptr_t* shape, uintptr_t ndim, const double* values) {
-    uintptr_t n = 1;
-    for (uintptr_t i = 0; i < ndim; i++) {
-        n *= shape[i];
-    }
-    DenseArray* array = dense_array_new(
-        shape,
-        ndim,
-        (DLDataType){.code = kDLFloat, .bits = 64, .lanes = 1},
-        values,
-        n * sizeof(double)
-    );
-    return dense_array_to_mts(array);
-}
-
-static struct mts_array_t dense_i32(const uintptr_t* shape, uintptr_t ndim, const int32_t* values) {
-    uintptr_t n = 1;
-    for (uintptr_t i = 0; i < ndim; i++) {
-        n *= shape[i];
-    }
-    DenseArray* array = dense_array_new(
-        shape,
-        ndim,
-        (DLDataType){.code = kDLInt, .bits = 32, .lanes = 1},
-        values,
-        n * sizeof(int32_t)
-    );
-    return dense_array_to_mts(array);
-}
-
-static const mts_labels_t* labels_from_i32(
-    const char* const* names,
-    uintptr_t n_names,
-    const int32_t* values,
-    uintptr_t n_entries
-) {
-    uintptr_t shape[2] = {n_entries, n_names};
-    return mts_labels(names, n_names, dense_i32(shape, 2, values));
-}
-
 
 // %%
 //
 // Model state
 // -----------
 //
-// The model owns its parameters. Here that is a force constant and the
-// equilibrium positions (diamond carbon basis, cubic cell :math:`a = 3.567`
-// Å). The initial geometry below is displaced by 0.05 Å so the energy and
-// forces are non-zero but easy to check by hand.
+// The model owns its parameters. Here that is a force constant; a later
+// tutorial will also store equilibrium positions and evaluate the energy.
 
-#define N_ATOMS 2
 #define FORCE_CONSTANT 10.0 /* eV / Angstrom^2 */
-#define CELL_A 3.567
 
 typedef struct {
     double force_constant;
-    double r0[N_ATOMS][3];
 } HarmonicModel;
-
-static const double EQUILIBRIUM[N_ATOMS][3] = {
-    {0.0, 0.0, 0.0},
-    {CELL_A / 4.0, CELL_A / 4.0, CELL_A / 4.0},
-};
-
-/* Displaced diamond basis: atom 0 along +x, atom 1 along +z. */
-static const double POSITIONS0[N_ATOMS][3] = {
-    {0.05, 0.0, 0.0},
-    {CELL_A / 4.0, CELL_A / 4.0, CELL_A / 4.0 + 0.05},
-};
 
 // %%
 //
@@ -450,122 +107,10 @@ static mta_status_t harmonic_supported_outputs(const void* model_data, mta_strin
     return (*out != NULL) ? MTA_SUCCESS : MTA_INTERNAL_ERROR;
 }
 
-static mta_status_t harmonic_requested_pair_lists(const void* model_data, mta_string_t* out) {
-    (void)model_data;
-    /* Non-interacting oscillators: no neighbor lists. */
-    *out = mta_string_create("[]");
-    return (*out != NULL) ? MTA_SUCCESS : MTA_INTERNAL_ERROR;
-}
-
-static mta_status_t harmonic_requested_inputs(const void* model_data, mta_string_t* out) {
+static mta_status_t harmonic_empty_list(const void* model_data, mta_string_t* out) {
     (void)model_data;
     *out = mta_string_create("[]");
     return (*out != NULL) ? MTA_SUCCESS : MTA_INTERNAL_ERROR;
-}
-
-// %%
-//
-// Building the energy TensorMap
-// -----------------------------
-//
-// :c:func:`execute_inner` must return one :c:type:`mts_tensormap_t` per
-// requested output. For system-level energy the block has samples
-// ``["system"]``, no components, and properties ``["energy"]``. Position
-// gradients use samples ``["sample", "system", "atom"]`` and component
-// ``["xyz"]``.
-
-static mts_tensormap_t* energy_with_forces(
-    double energy,
-    const double forces[N_ATOMS][3]
-) {
-    /* values: shape (n_systems=1, n_properties=1) */
-    double values_data[1] = {energy};
-    uintptr_t values_shape[2] = {1, 1};
-    int32_t sample_values[1] = {0};
-    int32_t property_values[1] = {0};
-    int32_t key_values[1] = {0};
-
-    const char* sample_names[] = {"system"};
-    const char* property_names[] = {"energy"};
-    const char* key_names[] = {"_"};
-
-    const mts_labels_t* samples = labels_from_i32(sample_names, 1, sample_values, 1);
-    const mts_labels_t* properties = labels_from_i32(property_names, 1, property_values, 1);
-    const mts_labels_t* keys = labels_from_i32(key_names, 1, key_values, 1);
-    if (samples == NULL || properties == NULL || keys == NULL) {
-        return NULL;
-    }
-
-    mts_block_t* block = mts_block(
-        dense_f64(values_shape, 2, values_data),
-        samples,
-        NULL,
-        0,
-        properties
-    );
-    mts_labels_free(samples);
-    mts_labels_free(properties);
-    if (block == NULL) {
-        mts_labels_free(keys);
-        return NULL;
-    }
-
-    /* gradients: ∂E/∂r = -F, shape (n_atoms, 3, 1) */
-    double grad_data[N_ATOMS * 3];
-    int32_t grad_samples_data[N_ATOMS * 3];
-    for (int i = 0; i < N_ATOMS; i++) {
-        grad_data[3 * i + 0] = -forces[i][0];
-        grad_data[3 * i + 1] = -forces[i][1];
-        grad_data[3 * i + 2] = -forces[i][2];
-        grad_samples_data[3 * i + 0] = 0; /* sample */
-        grad_samples_data[3 * i + 1] = 0; /* system */
-        grad_samples_data[3 * i + 2] = i; /* atom */
-    }
-
-    uintptr_t grad_shape[3] = {N_ATOMS, 3, 1};
-    int32_t xyz_data[3] = {0, 1, 2};
-    const char* grad_sample_names[] = {"sample", "system", "atom"};
-    const char* xyz_names[] = {"xyz"};
-
-    const mts_labels_t* grad_samples =
-        labels_from_i32(grad_sample_names, 3, grad_samples_data, N_ATOMS);
-    const mts_labels_t* xyz = labels_from_i32(xyz_names, 1, xyz_data, 3);
-    const mts_labels_t* grad_properties =
-        labels_from_i32(property_names, 1, property_values, 1);
-    if (grad_samples == NULL || xyz == NULL || grad_properties == NULL) {
-        mts_block_free(block);
-        mts_labels_free(keys);
-        return NULL;
-    }
-
-    const mts_labels_t* components[1] = {xyz};
-    mts_block_t* gradient = mts_block(
-        dense_f64(grad_shape, 3, grad_data),
-        grad_samples,
-        components,
-        1,
-        grad_properties
-    );
-    mts_labels_free(grad_samples);
-    mts_labels_free(xyz);
-    mts_labels_free(grad_properties);
-    if (gradient == NULL) {
-        mts_block_free(block);
-        mts_labels_free(keys);
-        return NULL;
-    }
-
-    if (mts_block_add_gradient(block, "positions", gradient) != MTS_SUCCESS) {
-        mts_block_free(gradient);
-        mts_block_free(block);
-        mts_labels_free(keys);
-        return NULL;
-    }
-
-    mts_block_t* blocks[1] = {block};
-    mts_tensormap_t* tensor = mts_tensormap(keys, blocks, 1);
-    mts_labels_free(keys);
-    return tensor;
 }
 
 static mta_status_t harmonic_execute_inner(
@@ -577,61 +122,20 @@ static mta_status_t harmonic_execute_inner(
     mts_tensormap_t** outputs,
     uintptr_t outputs_count
 ) {
-    HarmonicModel* model = (HarmonicModel*)model_data;
+    (void)model_data;
+    (void)systems;
+    (void)systems_count;
+    (void)selected_atoms;
     (void)requested_outputs_json;
-
-    if (selected_atoms != NULL) {
-        mta_set_last_error(
-            "selected_atoms is not supported by harmonic-diamond",
-            "harmonic_execute_inner",
-            NULL,
-            NULL
-        );
-        return MTA_INVALID_PARAMETER_ERROR;
-    }
-    if (systems_count != 1 || outputs_count != 1) {
-        mta_set_last_error(
-            "this tutorial model expects one system and one output",
-            "harmonic_execute_inner",
-            NULL,
-            NULL
-        );
-        return MTA_INVALID_PARAMETER_ERROR;
-    }
-
-    DLManagedTensorVersioned* positions = NULL;
-    mta_status_t status = mta_system_get_data(
-        systems[0], MTA_SYSTEM_DATA_POSITIONS, &positions
+    (void)outputs;
+    (void)outputs_count;
+    mta_set_last_error(
+        "harmonic-diamond execute_inner is not implemented yet (WIP)",
+        "harmonic_execute_inner",
+        NULL,
+        NULL
     );
-    if (status != MTA_SUCCESS) {
-        return status;
-    }
-
-    double* xyz = (double*)((char*)positions->dl_tensor.data + positions->dl_tensor.byte_offset);
-    double energy = 0.0;
-    double forces[N_ATOMS][3];
-    for (int i = 0; i < N_ATOMS; i++) {
-        for (int a = 0; a < 3; a++) {
-            double dr = xyz[3 * i + a] - model->r0[i][a];
-            energy += model->force_constant * dr * dr;
-            forces[i][a] = -2.0 * model->force_constant * dr;
-        }
-    }
-    positions->deleter(positions);
-
-    outputs[0] = energy_with_forces(energy, forces);
-    if (outputs[0] == NULL) {
-        const char* message = NULL;
-        mts_last_error(&message, NULL, NULL);
-        mta_set_last_error(
-            message != NULL ? message : "failed to build energy TensorMap",
-            "harmonic_execute_inner",
-            NULL,
-            NULL
-        );
-        return MTA_METATENSOR_ERROR;
-    }
-    return MTA_SUCCESS;
+    return MTA_INTERNAL_ERROR;
 }
 
 // %%
@@ -659,95 +163,24 @@ static mta_status_t harmonic_load_model(
         return MTA_INTERNAL_ERROR;
     }
     data->force_constant = FORCE_CONSTANT;
-    memcpy(data->r0, EQUILIBRIUM, sizeof(EQUILIBRIUM));
 
     model->data = data;
     model->unload = harmonic_unload;
     model->metadata = harmonic_metadata;
     model->capabilities = harmonic_capabilities;
     model->supported_outputs = harmonic_supported_outputs;
-    model->requested_pair_lists = harmonic_requested_pair_lists;
-    model->requested_inputs = harmonic_requested_inputs;
+    model->requested_pair_lists = harmonic_empty_list;
+    model->requested_inputs = harmonic_empty_list;
     model->execute_inner = harmonic_execute_inner;
     return MTA_SUCCESS;
 }
 
-// %%
-//
-// Helpers to build the system
-// ---------------------------
-
-typedef struct {
-    int64_t* shape;
-    int64_t* strides;
-} SystemDLPackContext;
-
-static void system_dlpack_deleter(DLManagedTensorVersioned* self) {
-    if (self == NULL) {
-        return;
-    }
-    SystemDLPackContext* ctx = (SystemDLPackContext*)self->manager_ctx;
-    if (ctx != NULL) {
-        free(ctx->shape);
-        free(ctx->strides);
-        free(ctx);
-    }
-    free(self);
-}
-
-static DLManagedTensorVersioned* system_tensor_from_data(
-    void* data,
-    int32_t ndim,
-    const int64_t* shape,
-    DLDataType dtype
-) {
-    SystemDLPackContext* ctx = malloc(sizeof(SystemDLPackContext));
-    DLManagedTensorVersioned* tensor = calloc(1, sizeof(*tensor));
-    if (ctx == NULL || tensor == NULL) {
-        free(ctx);
-        free(tensor);
-        return NULL;
-    }
-    ctx->shape = malloc((size_t)ndim * sizeof(int64_t));
-    ctx->strides = malloc((size_t)ndim * sizeof(int64_t));
-    if (ctx->shape == NULL || ctx->strides == NULL) {
-        free(ctx->shape);
-        free(ctx->strides);
-        free(ctx);
-        free(tensor);
-        return NULL;
-    }
-    memcpy(ctx->shape, shape, (size_t)ndim * sizeof(int64_t));
-    int64_t stride = 1;
-    for (int32_t i = ndim - 1; i >= 0; i--) {
-        ctx->strides[i] = stride;
-        stride *= shape[i];
-    }
-
-    tensor->version.major = DLPACK_MAJOR_VERSION;
-    tensor->version.minor = DLPACK_MINOR_VERSION;
-    tensor->manager_ctx = ctx;
-    tensor->deleter = system_dlpack_deleter;
-    tensor->flags = DLPACK_FLAG_BITMASK_READ_ONLY;
-    tensor->dl_tensor.data = data;
-    tensor->dl_tensor.device.device_type = kDLCPU;
-    tensor->dl_tensor.device.device_id = 0;
-    tensor->dl_tensor.dtype = dtype;
-    tensor->dl_tensor.ndim = ndim;
-    tensor->dl_tensor.shape = ctx->shape;
-    tensor->dl_tensor.strides = ctx->strides;
-    return tensor;
-}
-
-static int fail(mta_system_t* system, mta_model_t* model, const char* what) {
+static int fail(mta_model_t* model, const char* what) {
     const char* message = NULL;
     mta_last_error(&message, NULL, NULL);
     fprintf(stderr, "%s: %s\n", what, message != NULL ? message : "(no message)");
     if (model != NULL && model->unload != NULL && model->data != NULL) {
         model->unload(model->data);
-    }
-    if (system != NULL) {
-        mta_system_free(system);
     }
     return EXIT_FAILURE;
 }
@@ -761,130 +194,31 @@ int main(void) {
         .load_model = harmonic_load_model,
     };
     if (mta_register_plugin(PLUGIN) != MTA_SUCCESS) {
-        return fail(NULL, NULL, "failed to register plugin");
+        return fail(NULL, "failed to register plugin");
     }
 
     mta_model_t model = {0};
     if (mta_load_model("harmonic-diamond", "{}", "tutorial-harmonic-plugin", &model)
         != MTA_SUCCESS) {
-        return fail(NULL, NULL, "failed to load model");
+        return fail(NULL, "failed to load model");
     }
 
     mta_string_t metadata = NULL;
     if (model.metadata(model.data, &metadata) != MTA_SUCCESS) {
-        return fail(NULL, &model, "failed to get metadata");
+        return fail(&model, "failed to get metadata");
     }
     mta_string_t printed = NULL;
     if (mta_format_metadata(mta_string_view(metadata), &printed) != MTA_SUCCESS) {
         mta_string_free(metadata);
-        return fail(NULL, &model, "failed to format metadata");
+        return fail(&model, "failed to format metadata");
     }
     printf("%s\n", mta_string_view(printed));
     mta_string_free(metadata);
     mta_string_free(printed);
 
-    int32_t types_data[N_ATOMS] = {6, 6};
-    double positions_data[N_ATOMS * 3];
-    double cell_data[9] = {
-        CELL_A, 0.0, 0.0,
-        0.0, CELL_A, 0.0,
-        0.0, 0.0, CELL_A,
-    };
-    bool pbc_data[3] = {true, true, true};
-    memcpy(positions_data, POSITIONS0, sizeof(POSITIONS0));
-
-    DLManagedTensorVersioned* types = system_tensor_from_data(
-        types_data, 1, (int64_t[]){N_ATOMS},
-        (DLDataType){.code = kDLInt, .bits = 32, .lanes = 1}
-    );
-    DLManagedTensorVersioned* positions = system_tensor_from_data(
-        positions_data, 2, (int64_t[]){N_ATOMS, 3},
-        (DLDataType){.code = kDLFloat, .bits = 64, .lanes = 1}
-    );
-    DLManagedTensorVersioned* cell = system_tensor_from_data(
-        cell_data, 2, (int64_t[]){3, 3},
-        (DLDataType){.code = kDLFloat, .bits = 64, .lanes = 1}
-    );
-    DLManagedTensorVersioned* pbc = system_tensor_from_data(
-        pbc_data, 1, (int64_t[]){3},
-        (DLDataType){.code = kDLBool, .bits = 8, .lanes = 1}
-    );
-
-    mta_system_t* system = NULL;
-    if (mta_system_create("Angstrom", types, positions, cell, pbc, &system)
-        != MTA_SUCCESS) {
-        return fail(NULL, &model, "failed to create system");
-    }
-
-    /* Call execute_inner directly. Engines normally use mta_execute_model,
-       which adds validation and unit conversion on top of this callback. */
-    mts_tensormap_t* outputs[1] = {NULL};
-    const char* requested =
-        "[{\"type\":\"metatomic_quantity\",\"name\":\"energy\",\"unit\":\"eV\","
-        "\"gradients\":[\"positions\"],\"sample_kind\":\"system\"}]";
-    if (model.execute_inner(
-            model.data, (const mta_system_t* const*)&system, 1, NULL, requested, outputs, 1
-        )
-        != MTA_SUCCESS) {
-        return fail(system, &model, "execute_inner failed");
-    }
-
-    mts_block_t* block = NULL;
-    if (mts_tensormap_block_by_id(outputs[0], &block, 0) != MTS_SUCCESS) {
-        mts_tensormap_free(outputs[0]);
-        return fail(system, &model, "failed to get energy block");
-    }
-
-    mts_array_t values;
-    if (mts_block_data(block, &values) != MTS_SUCCESS) {
-        mts_tensormap_free(outputs[0]);
-        return fail(system, &model, "failed to get energy values");
-    }
-
-    DLManagedTensorVersioned* values_dl = NULL;
-    DLDevice cpu = {.device_type = kDLCPU, .device_id = 0};
-    DLPackVersion ver = {.major = DLPACK_MAJOR_VERSION, .minor = DLPACK_MINOR_VERSION};
-    if (values.as_dlpack(values.ptr, &values_dl, cpu, NULL, ver) != MTS_SUCCESS) {
-        mts_tensormap_free(outputs[0]);
-        return fail(system, &model, "failed to export energy values");
-    }
-    double energy = ((double*)((char*)values_dl->dl_tensor.data + values_dl->dl_tensor.byte_offset))[0];
-    values_dl->deleter(values_dl);
-
-    mts_block_t* gradient = NULL;
-    if (mts_block_gradient(block, "positions", &gradient) != MTS_SUCCESS) {
-        mts_tensormap_free(outputs[0]);
-        return fail(system, &model, "failed to get positions gradient");
-    }
-    mts_array_t grad_values;
-    if (mts_block_data(gradient, &grad_values) != MTS_SUCCESS) {
-        mts_tensormap_free(outputs[0]);
-        return fail(system, &model, "failed to get gradient values");
-    }
-    DLManagedTensorVersioned* grad_dl = NULL;
-    if (grad_values.as_dlpack(grad_values.ptr, &grad_dl, cpu, NULL, ver) != MTS_SUCCESS) {
-        mts_tensormap_free(outputs[0]);
-        return fail(system, &model, "failed to export gradient values");
-    }
-    double* grad = (double*)((char*)grad_dl->dl_tensor.data + grad_dl->dl_tensor.byte_offset);
-
-    printf("energy: %.6f eV\n", energy);
-    printf("forces (eV/Angstrom):\n");
-    for (int i = 0; i < N_ATOMS; i++) {
-        /* F = -∂E/∂r */
-        double fx = -grad[3 * i + 0];
-        double fy = -grad[3 * i + 1];
-        double fz = -grad[3 * i + 2];
-        if (fabs(fx) < 1e-12) { fx = 0.0; }
-        if (fabs(fy) < 1e-12) { fy = 0.0; }
-        if (fabs(fz) < 1e-12) { fz = 0.0; }
-        printf("  atom %d: %8.3f %8.3f %8.3f\n", i, fx, fy, fz);
-    }
-    grad_dl->deleter(grad_dl);
-    mts_tensormap_free(outputs[0]);
+    printf("execute_inner is WIP; energy TensorMaps will be added later\n");
 
     model.unload(model.data);
-    mta_system_free(system);
     return EXIT_SUCCESS;
 }
 
@@ -893,9 +227,7 @@ int main(void) {
 // Expected output
 // ---------------
 //
-// With :math:`k = 10` eV/Å² and 0.05 Å displacements, each atom contributes
-// :math:`10 \times 0.05^2 = 0.025` eV, so the total energy is 0.05 eV. The
-// non-zero force components have magnitude :math:`2k\times 0.05 = 1` eV/Å::
+// ::
 //
 //     This is the harmonic-diamond model
 //     ==================================
@@ -907,7 +239,4 @@ int main(void) {
 //
 //     - metatomic C tutorials
 //
-//     energy: 0.050000 eV
-//     forces (eV/Angstrom):
-//       atom 0:   -1.000    0.000    0.000
-//       atom 1:    0.000    0.000   -1.000
+//     execute_inner is WIP; energy TensorMaps will be added later

--- a/examples/c/2-add-model.c
+++ b/examples/c/2-add-model.c
@@ -1,0 +1,913 @@
+// Defining a harmonic model
+// =========================
+//
+// This tutorial shows how to implement a metatomic model in C by filling an
+// :c:type:`mta_model_t` vtable, registering it through a plugin, and evaluating
+// energy and forces for a small system.
+//
+// We use Einstein's solid: each atom is an independent harmonic oscillator
+// around an equilibrium position,
+//
+// .. math::
+//
+//     E = \sum_i k \left(\vec{r}_i - \vec{r}_i^0\right)^2,
+//
+// so the force on atom :math:`i` is :math:`\vec{F}_i = -2k(\vec{r}_i -
+// \vec{r}_i^0)`. In metatomic, forces are returned as the negative of the
+// ``"positions"`` energy gradient (see :ref:`energy-quantity-gradients`).
+
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <metatomic.h>
+#include <metatensor/dlpack/dlpack.h>
+
+// Dense CPU arrays for building metatensor Labels / TensorMaps
+// ------------------------------------------------------------
+//
+// The helpers below implement a small ``mts_array_t`` backend so this
+// example can construct energy TensorMaps (and position gradients)
+// without depending on the C++ ``SimpleDataArray`` helpers.
+
+/* Minimal CPU dense arrays for metatensor TensorMaps in C tutorials.
+ *
+ * Only the callbacks needed to build Labels / TensorBlocks and read values
+ * back are fully implemented. Advanced ops return an error.
+ */
+
+typedef struct {
+    uintptr_t* shape;
+    uintptr_t shape_count;
+    uint8_t* data;
+    uintptr_t n_bytes;
+    DLDataType dtype;
+} DenseArray;
+
+typedef struct {
+    DenseArray* array;
+    int64_t* shape;
+    int64_t* strides;
+} DenseDLPackContext;
+
+static mts_data_origin_t dense_array_origin_id(void) {
+    static mts_data_origin_t origin = 0;
+    if (origin == 0) {
+        mts_register_data_origin("metatomic::examples::DenseArray", &origin);
+    }
+    return origin;
+}
+
+static void dense_array_free(DenseArray* array) {
+    if (array == NULL) {
+        return;
+    }
+    free(array->shape);
+    free(array->data);
+    free(array);
+}
+
+static DenseArray* dense_array_new(
+    const uintptr_t* shape,
+    uintptr_t shape_count,
+    DLDataType dtype,
+    const void* values,
+    uintptr_t n_bytes
+) {
+    DenseArray* array = calloc(1, sizeof(DenseArray));
+    if (array == NULL) {
+        return NULL;
+    }
+
+    array->shape_count = shape_count;
+    array->dtype = dtype;
+    array->n_bytes = n_bytes;
+
+    if (shape_count > 0) {
+        array->shape = malloc(shape_count * sizeof(uintptr_t));
+        if (array->shape == NULL) {
+            free(array);
+            return NULL;
+        }
+        memcpy(array->shape, shape, shape_count * sizeof(uintptr_t));
+    }
+
+    array->data = malloc(n_bytes == 0 ? 1 : n_bytes);
+    if (array->data == NULL) {
+        free(array->shape);
+        free(array);
+        return NULL;
+    }
+    if (values != NULL && n_bytes > 0) {
+        memcpy(array->data, values, n_bytes);
+    } else if (n_bytes > 0) {
+        memset(array->data, 0, n_bytes);
+    }
+    return array;
+}
+
+static void dense_dlpack_deleter(DLManagedTensorVersioned* self) {
+    if (self == NULL) {
+        return;
+    }
+    DenseDLPackContext* ctx = (DenseDLPackContext*)self->manager_ctx;
+    if (ctx != NULL) {
+        free(ctx->shape);
+        free(ctx->strides);
+        free(ctx);
+    }
+    free(self);
+}
+
+static void dense_array_destroy(void* ptr) {
+    dense_array_free((DenseArray*)ptr);
+}
+
+static mts_status_t dense_array_origin(const void* ptr, mts_data_origin_t* origin) {
+    (void)ptr;
+    *origin = dense_array_origin_id();
+    return MTS_SUCCESS;
+}
+
+static mts_status_t dense_array_device(const void* ptr, DLDevice* device) {
+    (void)ptr;
+    device->device_type = kDLCPU;
+    device->device_id = 0;
+    return MTS_SUCCESS;
+}
+
+static mts_status_t dense_array_dtype(const void* ptr, DLDataType* dtype) {
+    *dtype = ((const DenseArray*)ptr)->dtype;
+    return MTS_SUCCESS;
+}
+
+static mts_status_t dense_array_shape(
+    const void* ptr,
+    const uintptr_t** shape,
+    uintptr_t* shape_count
+) {
+    const DenseArray* array = (const DenseArray*)ptr;
+    *shape = array->shape;
+    *shape_count = array->shape_count;
+    return MTS_SUCCESS;
+}
+
+static mts_status_t dense_array_as_dlpack(
+    void* ptr,
+    DLManagedTensorVersioned** out,
+    DLDevice device,
+    const int64_t* stream,
+    DLPackVersion max_version
+) {
+    DenseArray* array = (DenseArray*)ptr;
+
+    if (device.device_type != kDLCPU) {
+        mts_set_last_error("DenseArray only supports CPU", "dense_array", NULL, NULL);
+        return MTS_CALLBACK_ERROR;
+    }
+    if (stream != NULL) {
+        mts_set_last_error("DenseArray does not support streams", "dense_array", NULL, NULL);
+        return MTS_CALLBACK_ERROR;
+    }
+    if (max_version.major != DLPACK_MAJOR_VERSION) {
+        mts_set_last_error("unsupported DLPack version", "dense_array", NULL, NULL);
+        return MTS_CALLBACK_ERROR;
+    }
+
+    DenseDLPackContext* ctx = calloc(1, sizeof(DenseDLPackContext));
+    DLManagedTensorVersioned* tensor = calloc(1, sizeof(DLManagedTensorVersioned));
+    if (ctx == NULL || tensor == NULL) {
+        free(ctx);
+        free(tensor);
+        mts_set_last_error("out of memory", "dense_array", NULL, NULL);
+        return MTS_CALLBACK_ERROR;
+    }
+
+    if (array->shape_count > 0) {
+        ctx->shape = malloc(array->shape_count * sizeof(int64_t));
+        ctx->strides = malloc(array->shape_count * sizeof(int64_t));
+        if (ctx->shape == NULL || ctx->strides == NULL) {
+            free(ctx->shape);
+            free(ctx->strides);
+            free(ctx);
+            free(tensor);
+            mts_set_last_error("out of memory", "dense_array", NULL, NULL);
+            return MTS_CALLBACK_ERROR;
+        }
+        int64_t stride = 1;
+        for (uintptr_t i = array->shape_count; i-- > 0;) {
+            ctx->shape[i] = (int64_t)array->shape[i];
+            ctx->strides[i] = stride;
+            stride *= ctx->shape[i];
+        }
+    }
+
+    ctx->array = array;
+    tensor->version.major = DLPACK_MAJOR_VERSION;
+    tensor->version.minor = DLPACK_MINOR_VERSION;
+    tensor->manager_ctx = ctx;
+    tensor->deleter = dense_dlpack_deleter;
+    tensor->dl_tensor.data = array->data;
+    tensor->dl_tensor.device = device;
+    tensor->dl_tensor.ndim = (int32_t)array->shape_count;
+    tensor->dl_tensor.dtype = array->dtype;
+    tensor->dl_tensor.shape = ctx->shape;
+    tensor->dl_tensor.strides = ctx->strides;
+    tensor->dl_tensor.byte_offset = 0;
+
+    *out = tensor;
+    return MTS_SUCCESS;
+}
+
+static mts_status_t dense_array_unsupported(void) {
+    mts_set_last_error(
+        "operation not implemented for tutorial DenseArray",
+        "dense_array",
+        NULL,
+        NULL
+    );
+    return MTS_CALLBACK_ERROR;
+}
+
+static mts_status_t dense_array_reshape(void* array, const uintptr_t* shape, uintptr_t shape_count) {
+    (void)array;
+    (void)shape;
+    (void)shape_count;
+    return dense_array_unsupported();
+}
+
+static mts_status_t dense_array_swap_axes(void* array, uintptr_t axis_1, uintptr_t axis_2) {
+    (void)array;
+    (void)axis_1;
+    (void)axis_2;
+    return dense_array_unsupported();
+}
+
+static mts_status_t dense_array_create(
+    const void* array,
+    const uintptr_t* shape,
+    uintptr_t shape_count,
+    struct mts_array_t fill_value,
+    struct mts_array_t* new_array
+) {
+    (void)array;
+    (void)shape;
+    (void)shape_count;
+    (void)fill_value;
+    (void)new_array;
+    return dense_array_unsupported();
+}
+
+static mts_status_t dense_array_copy(const void* array, DLDevice device, struct mts_array_t* new_array) {
+    (void)array;
+    (void)device;
+    (void)new_array;
+    return dense_array_unsupported();
+}
+
+static mts_status_t dense_array_from_dlpack(
+    const void* array,
+    DLManagedTensorVersioned* dl_managed_tensor,
+    struct mts_array_t* new_array
+) {
+    (void)array;
+    (void)dl_managed_tensor;
+    (void)new_array;
+    return dense_array_unsupported();
+}
+
+static mts_status_t dense_array_move_data(
+    void* output,
+    const void* input,
+    const struct mts_data_movement_t* movements,
+    uintptr_t movements_count
+) {
+    (void)output;
+    (void)input;
+    (void)movements;
+    (void)movements_count;
+    return dense_array_unsupported();
+}
+
+static struct mts_array_t dense_array_to_mts(DenseArray* array) {
+    struct mts_array_t mts = {
+        .ptr = array,
+        .destroy = dense_array_destroy,
+        .origin = dense_array_origin,
+        .device = dense_array_device,
+        .dtype = dense_array_dtype,
+        .as_dlpack = dense_array_as_dlpack,
+        .from_dlpack = dense_array_from_dlpack,
+        .shape = dense_array_shape,
+        .reshape = dense_array_reshape,
+        .swap_axes = dense_array_swap_axes,
+        .create = dense_array_create,
+        .copy = dense_array_copy,
+        .move_data = dense_array_move_data,
+    };
+    return mts;
+}
+
+static struct mts_array_t dense_f64(const uintptr_t* shape, uintptr_t ndim, const double* values) {
+    uintptr_t n = 1;
+    for (uintptr_t i = 0; i < ndim; i++) {
+        n *= shape[i];
+    }
+    DenseArray* array = dense_array_new(
+        shape,
+        ndim,
+        (DLDataType){.code = kDLFloat, .bits = 64, .lanes = 1},
+        values,
+        n * sizeof(double)
+    );
+    return dense_array_to_mts(array);
+}
+
+static struct mts_array_t dense_i32(const uintptr_t* shape, uintptr_t ndim, const int32_t* values) {
+    uintptr_t n = 1;
+    for (uintptr_t i = 0; i < ndim; i++) {
+        n *= shape[i];
+    }
+    DenseArray* array = dense_array_new(
+        shape,
+        ndim,
+        (DLDataType){.code = kDLInt, .bits = 32, .lanes = 1},
+        values,
+        n * sizeof(int32_t)
+    );
+    return dense_array_to_mts(array);
+}
+
+static const mts_labels_t* labels_from_i32(
+    const char* const* names,
+    uintptr_t n_names,
+    const int32_t* values,
+    uintptr_t n_entries
+) {
+    uintptr_t shape[2] = {n_entries, n_names};
+    return mts_labels(names, n_names, dense_i32(shape, 2, values));
+}
+
+
+// %%
+//
+// Model state
+// -----------
+//
+// The model owns its parameters. Here that is a force constant and the
+// equilibrium positions (diamond carbon basis, cubic cell :math:`a = 3.567`
+// Å). The initial geometry below is displaced by 0.05 Å so the energy and
+// forces are non-zero but easy to check by hand.
+
+#define N_ATOMS 2
+#define FORCE_CONSTANT 10.0 /* eV / Angstrom^2 */
+#define CELL_A 3.567
+
+typedef struct {
+    double force_constant;
+    double r0[N_ATOMS][3];
+} HarmonicModel;
+
+static const double EQUILIBRIUM[N_ATOMS][3] = {
+    {0.0, 0.0, 0.0},
+    {CELL_A / 4.0, CELL_A / 4.0, CELL_A / 4.0},
+};
+
+/* Displaced diamond basis: atom 0 along +x, atom 1 along +z. */
+static const double POSITIONS0[N_ATOMS][3] = {
+    {0.05, 0.0, 0.0},
+    {CELL_A / 4.0, CELL_A / 4.0, CELL_A / 4.0 + 0.05},
+};
+
+// %%
+//
+// Metadata callbacks
+// ------------------
+//
+// Each callback writes a JSON document matching the schemas in
+// :ref:`core-json-formats`. Prefer the typed forms
+// (``"type": "metatomic_..."``) over older field names.
+
+static mta_status_t harmonic_unload(void* model_data) {
+    free(model_data);
+    return MTA_SUCCESS;
+}
+
+static mta_status_t harmonic_metadata(const void* model_data, mta_string_t* out) {
+    (void)model_data;
+    *out = mta_string_create(
+        "{"
+        "\"type\": \"metatomic_model_metadata\","
+        "\"name\": \"harmonic-diamond\","
+        "\"authors\": [\"metatomic C tutorials\"],"
+        "\"description\": \"Einstein solid on a diamond carbon basis\","
+        "\"references\": {"
+        "  \"model\": [],"
+        "  \"architecture\": [],"
+        "  \"implementation\": []"
+        "},"
+        "\"extra\": {\"potential\": \"harmonic\"}"
+        "}"
+    );
+    return (*out != NULL) ? MTA_SUCCESS : MTA_INTERNAL_ERROR;
+}
+
+static mta_status_t harmonic_capabilities(const void* model_data, mta_string_t* out) {
+    (void)model_data;
+    *out = mta_string_create(
+        "{"
+        "\"type\": \"metatomic_model_capabilities\","
+        "\"outputs\": [{"
+        "  \"type\": \"metatomic_quantity\","
+        "  \"name\": \"energy\","
+        "  \"unit\": \"eV\","
+        "  \"gradients\": [\"positions\"],"
+        "  \"sample_kind\": \"system\""
+        "}],"
+        "\"atomic_types\": [6],"
+        "\"interaction_range\": 0.0,"
+        "\"length_unit\": \"Angstrom\","
+        "\"supported_devices\": [\"cpu\"],"
+        "\"dtype\": \"float64\""
+        "}"
+    );
+    return (*out != NULL) ? MTA_SUCCESS : MTA_INTERNAL_ERROR;
+}
+
+static mta_status_t harmonic_supported_outputs(const void* model_data, mta_string_t* out) {
+    (void)model_data;
+    *out = mta_string_create(
+        "[{"
+        "\"type\": \"metatomic_quantity\","
+        "\"name\": \"energy\","
+        "\"unit\": \"eV\","
+        "\"gradients\": [\"positions\"],"
+        "\"sample_kind\": \"system\""
+        "}]"
+    );
+    return (*out != NULL) ? MTA_SUCCESS : MTA_INTERNAL_ERROR;
+}
+
+static mta_status_t harmonic_requested_pair_lists(const void* model_data, mta_string_t* out) {
+    (void)model_data;
+    /* Non-interacting oscillators: no neighbor lists. */
+    *out = mta_string_create("[]");
+    return (*out != NULL) ? MTA_SUCCESS : MTA_INTERNAL_ERROR;
+}
+
+static mta_status_t harmonic_requested_inputs(const void* model_data, mta_string_t* out) {
+    (void)model_data;
+    *out = mta_string_create("[]");
+    return (*out != NULL) ? MTA_SUCCESS : MTA_INTERNAL_ERROR;
+}
+
+// %%
+//
+// Building the energy TensorMap
+// -----------------------------
+//
+// :c:func:`execute_inner` must return one :c:type:`mts_tensormap_t` per
+// requested output. For system-level energy the block has samples
+// ``["system"]``, no components, and properties ``["energy"]``. Position
+// gradients use samples ``["sample", "system", "atom"]`` and component
+// ``["xyz"]``.
+
+static mts_tensormap_t* energy_with_forces(
+    double energy,
+    const double forces[N_ATOMS][3]
+) {
+    /* values: shape (n_systems=1, n_properties=1) */
+    double values_data[1] = {energy};
+    uintptr_t values_shape[2] = {1, 1};
+    int32_t sample_values[1] = {0};
+    int32_t property_values[1] = {0};
+    int32_t key_values[1] = {0};
+
+    const char* sample_names[] = {"system"};
+    const char* property_names[] = {"energy"};
+    const char* key_names[] = {"_"};
+
+    const mts_labels_t* samples = labels_from_i32(sample_names, 1, sample_values, 1);
+    const mts_labels_t* properties = labels_from_i32(property_names, 1, property_values, 1);
+    const mts_labels_t* keys = labels_from_i32(key_names, 1, key_values, 1);
+    if (samples == NULL || properties == NULL || keys == NULL) {
+        return NULL;
+    }
+
+    mts_block_t* block = mts_block(
+        dense_f64(values_shape, 2, values_data),
+        samples,
+        NULL,
+        0,
+        properties
+    );
+    mts_labels_free(samples);
+    mts_labels_free(properties);
+    if (block == NULL) {
+        mts_labels_free(keys);
+        return NULL;
+    }
+
+    /* gradients: ∂E/∂r = -F, shape (n_atoms, 3, 1) */
+    double grad_data[N_ATOMS * 3];
+    int32_t grad_samples_data[N_ATOMS * 3];
+    for (int i = 0; i < N_ATOMS; i++) {
+        grad_data[3 * i + 0] = -forces[i][0];
+        grad_data[3 * i + 1] = -forces[i][1];
+        grad_data[3 * i + 2] = -forces[i][2];
+        grad_samples_data[3 * i + 0] = 0; /* sample */
+        grad_samples_data[3 * i + 1] = 0; /* system */
+        grad_samples_data[3 * i + 2] = i; /* atom */
+    }
+
+    uintptr_t grad_shape[3] = {N_ATOMS, 3, 1};
+    int32_t xyz_data[3] = {0, 1, 2};
+    const char* grad_sample_names[] = {"sample", "system", "atom"};
+    const char* xyz_names[] = {"xyz"};
+
+    const mts_labels_t* grad_samples =
+        labels_from_i32(grad_sample_names, 3, grad_samples_data, N_ATOMS);
+    const mts_labels_t* xyz = labels_from_i32(xyz_names, 1, xyz_data, 3);
+    const mts_labels_t* grad_properties =
+        labels_from_i32(property_names, 1, property_values, 1);
+    if (grad_samples == NULL || xyz == NULL || grad_properties == NULL) {
+        mts_block_free(block);
+        mts_labels_free(keys);
+        return NULL;
+    }
+
+    const mts_labels_t* components[1] = {xyz};
+    mts_block_t* gradient = mts_block(
+        dense_f64(grad_shape, 3, grad_data),
+        grad_samples,
+        components,
+        1,
+        grad_properties
+    );
+    mts_labels_free(grad_samples);
+    mts_labels_free(xyz);
+    mts_labels_free(grad_properties);
+    if (gradient == NULL) {
+        mts_block_free(block);
+        mts_labels_free(keys);
+        return NULL;
+    }
+
+    if (mts_block_add_gradient(block, "positions", gradient) != MTS_SUCCESS) {
+        mts_block_free(gradient);
+        mts_block_free(block);
+        mts_labels_free(keys);
+        return NULL;
+    }
+
+    mts_block_t* blocks[1] = {block};
+    mts_tensormap_t* tensor = mts_tensormap(keys, blocks, 1);
+    mts_labels_free(keys);
+    return tensor;
+}
+
+static mta_status_t harmonic_execute_inner(
+    void* model_data,
+    const mta_system_t* const* systems,
+    uintptr_t systems_count,
+    const mts_labels_t* selected_atoms,
+    const char* requested_outputs_json,
+    mts_tensormap_t** outputs,
+    uintptr_t outputs_count
+) {
+    HarmonicModel* model = (HarmonicModel*)model_data;
+    (void)requested_outputs_json;
+
+    if (selected_atoms != NULL) {
+        mta_set_last_error(
+            "selected_atoms is not supported by harmonic-diamond",
+            "harmonic_execute_inner",
+            NULL,
+            NULL
+        );
+        return MTA_INVALID_PARAMETER_ERROR;
+    }
+    if (systems_count != 1 || outputs_count != 1) {
+        mta_set_last_error(
+            "this tutorial model expects one system and one output",
+            "harmonic_execute_inner",
+            NULL,
+            NULL
+        );
+        return MTA_INVALID_PARAMETER_ERROR;
+    }
+
+    DLManagedTensorVersioned* positions = NULL;
+    mta_status_t status = mta_system_get_data(
+        systems[0], MTA_SYSTEM_DATA_POSITIONS, &positions
+    );
+    if (status != MTA_SUCCESS) {
+        return status;
+    }
+
+    double* xyz = (double*)((char*)positions->dl_tensor.data + positions->dl_tensor.byte_offset);
+    double energy = 0.0;
+    double forces[N_ATOMS][3];
+    for (int i = 0; i < N_ATOMS; i++) {
+        for (int a = 0; a < 3; a++) {
+            double dr = xyz[3 * i + a] - model->r0[i][a];
+            energy += model->force_constant * dr * dr;
+            forces[i][a] = -2.0 * model->force_constant * dr;
+        }
+    }
+    positions->deleter(positions);
+
+    outputs[0] = energy_with_forces(energy, forces);
+    if (outputs[0] == NULL) {
+        const char* message = NULL;
+        mts_last_error(&message, NULL, NULL);
+        mta_set_last_error(
+            message != NULL ? message : "failed to build energy TensorMap",
+            "harmonic_execute_inner",
+            NULL,
+            NULL
+        );
+        return MTA_METATENSOR_ERROR;
+    }
+    return MTA_SUCCESS;
+}
+
+// %%
+//
+// Plugin registration
+// -------------------
+//
+// Models are produced by plugins. For a single-file tutorial we register the
+// plugin in-process with :c:func:`mta_register_plugin`. Shared-library plugins
+// use the :c:macro:`MTA_REGISTER_PLUGIN` macro instead (see the next tutorial).
+
+static mta_status_t harmonic_load_model(
+    const char* load_from,
+    const char* options_json,
+    mta_model_t* model
+) {
+    (void)options_json;
+    if (strcmp(load_from, "harmonic-diamond") != 0) {
+        return MTA_MODEL_NOT_SUPPORTED_ERROR;
+    }
+
+    HarmonicModel* data = malloc(sizeof(HarmonicModel));
+    if (data == NULL) {
+        mta_set_last_error("out of memory", "harmonic_load_model", NULL, NULL);
+        return MTA_INTERNAL_ERROR;
+    }
+    data->force_constant = FORCE_CONSTANT;
+    memcpy(data->r0, EQUILIBRIUM, sizeof(EQUILIBRIUM));
+
+    model->data = data;
+    model->unload = harmonic_unload;
+    model->metadata = harmonic_metadata;
+    model->capabilities = harmonic_capabilities;
+    model->supported_outputs = harmonic_supported_outputs;
+    model->requested_pair_lists = harmonic_requested_pair_lists;
+    model->requested_inputs = harmonic_requested_inputs;
+    model->execute_inner = harmonic_execute_inner;
+    return MTA_SUCCESS;
+}
+
+// %%
+//
+// Helpers to build the system
+// ---------------------------
+
+typedef struct {
+    int64_t* shape;
+    int64_t* strides;
+} SystemDLPackContext;
+
+static void system_dlpack_deleter(DLManagedTensorVersioned* self) {
+    if (self == NULL) {
+        return;
+    }
+    SystemDLPackContext* ctx = (SystemDLPackContext*)self->manager_ctx;
+    if (ctx != NULL) {
+        free(ctx->shape);
+        free(ctx->strides);
+        free(ctx);
+    }
+    free(self);
+}
+
+static DLManagedTensorVersioned* system_tensor_from_data(
+    void* data,
+    int32_t ndim,
+    const int64_t* shape,
+    DLDataType dtype
+) {
+    SystemDLPackContext* ctx = malloc(sizeof(SystemDLPackContext));
+    DLManagedTensorVersioned* tensor = calloc(1, sizeof(*tensor));
+    if (ctx == NULL || tensor == NULL) {
+        free(ctx);
+        free(tensor);
+        return NULL;
+    }
+    ctx->shape = malloc((size_t)ndim * sizeof(int64_t));
+    ctx->strides = malloc((size_t)ndim * sizeof(int64_t));
+    if (ctx->shape == NULL || ctx->strides == NULL) {
+        free(ctx->shape);
+        free(ctx->strides);
+        free(ctx);
+        free(tensor);
+        return NULL;
+    }
+    memcpy(ctx->shape, shape, (size_t)ndim * sizeof(int64_t));
+    int64_t stride = 1;
+    for (int32_t i = ndim - 1; i >= 0; i--) {
+        ctx->strides[i] = stride;
+        stride *= shape[i];
+    }
+
+    tensor->version.major = DLPACK_MAJOR_VERSION;
+    tensor->version.minor = DLPACK_MINOR_VERSION;
+    tensor->manager_ctx = ctx;
+    tensor->deleter = system_dlpack_deleter;
+    tensor->flags = DLPACK_FLAG_BITMASK_READ_ONLY;
+    tensor->dl_tensor.data = data;
+    tensor->dl_tensor.device.device_type = kDLCPU;
+    tensor->dl_tensor.device.device_id = 0;
+    tensor->dl_tensor.dtype = dtype;
+    tensor->dl_tensor.ndim = ndim;
+    tensor->dl_tensor.shape = ctx->shape;
+    tensor->dl_tensor.strides = ctx->strides;
+    return tensor;
+}
+
+static int fail(mta_system_t* system, mta_model_t* model, const char* what) {
+    const char* message = NULL;
+    mta_last_error(&message, NULL, NULL);
+    fprintf(stderr, "%s: %s\n", what, message != NULL ? message : "(no message)");
+    if (model != NULL && model->unload != NULL && model->data != NULL) {
+        model->unload(model->data);
+    }
+    if (system != NULL) {
+        mta_system_free(system);
+    }
+    return EXIT_FAILURE;
+}
+
+// %%
+
+int main(void) {
+    static mta_plugin_t PLUGIN = {
+        .abi_version = MTA_ABI_VERSION,
+        .name = "tutorial-harmonic-plugin",
+        .load_model = harmonic_load_model,
+    };
+    if (mta_register_plugin(PLUGIN) != MTA_SUCCESS) {
+        return fail(NULL, NULL, "failed to register plugin");
+    }
+
+    mta_model_t model = {0};
+    if (mta_load_model("harmonic-diamond", "{}", "tutorial-harmonic-plugin", &model)
+        != MTA_SUCCESS) {
+        return fail(NULL, NULL, "failed to load model");
+    }
+
+    mta_string_t metadata = NULL;
+    if (model.metadata(model.data, &metadata) != MTA_SUCCESS) {
+        return fail(NULL, &model, "failed to get metadata");
+    }
+    mta_string_t printed = NULL;
+    if (mta_format_metadata(mta_string_view(metadata), &printed) != MTA_SUCCESS) {
+        mta_string_free(metadata);
+        return fail(NULL, &model, "failed to format metadata");
+    }
+    printf("%s\n", mta_string_view(printed));
+    mta_string_free(metadata);
+    mta_string_free(printed);
+
+    int32_t types_data[N_ATOMS] = {6, 6};
+    double positions_data[N_ATOMS * 3];
+    double cell_data[9] = {
+        CELL_A, 0.0, 0.0,
+        0.0, CELL_A, 0.0,
+        0.0, 0.0, CELL_A,
+    };
+    bool pbc_data[3] = {true, true, true};
+    memcpy(positions_data, POSITIONS0, sizeof(POSITIONS0));
+
+    DLManagedTensorVersioned* types = system_tensor_from_data(
+        types_data, 1, (int64_t[]){N_ATOMS},
+        (DLDataType){.code = kDLInt, .bits = 32, .lanes = 1}
+    );
+    DLManagedTensorVersioned* positions = system_tensor_from_data(
+        positions_data, 2, (int64_t[]){N_ATOMS, 3},
+        (DLDataType){.code = kDLFloat, .bits = 64, .lanes = 1}
+    );
+    DLManagedTensorVersioned* cell = system_tensor_from_data(
+        cell_data, 2, (int64_t[]){3, 3},
+        (DLDataType){.code = kDLFloat, .bits = 64, .lanes = 1}
+    );
+    DLManagedTensorVersioned* pbc = system_tensor_from_data(
+        pbc_data, 1, (int64_t[]){3},
+        (DLDataType){.code = kDLBool, .bits = 8, .lanes = 1}
+    );
+
+    mta_system_t* system = NULL;
+    if (mta_system_create("Angstrom", types, positions, cell, pbc, &system)
+        != MTA_SUCCESS) {
+        return fail(NULL, &model, "failed to create system");
+    }
+
+    /* Call execute_inner directly. Engines normally use mta_execute_model,
+       which adds validation and unit conversion on top of this callback. */
+    mts_tensormap_t* outputs[1] = {NULL};
+    const char* requested =
+        "[{\"type\":\"metatomic_quantity\",\"name\":\"energy\",\"unit\":\"eV\","
+        "\"gradients\":[\"positions\"],\"sample_kind\":\"system\"}]";
+    if (model.execute_inner(
+            model.data, (const mta_system_t* const*)&system, 1, NULL, requested, outputs, 1
+        )
+        != MTA_SUCCESS) {
+        return fail(system, &model, "execute_inner failed");
+    }
+
+    mts_block_t* block = NULL;
+    if (mts_tensormap_block_by_id(outputs[0], &block, 0) != MTS_SUCCESS) {
+        mts_tensormap_free(outputs[0]);
+        return fail(system, &model, "failed to get energy block");
+    }
+
+    mts_array_t values;
+    if (mts_block_data(block, &values) != MTS_SUCCESS) {
+        mts_tensormap_free(outputs[0]);
+        return fail(system, &model, "failed to get energy values");
+    }
+
+    DLManagedTensorVersioned* values_dl = NULL;
+    DLDevice cpu = {.device_type = kDLCPU, .device_id = 0};
+    DLPackVersion ver = {.major = DLPACK_MAJOR_VERSION, .minor = DLPACK_MINOR_VERSION};
+    if (values.as_dlpack(values.ptr, &values_dl, cpu, NULL, ver) != MTS_SUCCESS) {
+        mts_tensormap_free(outputs[0]);
+        return fail(system, &model, "failed to export energy values");
+    }
+    double energy = ((double*)((char*)values_dl->dl_tensor.data + values_dl->dl_tensor.byte_offset))[0];
+    values_dl->deleter(values_dl);
+
+    mts_block_t* gradient = NULL;
+    if (mts_block_gradient(block, "positions", &gradient) != MTS_SUCCESS) {
+        mts_tensormap_free(outputs[0]);
+        return fail(system, &model, "failed to get positions gradient");
+    }
+    mts_array_t grad_values;
+    if (mts_block_data(gradient, &grad_values) != MTS_SUCCESS) {
+        mts_tensormap_free(outputs[0]);
+        return fail(system, &model, "failed to get gradient values");
+    }
+    DLManagedTensorVersioned* grad_dl = NULL;
+    if (grad_values.as_dlpack(grad_values.ptr, &grad_dl, cpu, NULL, ver) != MTS_SUCCESS) {
+        mts_tensormap_free(outputs[0]);
+        return fail(system, &model, "failed to export gradient values");
+    }
+    double* grad = (double*)((char*)grad_dl->dl_tensor.data + grad_dl->dl_tensor.byte_offset);
+
+    printf("energy: %.6f eV\n", energy);
+    printf("forces (eV/Angstrom):\n");
+    for (int i = 0; i < N_ATOMS; i++) {
+        /* F = -∂E/∂r */
+        double fx = -grad[3 * i + 0];
+        double fy = -grad[3 * i + 1];
+        double fz = -grad[3 * i + 2];
+        if (fabs(fx) < 1e-12) { fx = 0.0; }
+        if (fabs(fy) < 1e-12) { fy = 0.0; }
+        if (fabs(fz) < 1e-12) { fz = 0.0; }
+        printf("  atom %d: %8.3f %8.3f %8.3f\n", i, fx, fy, fz);
+    }
+    grad_dl->deleter(grad_dl);
+    mts_tensormap_free(outputs[0]);
+
+    model.unload(model.data);
+    mta_system_free(system);
+    return EXIT_SUCCESS;
+}
+
+// %%
+//
+// Expected output
+// ---------------
+//
+// With :math:`k = 10` eV/Å² and 0.05 Å displacements, each atom contributes
+// :math:`10 \times 0.05^2 = 0.025` eV, so the total energy is 0.05 eV. The
+// non-zero force components have magnitude :math:`2k\times 0.05 = 1` eV/Å::
+//
+//     This is the harmonic-diamond model
+//     ==================================
+//
+//     Einstein solid on a diamond carbon basis
+//
+//     Model authors
+//     -------------
+//
+//     - metatomic C tutorials
+//
+//     energy: 0.050000 eV
+//     forces (eV/Angstrom):
+//       atom 0:   -1.000    0.000    0.000
+//       atom 1:    0.000    0.000   -1.000

--- a/examples/c/3-add-plugin.c
+++ b/examples/c/3-add-plugin.c
@@ -106,7 +106,7 @@ static mta_status_t stub_execute_inner(
     (void)outputs;
     (void)outputs_count;
     mta_set_last_error(
-        "plugin-demo does not implement execute_inner; see 2-add-model.c",
+        "plugin-demo does not implement execute_inner (WIP)",
         "stub_execute_inner",
         NULL,
         NULL

--- a/examples/c/3-add-plugin.c
+++ b/examples/c/3-add-plugin.c
@@ -1,0 +1,247 @@
+// Loading models through plugins
+// ==============================
+//
+// Metatomic discovers models through **plugins**. A plugin is a small
+// :c:type:`mta_plugin_t` that knows how to turn a ``load_from`` string (path,
+// name, …) into a filled :c:type:`mta_model_t` vtable.
+//
+// There are two ways to register a plugin:
+//
+// - in a shared library, export ``mta_plugin_init`` with the
+//   :c:macro:`MTA_REGISTER_PLUGIN` macro, then call :c:func:`mta_load_plugin`;
+// - in the same process as the engine (handy for tests and tutorials), call
+//   :c:func:`mta_register_plugin` directly.
+//
+// This tutorial uses the in-process path and shows the shared-library pattern
+// you would ship in a ``.so`` / ``.dylib`` / ``.dll``.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <metatomic.h>
+
+// %%
+//
+// A minimal plugin
+// ----------------
+//
+// The plugin below can load a single named model. Anything else returns
+// :c:enumerator:`MTA_MODEL_NOT_SUPPORTED_ERROR` so other plugins get a chance
+// when ``plugin_name`` is left as ``NULL``.
+
+static mta_status_t stub_unload(void* model_data) {
+    free(model_data);
+    return MTA_SUCCESS;
+}
+
+static mta_status_t stub_metadata(const void* model_data, mta_string_t* out) {
+    (void)model_data;
+    *out = mta_string_create(
+        "{"
+        "\"type\": \"metatomic_model_metadata\","
+        "\"name\": \"plugin-demo\","
+        "\"authors\": [\"metatomic C tutorials\"],"
+        "\"description\": \"Minimal model used to demonstrate plugins\","
+        "\"references\": {"
+        "  \"model\": [], \"architecture\": [], \"implementation\": []"
+        "},"
+        "\"extra\": {}"
+        "}"
+    );
+    return (*out != NULL) ? MTA_SUCCESS : MTA_INTERNAL_ERROR;
+}
+
+static mta_status_t stub_capabilities(const void* model_data, mta_string_t* out) {
+    (void)model_data;
+    *out = mta_string_create(
+        "{"
+        "\"type\": \"metatomic_model_capabilities\","
+        "\"outputs\": [{"
+        "  \"type\": \"metatomic_quantity\","
+        "  \"name\": \"energy\","
+        "  \"unit\": \"eV\","
+        "  \"gradients\": [],"
+        "  \"sample_kind\": \"system\""
+        "}],"
+        "\"atomic_types\": [1, 6, 8],"
+        "\"interaction_range\": 0.0,"
+        "\"length_unit\": \"Angstrom\","
+        "\"supported_devices\": [\"cpu\"],"
+        "\"dtype\": \"float64\""
+        "}"
+    );
+    return (*out != NULL) ? MTA_SUCCESS : MTA_INTERNAL_ERROR;
+}
+
+static mta_status_t stub_supported_outputs(const void* model_data, mta_string_t* out) {
+    (void)model_data;
+    *out = mta_string_create(
+        "[{\"type\":\"metatomic_quantity\",\"name\":\"energy\",\"unit\":\"eV\","
+        "\"gradients\":[],\"sample_kind\":\"system\"}]"
+    );
+    return (*out != NULL) ? MTA_SUCCESS : MTA_INTERNAL_ERROR;
+}
+
+static mta_status_t stub_empty_list(const void* model_data, mta_string_t* out) {
+    (void)model_data;
+    *out = mta_string_create("[]");
+    return (*out != NULL) ? MTA_SUCCESS : MTA_INTERNAL_ERROR;
+}
+
+static mta_status_t stub_execute_inner(
+    void* model_data,
+    const mta_system_t* const* systems,
+    uintptr_t systems_count,
+    const mts_labels_t* selected_atoms,
+    const char* requested_outputs_json,
+    mts_tensormap_t** outputs,
+    uintptr_t outputs_count
+) {
+    (void)model_data;
+    (void)systems;
+    (void)systems_count;
+    (void)selected_atoms;
+    (void)requested_outputs_json;
+    (void)outputs;
+    (void)outputs_count;
+    mta_set_last_error(
+        "plugin-demo does not implement execute_inner; see 2-add-model.c",
+        "stub_execute_inner",
+        NULL,
+        NULL
+    );
+    return MTA_INTERNAL_ERROR;
+}
+
+static mta_status_t demo_load_model(
+    const char* load_from,
+    const char* options_json,
+    mta_model_t* model
+) {
+    (void)options_json;
+    if (strcmp(load_from, "plugin-demo") != 0) {
+        return MTA_MODEL_NOT_SUPPORTED_ERROR;
+    }
+
+    model->data = malloc(1);
+    if (model->data == NULL) {
+        mta_set_last_error("out of memory", "demo_load_model", NULL, NULL);
+        return MTA_INTERNAL_ERROR;
+    }
+    model->unload = stub_unload;
+    model->metadata = stub_metadata;
+    model->capabilities = stub_capabilities;
+    model->supported_outputs = stub_supported_outputs;
+    model->requested_pair_lists = stub_empty_list;
+    model->requested_inputs = stub_empty_list;
+    model->execute_inner = stub_execute_inner;
+    return MTA_SUCCESS;
+}
+
+// %%
+//
+// Shared-library entry point
+// --------------------------
+//
+// The same plugin body can be compiled as a shared library. The macro below
+// exports ``mta_plugin_init``, which :c:func:`mta_load_plugin` looks up after
+// ``dlopen``. Keep the ABI version at :c:macro:`MTA_ABI_VERSION`.
+//
+// .. code-block:: C
+//
+//     MTA_REGISTER_PLUGIN(register_plugin, {
+//         mta_plugin_t plugin = {
+//             .abi_version = MTA_ABI_VERSION,
+//             .name = "tutorial-demo-plugin",
+//             .load_model = demo_load_model,
+//         };
+//         return register_plugin(plugin);
+//     });
+
+// %%
+
+static void print_last_error(const char* prefix) {
+    const char* message = NULL;
+    mta_last_error(&message, NULL, NULL);
+    printf("%s: %s\n", prefix, message != NULL ? message : "(no message)");
+}
+
+int main(void) {
+    mta_plugin_t plugin = {
+        .abi_version = MTA_ABI_VERSION,
+        .name = "tutorial-demo-plugin",
+        .load_model = demo_load_model,
+    };
+
+    if (mta_register_plugin(plugin) != MTA_SUCCESS) {
+        print_last_error("register_plugin failed");
+        return EXIT_FAILURE;
+    }
+    printf("registered plugin '%s'\n", plugin.name);
+
+    mta_model_t model = {0};
+    if (mta_load_model("plugin-demo", "{}", "tutorial-demo-plugin", &model)
+        != MTA_SUCCESS) {
+        print_last_error("load_model failed");
+        return EXIT_FAILURE;
+    }
+    printf("loaded model 'plugin-demo'\n");
+
+    mta_string_t capabilities = NULL;
+    if (model.capabilities(model.data, &capabilities) != MTA_SUCCESS) {
+        print_last_error("capabilities failed");
+        model.unload(model.data);
+        return EXIT_FAILURE;
+    }
+    printf("capabilities: %s\n", mta_string_view(capabilities));
+    mta_string_free(capabilities);
+
+    /* Asking a plugin for a model it does not know must fail cleanly. */
+    mta_model_t missing = {0};
+    mta_status_t status =
+        mta_load_model("not-a-real-model", "{}", "tutorial-demo-plugin", &missing);
+    if (status == MTA_SUCCESS) {
+        fprintf(stderr, "expected load of unknown model to fail\n");
+        missing.unload(missing.data);
+        model.unload(model.data);
+        return EXIT_FAILURE;
+    }
+    print_last_error("unknown model");
+
+#ifdef PLUGIN_DIR
+    /* When this example is built with the CMake test suite, also try loading
+       the shared library plugin that ships with the tests. */
+    {
+        const char* path = PLUGIN_DIR "/test-c-plugin.so";
+        FILE* probe = fopen(path, "rb");
+        if (probe != NULL) {
+            fclose(probe);
+            status = mta_load_plugin(path);
+            if (status == MTA_SUCCESS) {
+                printf("loaded shared library plugin from %s\n", path);
+            } else {
+                print_last_error("shared plugin");
+                model.unload(model.data);
+                return EXIT_FAILURE;
+            }
+        }
+    }
+#endif
+
+    model.unload(model.data);
+    return EXIT_SUCCESS;
+}
+
+// %%
+//
+// Expected output
+// ---------------
+//
+// ::
+//
+//     registered plugin 'tutorial-demo-plugin'
+//     loaded model 'plugin-demo'
+//     capabilities: {"type": "metatomic_model_capabilities", ...}
+//     unknown model: invalid parameter: failed to load model from
+//     'not-a-real-model': plugin 'tutorial-demo-plugin' could not load the model

--- a/examples/c/4-strings-errors-units.c
+++ b/examples/c/4-strings-errors-units.c
@@ -1,0 +1,213 @@
+// Strings, errors, and units
+// ==========================
+//
+// The C API uses a few small helpers that show up in almost every integration:
+// heap-allocated strings (:c:type:`mta_string_t`), a thread-local last-error
+// slot, and unit conversion factors for engine/model unit mismatches.
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <metatomic.h>
+
+// %%
+//
+// Strings
+// -------
+//
+// :c:func:`mta_string_create` copies a UTF-8 C string.
+// :c:func:`mta_string_view` borrows it, and :c:func:`mta_string_free` releases
+// it (``NULL`` is a no-op).
+
+static int demo_strings(void) {
+    mta_string_t hello = mta_string_create("Angstrom");
+    if (hello == NULL) {
+        return EXIT_FAILURE;
+    }
+    printf("string view: %s\n", mta_string_view(hello));
+    mta_string_free(hello);
+    mta_string_free(NULL);
+    return EXIT_SUCCESS;
+}
+
+// %%
+//
+// Unit conversion
+// ---------------
+//
+// :c:func:`mta_unit_conversion_factor` parses unit expressions and returns the
+// multiplicative factor from ``from_unit`` to ``to_unit``. Dimensions must
+// match; see :ref:`units` for the expression grammar.
+
+static int demo_units(void) {
+    double factor = 0.0;
+
+    if (mta_unit_conversion_factor("m", "m", &factor) != MTA_SUCCESS) {
+        return EXIT_FAILURE;
+    }
+    printf("m -> m: %.1f\n", factor);
+
+    if (mta_unit_conversion_factor("kJ/mol", "eV", &factor) != MTA_SUCCESS) {
+        return EXIT_FAILURE;
+    }
+    printf("kJ/mol -> eV: %.12f\n", factor);
+
+    if (mta_unit_conversion_factor("Angstrom", "nm", &factor) != MTA_SUCCESS) {
+        return EXIT_FAILURE;
+    }
+    printf("Angstrom -> nm: %.3f\n", factor);
+
+    return EXIT_SUCCESS;
+}
+
+// %%
+//
+// Errors
+// ------
+//
+// On failure, functions return a non-zero :c:type:`mta_status_t` and store a
+// message that :c:func:`mta_last_error` can read. Plugins and models should
+// call :c:func:`mta_set_last_error` before returning an error status.
+
+static int demo_errors(void) {
+    double factor = 0.0;
+    mta_status_t status = mta_unit_conversion_factor("m", "kg", &factor);
+    if (status == MTA_SUCCESS) {
+        fprintf(stderr, "expected a dimension mismatch\n");
+        return EXIT_FAILURE;
+    }
+
+    const char* message = NULL;
+    const char* origin = NULL;
+    mta_last_error(&message, &origin, NULL);
+    printf("status: %d\n", (int)status);
+    printf("error: %s\n", message != NULL ? message : "(none)");
+
+    mta_set_last_error(
+        "tutorial-triggered error",
+        "demo_errors",
+        NULL,
+        NULL
+    );
+    message = NULL;
+    origin = NULL;
+    mta_last_error(&message, &origin, NULL);
+    printf("custom error: %s (origin=%s)\n", message, origin);
+    return EXIT_SUCCESS;
+}
+
+// %%
+//
+// Formatting metadata
+// -------------------
+//
+// :c:func:`mta_format_metadata` turns a JSON :c:type:`ModelMetadata` document
+// into a human-readable summary suitable for logging.
+
+static int demo_format_metadata(void) {
+    /* Use the published metatensor / metatomic citation — the same DOI as in
+       CITATION.cff — so the formatted output is something you could actually
+       paste into a paper or log. */
+    const char* json =
+        "{"
+        "\"type\": \"metatomic_model_metadata\","
+        "\"name\": \"tutorial-demo\","
+        "\"authors\": ["
+        "  \"Filippo Bigi\","
+        "  \"Joseph W. Abbott\","
+        "  \"Philip Loche\","
+        "  \"et al.\""
+        "],"
+        "\"description\": "
+        "\"Illustrative metadata for the C API strings tutorial, "
+        "citing the metatensor and metatomic paper.\","
+        "\"references\": {"
+        "  \"model\": ["
+        "    \"F. Bigi et al., J. Chem. Phys. 164, 064113 (2026), "
+        "https://doi.org/10.1063/5.0304911\""
+        "  ],"
+        "  \"architecture\": ["
+        "    \"metatensor and metatomic: foundational libraries for "
+        "interoperable atomistic machine learning\""
+        "  ],"
+        "  \"implementation\": ["
+        "    \"https://github.com/metatensor/metatomic\""
+        "  ]"
+        "},"
+        "\"extra\": {"
+        "  \"doi\": \"10.1063/5.0304911\""
+        "}"
+        "}";
+
+    mta_string_t printed = NULL;
+    if (mta_format_metadata(json, &printed) != MTA_SUCCESS) {
+        const char* message = NULL;
+        mta_last_error(&message, NULL, NULL);
+        fprintf(stderr, "format_metadata failed: %s\n", message);
+        return EXIT_FAILURE;
+    }
+    printf("%s", mta_string_view(printed));
+    mta_string_free(printed);
+    return EXIT_SUCCESS;
+}
+
+// %%
+
+int main(void) {
+    if (demo_strings() != EXIT_SUCCESS) {
+        return EXIT_FAILURE;
+    }
+    if (demo_units() != EXIT_SUCCESS) {
+        return EXIT_FAILURE;
+    }
+    if (demo_errors() != EXIT_SUCCESS) {
+        return EXIT_FAILURE;
+    }
+    if (demo_format_metadata() != EXIT_SUCCESS) {
+        return EXIT_FAILURE;
+    }
+    return EXIT_SUCCESS;
+}
+
+// %%
+//
+// Expected output
+// ---------------
+//
+// ::
+//
+//     string view: Angstrom
+//     m -> m: 1.0
+//     kJ/mol -> eV: 0.010364269656
+//     Angstrom -> nm: 0.100
+//     status: 1
+//     error: invalid parameter: dimension mismatch in unit conversion: 'm' has dimension [L] but 'kg' has dimension [M]
+//     custom error: tutorial-triggered error (origin=demo_errors)
+//     This is the tutorial-demo model
+//     ===============================
+//
+//     Illustrative metadata for the C API strings tutorial, citing the metatensor and
+//     metatomic paper.
+//
+//     Model authors
+//     -------------
+//
+//     - Filippo Bigi
+//     - Joseph W. Abbott
+//     - Philip Loche
+//     - et al.
+//
+//     Model references
+//     ----------------
+//
+//     Please cite the following references when using this model:
+//     - about this specific model:
+//       * F. Bigi et al., J. Chem. Phys. 164, 064113 (2026),
+//         https://doi.org/10.1063/5.0304911
+//     - about the architecture of this model:
+//       * metatensor and metatomic: foundational libraries for interoperable
+//         atomistic machine learning
+//     - about the implementation of this model:
+//       * https://github.com/metatensor/metatomic

--- a/examples/c/README.rst
+++ b/examples/c/README.rst
@@ -2,3 +2,8 @@
 
 C API tutorials
 ===============
+
+.. danger::
+
+    This section is a **work in progress (WIP)**. The examples and wording may
+    change without notice.

--- a/examples/c/README.rst
+++ b/examples/c/README.rst
@@ -7,3 +7,7 @@ C API tutorials
 
     This section is a **work in progress (WIP)**. The examples and wording may
     change without notice.
+
+``2-add-model.c`` currently covers the :c:type:`mta_model_t` vtable and plugin
+registration only. Implementing ``execute_inner`` (energy TensorMaps and
+forces) is deferred to a follow-up.

--- a/python/metatomic_ase/CHANGELOG.md
+++ b/python/metatomic_ase/CHANGELOG.md
@@ -16,6 +16,8 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 -->
 
+## [Version 0.1.4](https://github.com/metatensor/metatomic/releases/tag/metatomic-ase-v0.1.4) - 2026-09-01
+
 ### Fixed
 
 - `max_neighbors` in nvalchemi should be per-atom, it was set globally,

--- a/python/metatomic_ase/setup.py
+++ b/python/metatomic_ase/setup.py
@@ -11,7 +11,7 @@ from setuptools.command.sdist import sdist
 ROOT = os.path.realpath(os.path.dirname(__file__))
 METATOMIC_TORCH = os.path.realpath(os.path.join(ROOT, "..", "metatomic_torch"))
 
-METATOMIC_ASE_VERSION = "0.1.3"
+METATOMIC_ASE_VERSION = "0.1.4"
 
 
 class bdist_egg_disabled(bdist_egg):

--- a/python/metatomic_torchsim/CHANGELOG.md
+++ b/python/metatomic_torchsim/CHANGELOG.md
@@ -17,6 +17,8 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Removed
 -->
 
+## [Version 0.1.6](https://github.com/metatensor/metatomic/releases/tag/metatomic-torchsim-v0.1.6) - 2026-09-01
+
 ### Fixed
 
 - `max_neighbors` in nvalchemi should be per-atom, it was set globally,

--- a/python/metatomic_torchsim/setup.py
+++ b/python/metatomic_torchsim/setup.py
@@ -10,7 +10,7 @@ from setuptools.command.sdist import sdist
 ROOT = os.path.realpath(os.path.dirname(__file__))
 METATOMIC_TORCH = os.path.realpath(os.path.join(ROOT, "..", "metatomic_torch"))
 
-METATOMIC_TORCHSIM_VERSION = "0.1.5"
+METATOMIC_TORCHSIM_VERSION = "0.1.6"
 
 
 class sdist_generate_data(sdist):


### PR DESCRIPTION
<!-- What does this implement/fix? Explain your changes here. -->

Expand the C API tutorial gallery with practical examples built on top of the
existing `1-create-system` tutorial:

- **`1-create-system.c`**: query length unit plus types, positions, cell, and
  PBC via `mta_system_get_data`, and document the expected stdout.
- **`2-add-model.c`** (WIP stub): fill an `mta_model_t` vtable, register it
  through a plugin, and print formatted metadata. `execute_inner` (energy
  TensorMaps and forces) is deferred to a follow-up PR.
- **`3-add-plugin.c`**: demonstrate in-process `mta_register_plugin` /
  `mta_load_model`, unknown-model error handling, and the
  `MTA_REGISTER_PLUGIN` shared-library pattern.
- **`4-strings-errors-units.c`**: cover `mta_string_t`, unit conversion,
  last-error handling, and `mta_format_metadata`, citing the published
  metatensor/metatomic paper (`https://doi.org/10.1063/5.0304911`).
- Mark the C tutorials section as **WIP** in `examples/c/README.rst`.

# Contributor (creator of pull-request) checklist

 - [ ] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [ ] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [ ] CHANGELOG updated with public API or any other important changes?