### PR TITLE
Remove supported_outputs from mta_model_t

### DIFF
--- a/docs/src/core/reference/json-formats.rst
+++ b/docs/src/core/reference/json-formats.rst
@@ -60,8 +60,8 @@ Quantities
 
 The JSON representation of a physical quantity, used to represent custom models
 inputs and outputs. This is used for example in
-:c:member:`mta_model_t.requested_inputs` and
-:c:member:`mta_model_t.supported_outputs`.
+:c:member:`mta_model_t.requested_inputs` and the ``outputs`` field of the
+model's capabilities.
 
 .. code-block:: json
 

--- a/metatomic-core/include/metatomic.h
+++ b/metatomic-core/include/metatomic.h
@@ -203,20 +203,6 @@ typedef struct mta_model_t {
    */
   enum mta_status_t (*metadata)(const void *model_data, mta_string_t *metadata_json);
   /**
-   * List the outputs this model is able to compute as a JSON string.
-   *
-   * @verbatim embed:rst:leading-asterisk
-   * The expected JSON structure for each output is documented in :ref:`core-json-quantity`.
-   * @endverbatim
-   *
-   * @param model_data the model's `data` pointer
-   * @param outputs_json output string, set to a JSON array of `Quantity`
-   *     objects, one per supported output. The caller takes ownership and
-   *     must free it with `mta_string_free`.
-   * @return `MTA_SUCCESS` on success, another status code on error
-   */
-  enum mta_status_t (*supported_outputs)(const void *model_data, mta_string_t *outputs_json);
-  /**
    * List the pair lists (neighbor lists) the model needs as input as a JSON
    * string.
    *

--- a/metatomic-core/include/metatomic/model.hpp
+++ b/metatomic-core/include/metatomic/model.hpp
@@ -42,14 +42,6 @@ namespace metatomic {
         /// Get metadata describing this model.
         virtual ModelMetadata metadata() const = 0;
 
-        /// List the outputs this model is able to compute.
-        ///
-        /// The default implementation returns the outputs declared in
-        /// `capabilities()`.
-        virtual std::vector<Quantity> supported_outputs() const {
-            return capabilities().outputs();
-        }
-
         /// List the pair lists (neighbor lists) this model needs as input.
         virtual std::vector<PairListOptions> requested_pair_lists() const = 0;
 
@@ -144,20 +136,6 @@ namespace metatomic {
 
             auto json_str = details::string_from_mta(output);
             return nlohmann::json::parse(json_str).get<ModelMetadata>();
-        }
-
-        /// List the outputs this model is able to compute.
-        std::vector<Quantity> supported_outputs() const override {
-            if (model_.supported_outputs == nullptr) {
-                return BaseModel::supported_outputs();
-            }
-
-            mta_string_t output = nullptr;
-            auto status = model_.supported_outputs(model_.data, &output);
-            details::check_status(status);
-
-            auto json_str = details::string_from_mta(output);
-            return nlohmann::json::parse(json_str).get<std::vector<Quantity>>();
         }
 
         /// List the pair lists (neighbor lists) this model needs as input.
@@ -302,14 +280,6 @@ namespace metatomic {
                 nlohmann::json json = model->metadata();
                 *metadata_json = mta_string_create(json.dump().c_str());
             }, model_data, metadata_json);
-        };
-
-        m.supported_outputs = [](const void* model_data, mta_string_t* outputs_json) -> mta_status_t {
-            return details::catch_exceptions([](const void* model_data, mta_string_t* outputs_json) {
-                const auto* model = static_cast<const BaseModel*>(model_data);
-                nlohmann::json json = model->supported_outputs();
-                *outputs_json = mta_string_create(json.dump().c_str());
-            }, model_data, outputs_json);
         };
 
         m.requested_pair_lists = [](const void* model_data, mta_string_t* pair_options_json) -> mta_status_t {

--- a/metatomic-core/src/c_api/model.rs
+++ b/metatomic-core/src/c_api/model.rs
@@ -71,22 +71,6 @@ pub struct mta_model_t {
         metadata_json: *mut mta_string_t,
     ) -> mta_status_t>,
 
-    /// List the outputs this model is able to compute as a JSON string.
-    ///
-    /// @verbatim embed:rst:leading-asterisk
-    /// The expected JSON structure for each output is documented in :ref:`core-json-quantity`.
-    /// @endverbatim
-    ///
-    /// @param model_data the model's `data` pointer
-    /// @param outputs_json output string, set to a JSON array of `Quantity`
-    ///     objects, one per supported output. The caller takes ownership and
-    ///     must free it with `mta_string_free`.
-    /// @return `MTA_SUCCESS` on success, another status code on error
-    pub supported_outputs: Option<unsafe extern "C" fn(
-        model_data: *const c_void,
-        outputs_json: *mut mta_string_t,
-    ) -> mta_status_t>,
-
     /// List the pair lists (neighbor lists) the model needs as input as a JSON
     /// string.
     ///
@@ -172,7 +156,6 @@ impl mta_model_t {
             unload: None,
             capabilities: None,
             metadata: None,
-            supported_outputs: None,
             requested_pair_lists: None,
             requested_inputs: None,
             execute_inner: None,

--- a/metatomic-core/src/model/model.rs
+++ b/metatomic-core/src/model/model.rs
@@ -138,27 +138,6 @@ impl Model {
         }
         return Ok(result);
     }
-
-    /// Get the outputs this model can compute.
-    pub fn supported_outputs(&self) -> Result<Vec<Quantity>, Error> {
-        let callback = self.0.supported_outputs.ok_or_else(|| {
-            Error::Internal("model is missing a 'supported_outputs' callback".into())
-        })?;
-        let json_str = call_string_callback(callback, self.0.data)?;
-        let json = json::parse(&json_str).map_err(|e| {
-            Error::Serialization(format!("model returned invalid JSON for supported_outputs: {}", e))
-        })?;
-        if !json.is_array() {
-            return Err(Error::Serialization(
-                "model returned invalid JSON for supported_outputs, expected an array".into()
-            ));
-        }
-        let mut result = Vec::new();
-        for item in json.members() {
-            result.push(Quantity::try_from(item)?);
-        }
-        return Ok(result);
-    }
 }
 
 #[cfg(test)]
@@ -198,8 +177,15 @@ mod tests {
                     "type": "metatomic_quantity",
                     "name": "energy",
                     "unit": "eV",
-                    "gradients": [],
+                    "gradients": ["positions"],
                     "sample_kind": "system"
+                },
+                {
+                    "type": "metatomic_quantity",
+                    "name": "custom::output",
+                    "unit": "",
+                    "gradients": [],
+                    "sample_kind": "atom_pair"
                 }],
                 "atomic_types": [1, 6],
                 "interaction_range": 5.0,
@@ -242,31 +228,6 @@ mod tests {
         return mta_status_t::MTA_SUCCESS;
     }
 
-    unsafe extern "C" fn supported_outputs_impl(
-        _data: *const c_void,
-        out: *mut mta_string_t,
-    ) -> mta_status_t {
-        unsafe {
-            *out = mta_string_t::new(r#"[
-                {
-                    "type": "metatomic_quantity",
-                    "name": "energy",
-                    "unit": "eV",
-                    "gradients": ["positions"],
-                    "sample_kind": "system"
-                },
-                {
-                    "type": "metatomic_quantity",
-                    "name": "custom::output",
-                    "unit": "",
-                    "gradients": [],
-                    "sample_kind": "atom_pair"
-                }]"#
-            );
-        }
-        return mta_status_t::MTA_SUCCESS;
-    }
-
 
     fn test_model() -> Model {
         Model(mta_model_t {
@@ -274,7 +235,6 @@ mod tests {
             capabilities: Some(capabilities_impl),
             requested_pair_lists: Some(requested_pair_lists_impl),
             requested_inputs: Some(requested_inputs_impl),
-            supported_outputs:Some(supported_outputs_impl),
             ..mta_model_t::null()
         })
     }
@@ -291,8 +251,14 @@ mod tests {
     #[test]
     fn capabilities() {
         let capabilities = test_model().capabilities().unwrap();
-        assert_eq!(capabilities.outputs.len(), 1);
+
+        assert_eq!(capabilities.outputs.len(), 2);
         assert_eq!(capabilities.outputs[0].name.full(), "energy");
+        assert_eq!(capabilities.outputs[0].unit, "eV");
+
+        assert_eq!(capabilities.outputs[1].name.full(), "custom::output");
+        assert_eq!(capabilities.outputs[1].unit, "");
+
         assert_eq!(capabilities.atomic_types, vec![1, 6]);
         assert_eq!(capabilities.interaction_range.to_bits(), 5.0_f64.to_bits());
         assert_eq!(capabilities.length_unit, "Angstrom");
@@ -313,16 +279,5 @@ mod tests {
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].name.full(), "charge");
         assert_eq!(inputs[0].unit, "e");
-    }
-
-    #[test]
-    fn supported_outputs() {
-        let outputs = test_model().supported_outputs().unwrap();
-        assert_eq!(outputs.len(), 2);
-        assert_eq!(outputs[0].name.full(), "energy");
-        assert_eq!(outputs[0].unit, "eV");
-
-        assert_eq!(outputs[1].name.full(), "custom::output");
-        assert_eq!(outputs[1].unit, "");
     }
 }

--- a/metatomic-core/tests/c-model.cpp
+++ b/metatomic-core/tests/c-model.cpp
@@ -54,19 +54,6 @@ static mta_status_t capabilities_impl(const void* model_data, mta_string_t* capa
     return MTA_SUCCESS;
 }
 
-static mta_status_t supported_outputs_impl(
-    const void* model_data,
-    mta_string_t* outputs_json
-) {
-    (void) model_data;
-    *outputs_json = mta_string_create(R"([{
-        "quantity": "energy",
-        "unit": "eV",
-        "per_atom": false
-    }])");
-    return MTA_SUCCESS;
-}
-
 static mta_status_t requested_pair_lists_impl(
     const void* model_data,
     mta_string_t* pair_options_json
@@ -152,7 +139,6 @@ static mta_status_t load_model_impl(
     model->unload = unload_impl;
     model->metadata = metadata_impl;
     model->capabilities = capabilities_impl;
-    model->supported_outputs = supported_outputs_impl;
     model->requested_pair_lists = requested_pair_lists_impl;
     model->requested_inputs = requested_inputs_impl;
     model->execute_inner = execute_inner_impl;
@@ -176,7 +162,6 @@ TEST_CASE("simple C model can be registered and loaded through the C API") {
     CHECK(model.unload != nullptr);
     CHECK(model.metadata != nullptr);
     CHECK(model.capabilities != nullptr);
-    CHECK(model.supported_outputs != nullptr);
     CHECK(model.requested_pair_lists != nullptr);
     CHECK(model.requested_inputs != nullptr);
     CHECK(model.execute_inner != nullptr);

--- a/metatomic-core/tests/cxx/model.cpp
+++ b/metatomic-core/tests/cxx/model.cpp
@@ -14,41 +14,37 @@ class SimpleCppModel: public metatomic::BaseModel {
 public:
     explicit SimpleCppModel(double scale): scale_(scale) {}
 
-    metatomic::ModelCapabilities capabilities() const override final {
-        metatomic::ModelCapabilities caps;
-        caps.atomic_types({1, 6, 8});
-        caps.interaction_range(4.5);
-        caps.length_unit("nm");
-        caps.supported_devices({metatomic::ModelCapabilities::Device::CPU});
-        caps.dtype(metatomic::ModelCapabilities::DType::Float32);
+    metatomic::ModelCapabilities capabilities() const final {
+        auto capabilities = metatomic::ModelCapabilities();
+        capabilities.atomic_types({1, 6, 8});
+        capabilities.interaction_range(4.5);
+        capabilities.length_unit("nm");
+        capabilities.supported_devices({metatomic::ModelCapabilities::Device::CPU});
+        capabilities.dtype(metatomic::ModelCapabilities::DType::Float32);
 
-        caps.add_output(metatomic::Quantity(
+        capabilities.add_output(metatomic::Quantity(
             "energy", "eV", metatomic::SampleKind::System
         ));
 
-        return caps;
-    }
-
-    metatomic::ModelMetadata metadata() const override final {
-        metatomic::ModelMetadata meta;
-        meta.name("simple C++ model");
-        meta.description("test model for BaseModel");
-        return meta;
-    }
-
-    std::vector<metatomic::Quantity> supported_outputs() const override final {
-        auto outputs = capabilities().outputs();
-        outputs.push_back(metatomic::Quantity(
-            "energy_per_atom", "eV", metatomic::SampleKind::Atom
+        capabilities.add_output(metatomic::Quantity(
+            "custom::output", "eV", metatomic::SampleKind::Atom
         ));
-        return outputs;
+
+        return capabilities;
     }
 
-    std::vector<metatomic::PairListOptions> requested_pair_lists() const override final {
+    metatomic::ModelMetadata metadata() const final {
+        auto metadata = metatomic::ModelMetadata();
+        metadata.name("simple C++ model");
+        metadata.description("test model for BaseModel");
+        return metadata;
+    }
+
+    std::vector<metatomic::PairListOptions> requested_pair_lists() const final {
         return {};
     }
 
-    std::vector<metatomic::Quantity> requested_inputs() const override final {
+    std::vector<metatomic::Quantity> requested_inputs() const final {
         return {};
     }
 
@@ -56,7 +52,7 @@ public:
         const std::vector<metatomic::System>& systems,
         const metatensor::Labels* selected_atoms,
         const std::vector<metatomic::Quantity>& requested_outputs
-    ) override final {
+    ) final {
         std::vector<metatensor::TensorMap> outputs;
         outputs.reserve(requested_outputs.size());
 
@@ -85,39 +81,17 @@ private:
     double scale_;
 };
 
-
-static mta_status_t load_cpp_model(
-    const char* load_from,
-    const char* options_json,
-    mta_model_t* model
-) {
-    (void) options_json;
-
-    if (std::strcmp(load_from, "test-cpp-model") != 0) {
-        return MTA_MODEL_NOT_SUPPORTED_ERROR;
-    }
-
-    auto cpp_model = std::make_unique<SimpleCppModel>(2.5);
-    *model = metatomic::BaseModel::to_mta_model(std::move(cpp_model));
-    return MTA_SUCCESS;
-}
-
-
 TEST_CASE("BaseModel") {
     auto model = std::make_unique<SimpleCppModel>(2.5);
 
-    auto caps = model->capabilities();
-    CHECK(caps.atomic_types().size() == 3);
-    CHECK(caps.outputs().size() == 1);
-    CHECK(caps.outputs()[0].name() == "energy");
+    auto capabilities = model->capabilities();
+    CHECK(capabilities.atomic_types().size() == 3);
 
-    auto supported = model->supported_outputs();
-    CHECK(supported.size() == 2);
-    CHECK(supported[0].name() == "energy");
-    CHECK(supported[1].name() == "energy_per_atom");
-    CHECK(supported[1].sample_kind() == metatomic::SampleKind::Atom);
-
-    CHECK(model->capabilities().outputs().size() == 1);
+    const auto& outputs = capabilities.outputs();
+    CHECK(outputs.size() == 2);
+    CHECK(outputs[0].name() == "energy");
+    CHECK(outputs[1].name() == "custom::output");
+    CHECK(outputs[1].sample_kind() == metatomic::SampleKind::Atom);
 
     auto system = test_system(4);
     auto systems = std::vector<metatomic::System>();
@@ -125,12 +99,13 @@ TEST_CASE("BaseModel") {
 
     // NOTE: we call execute_inner directly only for testing
     // in practice, the model should be executed through the `mta_execute_model` function
-    auto outputs = model->execute_inner(systems, nullptr, caps.outputs());
+    auto requested_outputs = std::vector<metatomic::Quantity>{outputs[0]};
+    auto results = model->execute_inner(systems, nullptr, requested_outputs);
 
-    REQUIRE(outputs.size() == 1);
-    CHECK(outputs[0].keys().count() == 1);
+    REQUIRE(results.size() == 1);
+    CHECK(results[0].keys().count() == 1);
 
-    auto block = outputs[0].block_by_id(0);
+    auto block = results[0].block_by_id(0);
     auto values = block.values<double>();
     REQUIRE(values.data() != nullptr);
     CHECK(values.data()[0] == Approx(10.0));
@@ -141,11 +116,12 @@ TEST_CASE("Wrap mta_model_t with ExternalModel") {
     auto raw_model = metatomic::BaseModel::to_mta_model(
         std::make_unique<SimpleCppModel>(3.0)
     );
-    auto model = metatomic::ExternalModel(std::move(raw_model));
+    auto model = metatomic::ExternalModel(raw_model);
 
-    auto caps = model.capabilities();
-    CHECK(caps.outputs().size() == 1);
-    CHECK(caps.outputs()[0].name() == "energy");
+    auto outputs = model.capabilities().outputs();
+    CHECK(outputs.size() == 2);
+    CHECK(outputs[0].name() == "energy");
+    CHECK(outputs[1].name() == "custom::output");
 
     // TODO: uncomment once `mta_execute_model` is implemented on the Rust side.
     // auto system = test_system(4);
@@ -153,7 +129,7 @@ TEST_CASE("Wrap mta_model_t with ExternalModel") {
     // systems.push_back(std::move(system));
     //
     // auto outputs = metatomic::execute_model(
-    //     model, systems, nullptr, caps.outputs(), false
+    //     model, systems, nullptr, outputs, false
     // );
     // REQUIRE(outputs.size() == 1);
     //
@@ -169,12 +145,12 @@ TEST_CASE("ExternalModel move semantics") {
     auto raw = metatomic::BaseModel::to_mta_model(
         std::make_unique<SimpleCppModel>(1.0)
     );
-    auto model = metatomic::ExternalModel(std::move(raw));
+    auto model = metatomic::ExternalModel(raw);
     CHECK(model.as_mta_model_t() != nullptr);
 
     auto moved = std::move(model);
     CHECK(moved.as_mta_model_t() != nullptr);
-    CHECK(moved.capabilities().outputs().size() == 1);
+    CHECK(moved.capabilities().outputs().size() == 2);
 }
 
 
@@ -182,7 +158,7 @@ TEST_CASE("ExternalModel release transfers ownership") {
     auto raw = metatomic::BaseModel::to_mta_model(
         std::make_unique<SimpleCppModel>(2.0)
     );
-    auto model = metatomic::ExternalModel(std::move(raw));
+    auto model = metatomic::ExternalModel(raw);
 
     // release the raw model back to the caller; the ExternalModel is empty
     // and will not call unload on destruction
@@ -190,11 +166,12 @@ TEST_CASE("ExternalModel release transfers ownership") {
     CHECK(released.unload != nullptr);
 
     // re-wrap the released model to verify it is still valid
-    auto wrapped = metatomic::ExternalModel(std::move(released));
+    auto wrapped = metatomic::ExternalModel(released);
 
-    auto caps = wrapped.capabilities();
-    CHECK(caps.outputs().size() == 1);
-    CHECK(caps.outputs()[0].name() == "energy");
+    auto outputs = wrapped.capabilities().outputs();
+    CHECK(outputs.size() == 2);
+    CHECK(outputs[0].name() == "energy");
+    CHECK(outputs[1].name() == "custom::output");
 
     // TODO: uncomment once `mta_execute_model` is implemented on the Rust side.
     // auto system = test_system(4);
@@ -202,7 +179,7 @@ TEST_CASE("ExternalModel release transfers ownership") {
     // systems.push_back(std::move(system));
     //
     // auto outputs = metatomic::execute_model(
-    //     wrapped, systems, nullptr, caps.outputs(), false
+    //     wrapped, systems, nullptr, outputs, false
     // );
     // REQUIRE(outputs.size() == 1);
     //
@@ -219,7 +196,7 @@ TEST_CASE("to_mta_model for ExternalModel") {
         std::make_unique<SimpleCppModel>(3.0)
     );
     void* inner_data = inner_raw.data;
-    auto external = std::make_unique<metatomic::ExternalModel>(std::move(inner_raw));
+    auto external = std::make_unique<metatomic::ExternalModel>(inner_raw);
     auto outer_raw = metatomic::BaseModel::to_mta_model(std::move(external));
 
     // `to_mta_model` short-circuits for `ExternalModel`
@@ -229,28 +206,25 @@ TEST_CASE("to_mta_model for ExternalModel") {
     // The raw model's callbacks must all be set by `to_mta_model`.
     CHECK(outer_raw.capabilities != nullptr);
     CHECK(outer_raw.metadata != nullptr);
-    CHECK(outer_raw.supported_outputs != nullptr);
     CHECK(outer_raw.requested_pair_lists != nullptr);
     CHECK(outer_raw.requested_inputs != nullptr);
     CHECK(outer_raw.execute_inner != nullptr);
     CHECK(outer_raw.unload != nullptr);
 
     // Wrap the raw model back in an ExternalModel to test through the C++ interface.
-    auto model = metatomic::ExternalModel(std::move(outer_raw));
+    auto model = metatomic::ExternalModel(outer_raw);
 
-    auto caps = model.capabilities();
-    CHECK(caps.length_unit() == "nm");
-    CHECK(caps.outputs().size() == 1);
-    CHECK(caps.outputs()[0].name() == "energy");
+    auto capabilities = model.capabilities();
+    CHECK(capabilities.length_unit() == "nm");
 
     auto metadata = model.metadata();
     CHECK(metadata.name() == "simple C++ model");
 
-    auto supported = model.supported_outputs();
-    REQUIRE(supported.size() == 2);
-    CHECK(supported[0].name() == "energy");
-    CHECK(supported[1].name() == "energy_per_atom");
-    CHECK(supported[1].sample_kind() == metatomic::SampleKind::Atom);
+    const auto& outputs = capabilities.outputs();
+    REQUIRE(outputs.size() == 2);
+    CHECK(outputs[0].name() == "energy");
+    CHECK(outputs[1].name() == "custom::output");
+    CHECK(outputs[1].sample_kind() == metatomic::SampleKind::Atom);
 
     CHECK(model.requested_pair_lists().empty());
     CHECK(model.requested_inputs().empty());


### PR DESCRIPTION
We already have this information from the capabilities, having two separate functions means that they can be out of sync.

# Contributor (creator of pull-request) checklist

 - [x] Tests updated (for new features and bugfixes)?
 - [x] Documentation updated (for new features)?
 - [ ] ~Issue referenced (for PRs that solve an issue)?~

# Reviewer checklist

 - [ ] ~CHANGELOG updated with public API or any other important changes?~
