### PR TITLE
C++ wrapper for mta_execute_model

### DIFF
--- a/metatomic-core/include/metatomic/model.hpp
+++ b/metatomic-core/include/metatomic/model.hpp
@@ -356,4 +356,59 @@ namespace metatomic {
 
         return m;
     }
+
+    /// Execute a model to compute the requested outputs for a set of systems.
+    ///
+    /// @param model the model to execute
+    /// @param systems systems to run the model on
+    /// @param selected_atoms optional selection of atoms to compute outputs
+    ///     for, or `nullptr` to use all atoms
+    /// @param requested_outputs outputs the model should compute, one per
+    ///     requested output
+    /// @param check_consistency if `true`, run additional checks on the inputs
+    ///     and on the data produced by the model
+    /// @return the computed outputs, one tensor map per requested output
+    inline std::vector<metatensor::TensorMap> execute_model(
+        ExternalModel& model,
+        const std::vector<System>& systems,
+        const metatensor::Labels* selected_atoms,
+        const std::vector<Quantity>& requested_outputs,
+        bool check_consistency
+    ) {
+        std::vector<const mta_system_t*> systems_ptrs;
+        systems_ptrs.reserve(systems.size());
+        for (const auto& system: systems) {
+            systems_ptrs.push_back(system.as_mta_system_t());
+        }
+
+        const mts_labels_t* selected_atoms_ptr = nullptr;
+        if (selected_atoms != nullptr) {
+            selected_atoms_ptr = selected_atoms->as_mts_labels_t();
+        }
+
+        nlohmann::json json = requested_outputs;
+        auto requested_outputs_str = json.dump();
+
+        std::vector<mts_tensormap_t*> outputs(requested_outputs.size(), nullptr);
+
+        auto status = mta_execute_model(
+            *model.as_mta_model_t(),
+            systems_ptrs.data(),
+            static_cast<uintptr_t>(systems_ptrs.size()),
+            selected_atoms_ptr,
+            requested_outputs_str.c_str(),
+            check_consistency,
+            outputs.data(),
+            static_cast<uintptr_t>(outputs.size())
+        );
+        details::check_status(status);
+
+        std::vector<metatensor::TensorMap> result;
+        result.reserve(outputs.size());
+        for (auto* output: outputs) {
+            result.push_back(metatensor::TensorMap::unsafe_from_ptr(output));
+        }
+
+        return result;
+    }
 } // namespace metatomic

--- a/metatomic-core/tests/cxx/model.cpp
+++ b/metatomic-core/tests/cxx/model.cpp
@@ -16,7 +16,7 @@ public:
 
     metatomic::ModelCapabilities capabilities() const override final {
         return metatomic::ModelCapabilities::builder()
-            .atomic_types({1, 6, 8})
+            .atomic_types({1, 4, 7, 10})
             .interaction_range(4.5)
             .length_unit("nm")
             .supported_devices({metatomic::ModelCapabilities::Device::CPU})
@@ -86,7 +86,7 @@ TEST_CASE("BaseModel") {
     auto model = std::make_unique<SimpleCppModel>(2.5);
 
     auto capabilities = model->capabilities();
-    CHECK(capabilities.atomic_types().size() == 3);
+    CHECK(capabilities.atomic_types().size() == 4);
 
     const auto& outputs = capabilities.outputs();
     CHECK(outputs.size() == 2);
@@ -124,21 +124,22 @@ TEST_CASE("Wrap mta_model_t with ExternalModel") {
     CHECK(outputs[0].name() == "energy");
     CHECK(outputs[1].name() == "custom::output");
 
-    // TODO: uncomment once `mta_execute_model` is implemented on the Rust side.
-    // auto system = test_system(4);
-    // std::vector<metatomic::System> systems;
-    // systems.push_back(std::move(system));
-    //
-    // auto outputs = metatomic::execute_model(
-    //     model, systems, nullptr, outputs, false
-    // );
-    // REQUIRE(outputs.size() == 1);
-    //
-    // // 4 atoms * scale 3.0 = 12.0
-    // auto block = outputs[0].block_by_id(0);
-    // auto values = block.values<double>();
-    // REQUIRE(values.data() != nullptr);
-    // CHECK(values.data()[0] == Approx(12.0));
+    auto system = test_system(4);
+    std::vector<metatomic::System> systems;
+    systems.push_back(std::move(system));
+
+    // Request only "energy" output
+    // The "custom::output" errors out
+    auto out = metatomic::execute_model(
+        model, systems, nullptr, std::vector<metatomic::Quantity>{outputs[0]}, false
+    );
+    REQUIRE(out.size() == 1);
+
+    // 4 atoms * scale 3.0 = 12.0
+    auto block = out[0].block_by_id(0);
+    auto values = block.values<double>();
+    REQUIRE(values.data() != nullptr);
+    CHECK(values.data()[0] == Approx(12.0));
 }
 
 
@@ -174,21 +175,22 @@ TEST_CASE("ExternalModel release transfers ownership") {
     CHECK(outputs[0].name() == "energy");
     CHECK(outputs[1].name() == "custom::output");
 
-    // TODO: uncomment once `mta_execute_model` is implemented on the Rust side.
-    // auto system = test_system(4);
-    // std::vector<metatomic::System> systems;
-    // systems.push_back(std::move(system));
-    //
-    // auto outputs = metatomic::execute_model(
-    //     wrapped, systems, nullptr, outputs, false
-    // );
-    // REQUIRE(outputs.size() == 1);
-    //
-    // // 4 atoms * scale 2.0 = 8.0
-    // auto block = outputs[0].block_by_id(0);
-    // auto values = block.values<double>();
-    // REQUIRE(values.data() != nullptr);
-    // CHECK(values.data()[0] == Approx(8.0));
+    auto system = test_system(4);
+    std::vector<metatomic::System> systems;
+    systems.push_back(std::move(system));
+
+    // Request only "energy" output
+    // The "custom::output" errors out
+    auto out = metatomic::execute_model(
+        wrapped, systems, nullptr, std::vector<metatomic::Quantity>{outputs[0]}, false
+    );
+    REQUIRE(out.size() == 1);
+
+    // 4 atoms * scale 2.0 = 8.0
+    auto block = out[0].block_by_id(0);
+    auto values = block.values<double>();
+    REQUIRE(values.data() != nullptr);
+    CHECK(values.data()[0] == Approx(8.0));
 }
 
 


### PR DESCRIPTION
Implement `metatomic::execute_model` based on `mta_execute_model`, and uncomment the related tests.


<!-- download-section Documentation docs start -->
[📚 Download documentation for this pull-request](https://nightly.link/metatensor/metatomic/actions/artifacts/10391132110.zip)
<!-- download-section Documentation docs end -->