### PR TITLE
Release metatomic-torchsim v0.1.7

### DIFF
--- a/python/metatomic_torchsim/CHANGELOG.md
+++ b/python/metatomic_torchsim/CHANGELOG.md
@@ -7,6 +7,10 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/metatensor/metatomic/)
 
+### Changed
+
+- Update the `vesin` dependency to `>=0.6.0,<0.7`, matching `metatomic-ase`.
+
 <!-- Possible sections
 ### Added
 

--- a/python/metatomic_torchsim/CHANGELOG.md
+++ b/python/metatomic_torchsim/CHANGELOG.md
@@ -7,10 +7,6 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/metatensor/metatomic/)
 
-### Changed
-
-- Update the `vesin` dependency to `>=0.6.0,<0.7`, matching `metatomic-ase`.
-
 <!-- Possible sections
 ### Added
 
@@ -20,6 +16,12 @@ follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Removed
 -->
+
+## [Version 0.1.7](https://github.com/metatensor/metatomic/releases/tag/metatomic-torchsim-v0.1.7) - 2026-09-04
+
+### Changed
+
+- Update the `vesin` dependency to `>=0.6.0,<0.7`, matching `metatomic-ase`.
 
 ## [Version 0.1.6](https://github.com/metatensor/metatomic/releases/tag/metatomic-torchsim-v0.1.6) - 2026-09-01
 

--- a/python/metatomic_torchsim/setup.py
+++ b/python/metatomic_torchsim/setup.py
@@ -10,7 +10,7 @@ from setuptools.command.sdist import sdist
 ROOT = os.path.realpath(os.path.dirname(__file__))
 METATOMIC_TORCH = os.path.realpath(os.path.join(ROOT, "..", "metatomic_torch"))
 
-METATOMIC_TORCHSIM_VERSION = "0.1.6"
+METATOMIC_TORCHSIM_VERSION = "0.1.7"
 
 
 class sdist_generate_data(sdist):

--- a/python/metatomic_torchsim/setup.py
+++ b/python/metatomic_torchsim/setup.py
@@ -107,7 +107,7 @@ if __name__ == "__main__":
 
     install_requires = [
         "torch-sim-atomistic >=0.5",
-        "vesin >=0.5.6,<0.6",
+        "vesin >=0.6.0,<0.7",
     ]
 
     # when packaging a sdist for release, we should never use local dependencies


### PR DESCRIPTION
Follow-up to #316: cut `metatomic-torchsim` 0.1.7 so the vesin 0.6 pin is on PyPI.

Fixes #315.

# Contributor (creator of pull-request) checklist

 - [ ] ~Tests updated (for new features and bugfixes)?~
 - [ ] ~Documentation updated (for new features)?~
 - [x] Issue referenced (for PRs that solve an issue)?

# Reviewer checklist

 - [x] CHANGELOG updated with public API or any other important changes?