### PR TITLE
Update metatomic-torchsim to vesin 0.6

### DIFF
--- a/python/metatomic_torchsim/CHANGELOG.md
+++ b/python/metatomic_torchsim/CHANGELOG.md
@@ -7,6 +7,10 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/metatensor/metatomic/)
 
+### Changed
+
+- Update the `vesin` dependency to `>=0.6.0,<0.7`, matching `metatomic-ase`.
+
 <!-- Possible sections
 ### Added
 

--- a/python/metatomic_torchsim/setup.py
+++ b/python/metatomic_torchsim/setup.py
@@ -107,7 +107,7 @@ if __name__ == "__main__":
 
     install_requires = [
         "torch-sim-atomistic >=0.5",
-        "vesin >=0.5.6,<0.6",
+        "vesin >=0.6.0,<0.7",
     ]
 
     # when packaging a sdist for release, we should never use local dependencies


### PR DESCRIPTION
This was missed in #283, so `metatomic[torchsim]` could not resolve: `metatomic-torchsim` required `vesin<0.6` while `metatomic-ase` requires `vesin>=0.6`.

Fixes #315.

# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [ ] ~Documentation updated (for new features)?~
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [x] CHANGELOG updated with public API or any other important changes?